### PR TITLE
Update compute.md

### DIFF
--- a/docs/compute.md
+++ b/docs/compute.md
@@ -50,7 +50,7 @@ Add the **`xen-pciback.hide`** parameter to the kernel boot parameters:
 ```
 > You can hide multiple devices. If you wanted to add another device at `00:19.0` just append it to the parameter.
 >
-> `/opt/xensource/libexec/xen-cmdline --set-dom0 "xen-pciback.hide=(0000:04:01.0)(00:19.0)"`
+> `/opt/xensource/libexec/xen-cmdline --set-dom0 "xen-pciback.hide=(0000:04:01.0)(0000:00:19.0)"`
 
 To remove any passthrough devices from dom0:
 ```bash


### PR DESCRIPTION
Missing extra zeros from PCI passthrough example for multiple devices being passed through.