### PR TITLE
docs: add multi-cert SB variable instructions

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -1042,22 +1042,28 @@ secureboot-certs install
 Advanced use, not needed by most users.
 :::
 
-`secureboot-certs` also supports installing your own custom certificates. The certs must be in the format of ".auth" files, which may be accomplished using `/opt/xensource/libexec/create-auth`.
+`secureboot-certs` also supports installing your own custom certificates. The certs may be in the following formats:
+
+* DER-encoded certificate
+* PEM-encdoed certificate
+* An auth file (can be created with `/opt/xensource/libexec/create-auth`).
 
 For example, to install a custom PK you may do the following:
 
 ```
 # Create the key and cert using OpenSSL
-openssl req -newkey rsa:4096 -nodes -new -x509 -sha256 -days 3650 -subj "/CN=My PK/" -keyout pk.key -out pk.cer
+openssl req -newkey rsa:4096 -nodes -new -x509 -sha256 -days 3650 -subj "/CN=My PK/" -keyout pk.key -out PK.cer
 
 # Create the .auth file from the DER certificate
 /opt/xensource/libexec/create-auth -k pk.key -c pk.cer PK PK.auth pk.cer
 
 # Enroll it, along with the default certificates, with secureboot-certs
-secureboot-certs install PK.auth default default latest
+secureboot-certs install PK.cer default default latest
 ```
 
 The same procedure may be used to install custom KEK, db, or dbx certs.
+
+To use multiple certificates in one variable (that is, have multiple certificates in PK, KEK, db, or dbx), the certs must be packaged together into a .auth file, see [Use two or more certificates for a Secure Boot variable](#use-two-or-more-certificates-for-a-secure-boot-variable).
 
 Note that the virtual firmware (uefistored + OVMF), as is allowed by the specification, does not mandate that these default certificates be signed by their parent (i.e., the KEK doesn't need to be signed by PK) if they're installed via `secureboot-certs`. This verification *does* occur, however, when trying to enroll new certificates from inside the guest after boot. This is designed to give the host administrator full control over the certificates from the control domain.
 
@@ -1303,3 +1309,26 @@ From command line, use:
 ```
 xe vm-param-get uuid=<vm-uuid> param-name=HVM-boot-params param-key=firmware
 ```
+
+#### Use two or more certificates for a Secure Boot variable
+
+To create a Secure Boot variable (PK, KEK, db, or dbx) with multiple certificates, it is required to use the `create-auth` tool to bundle the certificates into a single .auth file.
+
+From command line, to create a KEK with certifcates `cert1.crt` and `cert2.crt`:
+```
+/opt/xensource/libexec/create-auth KEK KEK.auth cert1.crt cert2.crt
+```
+
+To create the same auth as above, but also sign it with a custom key:
+```
+/opt/xensource/libexec/create-auth -c signer.crt -k signer.key KEK KEK.auth cert1.crt cert2.crt
+```
+
+After creating the auth file, use secureboot-certs to install it with the rest of your certs:
+
+```
+# Install custom KEK, download and install public PK/db/dbx certificates
+secureboot-certs install default KEK.auth default latest
+```
+
+This may be done with any PK, KEK, db, or dbx.

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -1045,25 +1045,19 @@ Advanced use, not needed by most users.
 `secureboot-certs` also supports installing your own custom certificates. The certs may be in the following formats:
 
 * DER-encoded certificate
-* PEM-encdoed certificate
+* PEM-encoded certificate
 * An auth file (can be created with `/opt/xensource/libexec/create-auth`).
 
 For example, to install a custom PK you may do the following:
 
 ```
-# Create the key and cert using OpenSSL
-openssl req -newkey rsa:4096 -nodes -new -x509 -sha256 -days 3650 -subj "/CN=My PK/" -keyout pk.key -out PK.cer
-
-# Create the .auth file from the DER certificate
-/opt/xensource/libexec/create-auth -k pk.key -c pk.cer PK PK.auth pk.cer
-
 # Enroll it, along with the default certificates, with secureboot-certs
 secureboot-certs install PK.cer default default latest
 ```
 
 The same procedure may be used to install custom KEK, db, or dbx certs.
 
-To use multiple certificates in one variable (that is, have multiple certificates in PK, KEK, db, or dbx), the certs must be packaged together into a .auth file, see [Use two or more certificates for a Secure Boot variable](#use-two-or-more-certificates-for-a-secure-boot-variable).
+To use multiple certificates in one variable (that is, have multiple certificates stored as a single KEK, db, or dbx), the certs must be packaged together into a .auth file, see [Use two or more certificates for a Secure Boot variable](#use-two-or-more-certificates-for-a-secure-boot-variable). Note that multiple certificates in the PK is not supported. If an auth file with multiple certs is loaded as the PK, only the first one found will be used.
 
 Note that the virtual firmware (uefistored + OVMF), as is allowed by the specification, does not mandate that these default certificates be signed by their parent (i.e., the KEK doesn't need to be signed by PK) if they're installed via `secureboot-certs`. This verification *does* occur, however, when trying to enroll new certificates from inside the guest after boot. This is designed to give the host administrator full control over the certificates from the control domain.
 


### PR DESCRIPTION
This commit adds instructions for adding multiple certs to a single
variable in the pool-wide variable store for guest secure boot. This
information will be useful for users wishing to use custom certificates
and needing to allocate trust according to a more bespoke trust policy.
It will also be useful to users that would like to add other
certificates in addition to the public MSFT/UEFI certificates.

Signed-off-by: Bobby Eshleman <bobby.eshleman@gmail.com>



> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://xcp-ng.org/docs/contributing.html#developer-certificate-of-origin-dco
