### PR TITLE
Add a pull request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,8 @@
+
+
+> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
+> * [ ] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
+> * [ ] "My contribution complies with the Developer Certificate of Origin [2]." 
+>
+> [1] https://creativecommons.org/licenses/by-sa/2.0/
+> [2] https://xcp-ng.org/docs/contributing.html#developer-certificate-of-origin-dco


### PR DESCRIPTION
The template asks users to check two boxes, as a way to make them aware
of the DCO and under which license they put their contribution.

To be discussed.