### PR TITLE
Use comment-lines icon instead of stack-overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
             <div class="number-box p-1">
                 <div class="row number align-middle">
                     <div class="col p-0">
-                        <i class="fab fa-stack-overflow"></i>
+                        <i class="fab fa-comment-lines"></i>
                     </div>
                     <div class="col">
                         <span id="xcp-ng-stars-on-github" class="count">23</span>K+
@@ -276,7 +276,7 @@
 
         <div class="row text-center justify-content-center">
             <div class="col-5 col-sm-3 p-3 p-sm-1">
-                <a href="https://xcp-ng.org/forum"><i class="fab fa-stack-overflow fa-3x"></i><br/>Forum</a>
+                <a href="https://xcp-ng.org/forum"><i class="fab fa-comment-lines fa-3x"></i><br/>Forum</a>
             </div>
             <div class="col-5 col-sm-3 p-3 p-sm-1">
                 <a href="https://twitter.com/xcpng"><i class="fab fa-twitter fa-3x"></i><br/>@xcpng</a>


### PR DESCRIPTION
Use the [`comment-lines`](https://fontawesome.com/icons/comment-lines?style=regular) icon instead of stack-overflow https://fontawesome.com/icons/comment-lines?style=regular

Fixes #66