### PR TITLE
Reword annexes to appendices

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -78,7 +78,7 @@ module.exports = {
         ]
       },
       {
-        title: 'Annexes',   // required
+        title: 'Appendix',// required
         collapsable: false, // optional, defaults to true
         sidebarDepth: 1,    // optional, defaults to 1
         children: [


### PR DESCRIPTION
Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>

To be confirmed by @beshleman or @Fohdeesha: I think the correct word for the section that comes at the end of a document would be "Appendices" in english, rather than "Annexes" (which does exist in english but may not convey the exact same sense as in French). Reference: https://dictionary.cambridge.org/fr/dictionnaire/francais-anglais/annexe