### PR TITLE
Force to use only HTTPS supported mirrors to avoid HTTPS downgrade to…

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,7 +329,7 @@
                 <div class="tab-pane fade show active" id="v-pills-download" role="tabpanel"
                      aria-labelledby="v-pills-download-tab">
                     <p>
-                        Grab the <a href="https://mirrors.xcp-ng.org/isos/8.2/" onclick="_paq.push(['trackEvent', 'Download', 'full']);">8.2 ISO here</a>, then create your bootable USB key with:
+                        Grab the <a href="https://mirrors.xcp-ng.org/isos/8.2/xcp-ng-8.2.0.iso?https=1" onclick="_paq.push(['trackEvent', 'Download', 'full']);">8.2 ISO here</a>, then create your bootable USB key with:
                     </p>
                     <div class="code p-1 m-1 p-sm-3 m-sm-3">
                         dd if=xcp-ng-8.2.0.iso of=/dev/sdX bs=8M oflag=direct
@@ -341,7 +341,7 @@
                 <div class="tab-pane fade" id="v-pills-net-install" role="tabpanel"
                      aria-labelledby="v-pills-net-install-tab">
                     <p>
-                        Download the <a href="https://mirrors.xcp-ng.org/isos/8.2/" onclick="_paq.push(['trackEvent', 'Download', 'netinstall']);">Net install ISO</a> (150MiB), then create your bootable USB key:
+                        Download the <a href="https://mirrors.xcp-ng.org/isos/8.2/xcp-ng-8.2.0-netinstall.iso?https=1" onclick="_paq.push(['trackEvent', 'Download', 'netinstall']);">Net install ISO</a> (150MiB), then create your bootable USB key:
                     </p>
                     <div class="code p-1 m-1 p-sm-3 m-sm-3">
                         dd if=xcp-ng-8.2.0-netinstall.iso of=/dev/sdX bs=8M oflag=direct
@@ -372,7 +372,7 @@
                     <p>We strongly suggest to download only the current release. This is only for historical purpose.</p>
                     <div>
                         <p>You can find all previous XCP-ng releases here:</p>
-                        <a href="https://updates.xcp-ng.org/isos/">https://updates.xcp-ng.org/isos/</a>
+                        <a href="https://mirrors.xcp-ng.org/isos?https=1">https://mirrors.xcp-ng.org</a>
                     </div><br/>
                 </div>
                 <div class="tab-pane fade" id="v-pills-from-xo" role="tabpanel"


### PR DESCRIPTION
… HTTP, which isn't supported by Chrome anymore.