### PR TITLE
Update Releases page and rename release types

### DIFF
--- a/docs/release-8-1.md
+++ b/docs/release-8-1.md
@@ -1,6 +1,6 @@
-# XCP-ng 8.1 (CR)
+# XCP-ng 8.1
 
-**XCP-ng 8.1** is the current and latest release of XCP-ng. [Download the installation ISO](http://mirrors.xcp-ng.org/isos/8.1/xcp-ng-8.1.0-2.iso).
+**XCP-ng 8.1** is a [standard release](releases.md#standard-releases). [Download the installation ISO](http://mirrors.xcp-ng.org/isos/8.1/xcp-ng-8.1.0-2.iso).
 
 SHA256 checksums, GPG signatures and net-install ISO are available [here](http://mirrors.xcp-ng.org/isos/8.1/).
 

--- a/docs/release-8-2.md
+++ b/docs/release-8-2.md
@@ -1,6 +1,6 @@
-# XCP-ng 8.2 (LTSR)
+# XCP-ng 8.2 LTS
 
-XCP-ng 8.2 is a LTS Release (LTSR). [Download the installation ISO](http://mirrors.xcp-ng.org/isos/8.2/xcp-ng-8.2.0.iso).
+XCP-ng 8.2 is a [LTS Release](releases.md#lts-releases). [Download the installation ISO](http://mirrors.xcp-ng.org/isos/8.2/xcp-ng-8.2.0.iso).
 
 SHA256 checksums, GPG signatures and net-install ISO are available [here](https://xcp-ng.org/#easy-to-install).
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,42 +1,50 @@
 # Releases
 
-There's multiple releases of XCP-ng. In general, one CR (Current Release) and one LTSR (Long Term Support Release).
+There are two kinds of XCP-ng releases: standard releases and Long Term Support (LTS) releases.
 
-## CR (Current Release)
+## Standard Releases
 
-Using the CR version is relevant if:
+*Latest: [XCP-ng 8.2](release-8-2.md)*
+
+Using the standard release is relevant if:
 
 * you want to enjoy the most recent features and enhancements
 * you want to have the latest hardware support
 * you want to enjoy more performances
 * it's not a problem to do an upgrade twice a year or so
 
-If you prefer to be more conservative, go for our [LTS release](releases.md#ltsr-long-term-support-release).
+Standard releases are supported until the next release, plus a few months to give you some time to transition. Check the support dates [in the table below](#all-releases).
+
+If you prefer to be more conservative, go for our [LTS release](#lts-releases).
 
 :::tip
-Right now, the current release (8.2) is also the LTSR. As soon there's a new release after that, for example 8.3, this new version will be the CR, and 8.2 will stay as the LTS.
+Right now, the latest standard release (8.2) is also the LTS release. When XCP-ng 8.3 will be released, it will become the latest standard release, and 8.2 will stay as the latest LTS.
 :::
 
-## LTSR (Long Term Support Release)
+## LTS Releases
 
-Using the LTSR version is relevant if:
+*Latest LTS: [XCP-ng 8.2](release-8-2.md)*
+
+Using the Long Term Support version is relevant if:
 
 * you want to be sure the system will stay stable
 * you want to have all security fixes without doing major upgrades every year
 * you want a predictable migration path on a longer timeframe
 * you don't care about new features coming for the next years
 
+LTS releases are supported for 5 years.
+
 ![](../assets/img/lts.png)
 
-If you prefer to get latest improvements, go for our [current release](currentrelease.md).
+If you prefer to get the latest improvements, go for our [latest standard release](#standard-releases).
 
 ## All releases
 
-| Version | Released   | Status               | Support until                                | Release notes              |
-| ---     | ---        | ---                  | ---                                          | ---                        |
-| [8.2 LTS](release-8-2.md) | 2020-11-14 | Full support, LTS    | 2025-06-25                                   | [8.2 Release notes](release-8-2.md)  |
-| [8.1](release-8-1.md)     | 2020-03-31 | Full support         | *Until the release of XCP-ng 8.3 (~Q1 2021)* | [8.1 Release notes](release-8-1.md)  |
-| 8.0     | 2019-07-25 | Best effort support  | 2020-11-13                                   |                            |
-| 7.6     | 2018-10-31 | EOL                  | 2020-03-30                                   |                            |
-| 7.5     | 2018-08-10 | EOL                  | 2019-07-25                                   |                            |
-| 7.4     | 2018-03-31 | EOL                  | 2018-10-31                                   |                            |
+| Version                   | Released   | Status               | Support until                                | Release notes                        |
+| ---                       | ---        | ---                  | ---                                          | ---                                  |
+| [8.2 LTS](release-8-2.md) | 2020-11-18 | Full support, LTS    | 2025-06-25                                   | [8.2 Release notes](release-8-2.md)  |
+| [8.1](release-8-1.md)     | 2020-03-31 | Full support         | Until the release of XCP-ng 8.3 (~Q1 2021)   | [8.1 Release notes](release-8-1.md)  |
+| 8.0                       | 2019-07-25 | EOL                  | 2020-11-13                                   |                                      |
+| 7.6                       | 2018-10-31 | EOL                  | 2020-03-30                                   |                                      |
+| 7.5                       | 2018-08-10 | EOL                  | 2019-07-25                                   |                                      |
+| 7.4                       | 2018-03-31 | EOL                  | 2018-10-31                                   |                                      |


### PR DESCRIPTION
LTSR => LTS
CR => standard release

Makes it easier to describe former releases (such as 8.1), for which
"Current Release" doesn't fit well.