### PR TITLE
Enforce HTTPS for download links and update mirror docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -8,7 +8,7 @@ If you want to use the netinstall ISO, see the [Netinstall section](install.md#n
 
 ### Download and create media
 
-You can download the 8.2 ISO here: <http://mirrors.xcp-ng.org/isos/8.2/xcp-ng-8.2.0.iso>.
+You can download the 8.2 ISO here: <https://mirrors.xcp-ng.org/isos/8.2/xcp-ng-8.2.0.iso?https=1>.
 
 SHA256 checksums, GPG signatures and net-install ISO are available [here](https://xcp-ng.org/#easy-to-install).
 
@@ -164,7 +164,7 @@ It means the system is correctly installed! Enjoy XCP-ng 🚀
 
 The netinstall image is a lightweight ISO (around 150MiB) that will only contain the installer, but no actual RPM packages. Sometimes, it's more convenient/faster when your ISO is on a slow connection (e.g. a virtual media using a server IPMI).
 
-You can download it on this URL: <http://mirrors.xcp-ng.org/isos/8.2/xcp-ng-8.2.0-netinstall.iso>.
+You can download it on this URL: <https://mirrors.xcp-ng.org/isos/8.2/xcp-ng-8.2.0-netinstall.iso?https=1>.
 
 As with the regular installation ISO, write it on an USB media:
 

--- a/docs/mirrors.md
+++ b/docs/mirrors.md
@@ -12,7 +12,7 @@ Previous versions of XCP-ng downloaded files directly from `https://updates.xcp-
 
 ## List of mirrors
 
-You can check our live list of mirror at this URL: [http://mirrors.xcp-ng.org/?mirrorstats](http://mirrors.xcp-ng.org/?mirrorstats)
+You can check our live list of mirrors at this URL: [https://mirrors.xcp-ng.org/?mirrorstats](https://mirrors.xcp-ng.org/?mirrorstats)
 
 :::tip
 If loading this page fails due to too many redirections, just go to <https://xcp-ng.org> once, then try again)
@@ -26,8 +26,9 @@ Anyone or any entity can submit a mirror to our approval so that we add it to th
 
 In order to guarantee the quality of the mirrors offered to our users, there a some prerequisites:
 * Offer HTTP (more convenient than anonymous FTP for mirrors nowadays), or HTTPS.
-  * Note: HTTPS does not add much value because ISO image checksums, repository data and all RPMs are signed. HTTP is OK.
+  * Note: HTTPS is required for downloads of installation ISO images, because recent browsers tend to refuse any HTTPS to HTTP downgrade. If you mirror only provides HTTP, it can still be used for downloading RPMs from XCP-ng hosts, since every RPM is GPG-signed. HTTPS may become a requirement for this too in the future.
   * If you offer HTTPS, you need a valid certificate and must renew it in time to avoid downtime.
+  * If you already provided a mirror but are unsure if we added it as an HTTP or HTTPS mirror, check http://mirrors.xcp-ng.org/README.txt?mirrorlist&https=1, which selects HTTPS mirrors and lists the others in an "Excluded Mirrors" section.
 * Offer read-only `rsync`. Two reasons:
   * Mirrorbits needs this to regularly check the state of the mirror and automatically disable outdated or broken mirrors.
   * This will allow nearby mirrors to sync from yours in the future, if needed.

--- a/docs/release-8-1.md
+++ b/docs/release-8-1.md
@@ -1,6 +1,6 @@
 # XCP-ng 8.1
 
-**XCP-ng 8.1** is a [standard release](releases.md#standard-releases). [Download the installation ISO](http://mirrors.xcp-ng.org/isos/8.1/xcp-ng-8.1.0-2.iso).
+**XCP-ng 8.1** is a [standard release](releases.md#standard-releases). [Download the installation ISO](https://mirrors.xcp-ng.org/isos/8.1/xcp-ng-8.1.0-2.iso?https=1).
 
 SHA256 checksums, GPG signatures and net-install ISO are available [here](http://mirrors.xcp-ng.org/isos/8.1/).
 

--- a/docs/release-8-2.md
+++ b/docs/release-8-2.md
@@ -1,6 +1,6 @@
 # XCP-ng 8.2 LTS
 
-XCP-ng 8.2 is a [LTS Release](releases.md#lts-releases). [Download the installation ISO](http://mirrors.xcp-ng.org/isos/8.2/xcp-ng-8.2.0.iso).
+XCP-ng 8.2 is a [LTS Release](releases.md#lts-releases). [Download the installation ISO](https://mirrors.xcp-ng.org/isos/8.2/xcp-ng-8.2.0.iso?https=1).
 
 SHA256 checksums, GPG signatures and net-install ISO are available [here](https://xcp-ng.org/#easy-to-install).
 


### PR DESCRIPTION
- ISO downloads must be done on HTTPS to avoid browsers blocking due to
  the HTTP downgrade, and the `https=1` parameter must be passed to
  mirrorbits so that it only selects HTTPS mirrors for these requests.
- Docs about mirrors updated: HTTPS is now highly recommended for any
  mirror.