### PR TITLE
Add an end of support date for XCP-ng 8.1

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -43,7 +43,7 @@ If you prefer to get the latest improvements, go for our [latest standard releas
 | Version                   | Released   | Status               | Support until                                | Release notes                        |
 | ---                       | ---        | ---                  | ---                                          | ---                                  |
 | [8.2 LTS](release-8-2.md) | 2020-11-18 | Full support, LTS    | 2025-06-25                                   | [8.2 Release notes](release-8-2.md)  |
-| [8.1](release-8-1.md)     | 2020-03-31 | Full support         | Until the release of XCP-ng 8.3 (~Q1 2021)   | [8.1 Release notes](release-8-1.md)  |
+| [8.1](release-8-1.md)     | 2020-03-31 | Full support         | 2021-03-31 or release of XCP-ng 8.3, whichever comes first | [8.1 Release notes](release-8-1.md)  |
 | 8.0                       | 2019-07-25 | EOL                  | 2020-11-13                                   |                                      |
 | 7.6                       | 2018-10-31 | EOL                  | 2020-03-30                                   |                                      |
 | 7.5                       | 2018-08-10 | EOL                  | 2019-07-25                                   |                                      |

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -11,7 +11,7 @@ We maintain two releases in parallel:
 If your version is lower than `8.2`, it will not receive updates anymore. To keep benefiting from bugfixes and security fixes you need to [upgrade](upgrade.md).
 
 :::tip
-Exceptionally, XCP-ng 8.1 will continue to receive support until XCP-ng 8.3 is available. The general rule is to offer a transition period for you to upgrade after each new Standard release, a few months in general.
+Exceptionally, XCP-ng 8.1 will continue to receive support until either XCP-ng 8.3 is available or until March 31 2021, whichever comes first. The general rule is to offer a transition period for you to upgrade after each new Standard release, a few months in general.
 :::
 
 ## Prerequisites


### PR DESCRIPTION
The date of release of XCP-ng 8.3 being still unknown, we can't safely
use it as a moving EOL date for XCP-ng 8.1. Thus support for XCP-ng 8.1
will end at most on 2021-03-31 (which is approximately the date we
initially thought we would release XCP-ng 8.3 at).

This is not a perfect solution, but at least XCP-ng 8.2 LTS is now here
to allow users to benefit from an long term support period.