### PR TITLE
(Docu) compute.md cleanup (nvidia driver note, USB passthrough)

### DIFF
--- a/docs/compute.md
+++ b/docs/compute.md
@@ -103,6 +103,44 @@ This kernel parameter is not retained when you upgrade an XCP-ng host [using the
 
 `[root@xen ~]# xe vm-start uuid=<vm uuid>`
 
+## GPU Passthrough
+To passthrough a complete graphics card to a VM (not virtualize it into multiple virtual vGPUs, which is different, see the vGPU section below), just follow the regular PCI passthrough instructions, no special steps are needed. Most Nvidia and AMD video cards should work without issue.  
+
+:::tip
+Previously, Nvidia would block the use of gaming/consumer video cards for passthrough (the Nvidia installer would throw an **Error 43** when installing the driver inside your VM). They lifted this restriction in 2021 with driver R465 and above, so be sure to use the latest driver. [Details from Nvidia here.](https://nvidia.custhelp.com/app/answers/detail/a_id/5173/)
+:::
+
+## vGPU
+
+### NVIDIA vGPU
+
+:::warning
+Due to a proprietary piece of code in XenServer, XCP-ng doesn't have (yet) support for NVIDIA vGPUs.
+:::
+
+### MxGPU (AMD vGPU)
+
+AMD GPU are trivial using industry standard.  
+Version 2.0 of the mxgpu iso should work on any 8.X version of XCP-ng
+
+1. Enable SR-IOV in the server's BIOS
+2. Install XCP-ng
+3. Download Citrix XenServer from AMD's Drivers & Support page. (Currently version 2.0.0 for XenServer 8.1)
+4. Copy the `mxgpu-2.0.0.amd.iso` to the host
+5. Install the supplemental pack:
+
+`cd /tmp`
+
+`xe-install-supplemental-pack mxgpu-2.0.0.amd.iso`
+
+6. Reboot the XCP-ng
+7. Assign an MxGPU to the VM from the VM properties page.  Go to the GPU section.  From the Drop down choose how big of a slice of the GPU you want on the VM and click OK
+
+Start the VM and log into the guest OS and load the appropriate guest driver from AMD's Drivers & Support page.
+
+> Known working cards:
+* S7150x2
+
 ## USB Passthrough
 
 :::tip
@@ -157,45 +195,6 @@ In the future if you ever need to unplug the virtual USB device from your VM, or
 xe vusb-unplug uuid=<vusb_uuid>
 xe vusb-destroy uuid=<vusb_uuid>
 ```
-
-## GPU Passthrough
-To passthrough a complete graphics card to a VM (not virtualize it into multiple virtual vGPUs, which is different, see the vGPU section below), just follow the regular PCI passthrough instructions, no special steps are needed. Most Nvidia and AMD video cards should work without issue.  
-
-:::tip
-Previously, Nvidia would block the use of gaming/consumer video cards for passthrough (the Nvidia installer would throw an **Error 43** when installing the driver inside your VM). They lifted this restriction in 2021 with driver R465 and above, so be sure to use the latest driver. [Details from Nvidia here.](https://nvidia.custhelp.com/app/answers/detail/a_id/5173/)
-:::
-
-## vGPU
-
-### NVIDIA vGPU
-
-:::warning
-Due to a proprietary piece of code in XenServer, XCP-ng doesn't have (yet) support for NVIDIA vGPUs.
-:::
-
-### MxGPU (AMD vGPU)
-
-AMD GPU are trivial using industry standard.  
-Version 2.0 of the mxgpu iso should work on any 8.X version of XCP-ng
-
-1. Enable SR-IOV in the server's BIOS
-2. Install XCP-ng
-3. Download Citrix XenServer from AMD's Drivers & Support page. (Currently version 2.0.0 for XenServer 8.1)
-4. Copy the `mxgpu-2.0.0.amd.iso` to the host
-5. Install the supplemental pack:
-
-`cd /tmp`
-
-`xe-install-supplemental-pack mxgpu-2.0.0.amd.iso`
-
-6. Reboot the XCP-ng
-7. Assign an MxGPU to the VM from the VM properties page.  Go to the GPU section.  From the Drop down choose how big of a slice of the GPU you want on the VM and click OK
-
-Start the VM and log into the guest OS and load the appropriate guest driver from AMD's Drivers & Support page.
-
-
-> Known working cards:
-* S7150x2
 
 ## VM load balancing
 

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -180,8 +180,10 @@ xe network-param-set uuid=<network UUID> other-config:static-routes=10.88.0.0/14
 You **must** restart the toolstack on the host for the new route to be added!
 :::
 
-You can check the result with a `route -n` afterwards to see if the route is now present.
-
+You can check the result with a `route -n` afterwards to see if the route is now present. If you must add multiple static routes, it must be in one command, and the routes separated by commas. For example, to add both 10.88.0.0/14 via 10.88.113.193 *and* 10.0.0.0/24 via 192.168.1.1, you would use this:
+```
+xe network-param-set uuid=<network UUID> other-config:static-routes=10.88.0.0/14/10.88.113.193,10.0.0.0/24/192.168.1.1
+```
 ### Removing static routes
 
 To **remove** static routes you have added, stick the same network UUID from before in the below command:


### PR DESCRIPTION
Significant cleanup of the Compute documentation page:

- The GPU passthrough section is now fleshed out with basic info, and a note has been added regarding Nvidia unlocking gpu passthrough on consumer cards in early 2021
- This GPU section was moved down below the USB passthrough section, so it's now contiguous with the vGPU section (currently, the USB passthrough section interrupts and splits the GPU and vGPU sections)
- The USB passthrough section was cleaned up and re-ordered to make more sense, with examples as well as instructions on how to remove USB devices as well

Due to the moving of large blocks the diff probably looks quite ugly, recommend viewing the new compute.md in full in a markdown editor 