### PR TITLE
Update memory limit for xcp-ng 8.1 pxe installation

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -200,7 +200,7 @@ The configuration file pxelinux.cfg/default is as follow:
 default xenserver
 label xenserver
 kernel mboot.c32
-append xcp-ng/xen.gz dom0_max_vcpus=1-2 dom0_mem=2048M,max:2048M com1=115200,8n1 console=com1,vga --- xcp-ng/vmlinuz xencons=hvc console=hvc0 console=tty0 answerfile=https://gist.githubusercontent.com/nraynaud/4cca5205c805394a34fc4170b3903113/raw/ install --- xcp-ng/install.img
+append xcp-ng/xen.gz dom0_max_vcpus=1-2 dom0_mem=max:2048M com1=115200,8n1 console=com1,vga --- xcp-ng/vmlinuz xencons=hvc console=hvc0 console=tty0 answerfile=https://gist.githubusercontent.com/nraynaud/4cca5205c805394a34fc4170b3903113/raw/ install --- xcp-ng/install.img
 ```
 
 Here is the beginning of an answer file:

--- a/docs/install.md
+++ b/docs/install.md
@@ -200,7 +200,7 @@ The configuration file pxelinux.cfg/default is as follow:
 default xenserver
 label xenserver
 kernel mboot.c32
-append xcp-ng/xen.gz dom0_max_vcpus=1-2 dom0_mem=1024M,max:1024M com1=115200,8n1 console=com1,vga --- xcp-ng/vmlinuz xencons=hvc console=hvc0 console=tty0 answerfile=https://gist.githubusercontent.com/nraynaud/4cca5205c805394a34fc4170b3903113/raw/ install --- xcp-ng/install.img
+append xcp-ng/xen.gz dom0_max_vcpus=1-2 dom0_mem=2048M,max:2048M com1=115200,8n1 console=com1,vga --- xcp-ng/vmlinuz xencons=hvc console=hvc0 console=tty0 answerfile=https://gist.githubusercontent.com/nraynaud/4cca5205c805394a34fc4170b3903113/raw/ install --- xcp-ng/install.img
 ```
 
 Here is the beginning of an answer file:


### PR DESCRIPTION
we tried to install xcp-ng 8.1 via pxe boot but got some errors:
```
no space for mem size 0x00080000 pref
failed to assign mem size 0x00080000 prefunpacking initramfs...
initramfs unpacking failed: write error
freeing initrd memory: 130016krun /init as init process
failed to execute init (error -2)kernel panic - not syncing: no working init found - try passing init= option to kernel
```

after increasing the memory limit it worked.