### PR TITLE
Adding a guide : change the server certificate

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -399,6 +399,10 @@ If you would like to replace this certificate by a valid one, either from an int
 
 Note that if you use an non-public certificate authority and XenOrchestra, you have [additional configuration to specify on XenOrchestra side](https://xen-orchestra.com/docs/configuration.html#custom-certificate-authority)
 
+:::warning
+This indication is valid for XCP-ng up to v8.1. Version 8.2 is expected to improve deployment of new certificates, like [Citrix did for XenServer 8.2](https://docs.citrix.com/en-us/citrix-hypervisor/hosts-pools.html#install-a-tls-certificate-on-your-server).
+:::
+
 ### Generate certificate signing request
 
 You can use the auto-generated key to create a certificate signing request :

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -390,3 +390,28 @@ That's it, you're good to go!  Go to your interfaces > assignments in pfSense, s
 * [Forums: My initial question and discussion about vlan trunk support](https://xcp-ng.org/forum/topic/729/how-to-connect-vlan-trunk-to-vm)
 * [pfSense interface does not support VLANs](https://forum.netgate.com/topic/112359/xenserver-vlan-doesn-t-supporting-eth-device-for-vlan)
 * [pfSense: Adding VLAN support for Xen xn interfaces](https://eliasmoraispereira.wordpress.com/2016/10/05/pfsense-virtualizacao-com-xenserver-criando-vlans/)
+
+## TLS certificate for XCP-ng
+
+After installing XCP-ng, access to xapi via XCP-ng center or XenOrchestra is protected by TLS with a [self-signed certificate](https://en.wikipedia.org/wiki/Self-signed_certificate) : this means that you have to either verify the certificate signature before allowing the connection (comparing against signature shown on the console of the server), either work on trust-on-first-use basis (i.e. assume that the first time you connect to the server, nobody is tampering with the connection).
+
+If you would like to replace this certificate by a valid one, either from an internal Certificate Authority or from a public one, you'll find here some indications on how to do that.
+
+Note that if you use an non-public certificate authority and XenOrchestra, you have [additional configuration to specify on XenOrchestra side](https://xen-orchestra.com/docs/configuration.html#custom-certificate-authority)
+
+### Generate certificate signing request
+
+You can use the auto-generated key to create a certificate signing request :
+
+```
+openssl req -new -key /etc/xensource/xapi-ssl.pem -subj '/CN=XCP-ng hypervisor/' -out xcp-ng.csr
+```
+
+### Install the certificate chain
+
+The certificate, intermediate certificates (if needed), certificate authority and private key are stored in `/etc/xensource/xapi-ssl.pem`, in that order. You have to replace all lines before `-----BEGIN RSA PRIVATE KEY-----̀` with the certificate and the chain you got from your provider, using your favorite editor (`nano` is present on XCP-ng by default).
+
+Then, you have to restart xapi :
+```
+systemctl restart xapi
+```


### PR DESCRIPTION
Hi,

I just renewed certificates from internal CA for my XCP-ng servers. As I struggled a bit to find out where they where put, I just wrote a small explanation on how to get & install the server certificate from the already existing private key on the server.

Other possibilities include creating a new private key (but I guess the initial private key is randomly generated on install, right ?) and changing the file path (but it's a bit more complicated, as it should then be specified in `/etc/xapi.conf`, `/usr/lib/systemd/system/xapi-nbd.service` and `/etc/systemd/system/default.target.wants/xapi-nbd.path`).

I've put it in "guides.md" (which looks like a bit like "the things we didn't know where else to put"), but feel free to change this to a more suitable place (perhaps in installation.md ?)

Note that after a quick search, I don't find any information on how the user is supposed to verify the TLS certificate when connecting XCP-ng center or XenOrchestra to the server (but I may have missed some doc). The same goes for the first connection using SSH. Maybe this should be the subject of a last part of "installation" (whith a screenshot from xsconsole) ?

And, last note : maybe after the [sha-mbles](https://sha-mbles.github.io/) paper, it should be safer to print out sha-256 fingerprint in xsconsole, rather than sha-1 fingerprint.