### PR TITLE
Add or fix licensing information in the docs

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -8,7 +8,8 @@ module.exports = {
   themeConfig: {
     smoothScroll: false,
     logo: 'https://xcp-ng.org/assets/img/smalllogo_notext.png',
-    lastUpdated: 'Last Updated', // add latest Git commit modification for each file
+    // "abuse" lastUpdated label to add the License in the footer
+    lastUpdated: 'License: CC BY-SA 2.0 - Last Updated', // add latest Git commit modification for each file
     repo: 'xcp-ng/xcp-ng-org', // point to the GH repo
     editLinks: true, // display link for people to edit a page
     editLinkText: 'Help us to improve this page!', // link text

--- a/docs/licenses.md
+++ b/docs/licenses.md
@@ -1,7 +1,9 @@
 XCP-ng is Free Software. It is built on top of various components including the Linux kernel (GPLv2), Xen (GPLv2, LGPLv2+ or BSD, depending on the components) and many more [F/OSS](https://fr.wikipedia.org/wiki/Free/Libre_Open_Source_Software) components (the license for each is defined in the License tag of each RPM).
 
-A file compiling the texts of the licenses is available at <https://github.com/xcp-ng/xcp/tree/master/iso>, for each release of XCP-ng, in a file named `LICENSES`.
+A file compiling the texts of the licenses is available at <https://github.com/xcp-ng/branding-xcp-ng/blob/master/branding/LICENSES>. For the licenses of a specific release of XCP-ng, use the select box on the top and select the tag that corresponds to the release you are interested it.
 
 It is also present in the installer ISO image.
 
 All features are available for free. Pro support is available from <https://xcp-ng.com/>
+
+XCP-ng's documentation itself is published under the [Creative Commons BY SA 2.0](https://creativecommons.org/licenses/by-sa/2.0/) license.


### PR DESCRIPTION
* Add "License: CC BY-SA 2.0" in the footer
* Also add a sentence about the documentation's license in the Licenses
  page.
* Fix link to XCP-ng's LICENSES files.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://xcp-ng.org/docs/contributing.html#developer-certificate-of-origin-dco
