### PR TITLE
Add iPXE over HTTP install instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -238,6 +238,61 @@ When you do copy the installation files, **DO NOT FORGET** the `.treeinfo` file.
 3. Select boot from the Ethernet card
 4. You should see the PXE menu you created before!
 
+## Network boot (UEFI / iPXE over HTTP)
+
+### Requirements
+
+To get XCP-ng installed from iPXE over HTTP, you need:
+
+* An HTTP server to host XCP-ng installation files
+* A iPXE compatible network card and iPXE firmware on your host
+
+1. In your HTTP root directory copy the contents of the net install ISO.
+
+   The top-level should look like this:
+
+        tree -L 1 /path/to/http-directory/
+        .
+        ├── EFI
+        ├── EULA
+        ├── LICENSES
+        ├── RPM-GPG-KEY-CH-8
+        ├── RPM-GPG-KEY-CH-8-LCM
+        ├── RPM-GPG-KEY-Platform-V1
+        ├── boot
+        └── install.img
+
+3. Boot the target machine.
+4. Press Ctrl-B to catch the iPXE menu.  Use the chainload command to load grub.
+
+        chain http://SERVER_IP/EFI/xenserver/grubx64.efi
+
+:::tip
+Sometimes grub takes a very long time to load after displaying "Welcome to
+Grub".  This can be fixed by compiling a new version of Grub wit
+`grub-mkstandalone`.
+:::
+
+5. Once the grub prompt loads, set the root to http and load the config file.
+
+        # Replace with your server's  ip
+        set root=(http,SERVER_IP)
+        configfile /EFI/xenserver/grub.cfg
+
+6. Select the "install" menu entry.
+7. Wait for grub to load the necessary binaries.  This may take a minute.  If
+   you look at your http server log you should see something like:
+
+        ```
+        (from python3 -m http.server path-to-directory 80)
+
+        192.168.0.10 - - [11/Mar/2021 03:25:58] "GET /boot/xen.gz HTTP/1.1" 200 -
+        192.168.0.10 - - [11/Mar/2021 03:25:58] "GET /boot/vmlinuz HTTP/1.1" 200 -
+        192.168.0.10 - - [11/Mar/2021 03:26:03] "GET /install.img HTTP/1.1" 200 -
+        ```
+8. Continue with installation as normal.
+
+
 ## Automated install
 
 ### Via PXE


### PR DESCRIPTION
This just adds instructions for doing iPXE over HTTP.

This shows how to do it purely over HTTP (no TFTP, even for iPXE -> Grub).  For some reason when Grub is loaded over HTTP, it *thinks* it has been loaded over tftp.  This can be tested by `echo ${root}` when you reach the Grub prompt after chainloading over HTTP (it will claim its root is tftp).  Because of this, you have to manually set the root to http before loading the config file.

The iPXE portion can be automated recompiling it with an embedded script with the chain command.  Or by simply using TFTP and configure your DHCP server.  I also believe Grub can be configured to automate the root change and configuration load, but also will require recompilation.  I noticed that Ubuntu offers a seperate grub for net booting, which may contain some of these small changes for them.