### PR TITLE
Add notes about "incompatible license" errors when mixing product types

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -143,7 +143,7 @@ please try to:
 > Usually, when you install a recent distro in PVHVM (using other media) and you get a blank screen, try blacklisting by adding the following in your grub command at the end
 >
 > modprobe.blacklist=bochs_drm
-
+***
 ### Initrd is missing after an update
 
 #### Symptom
@@ -164,6 +164,7 @@ Can be a `yum` update process interrupted while rebuilding the `initrd`, such as
 Here is an example of `dracut` command on a 8.2 host: `dracut -f /boot/initrd-4.19.0+1.img 4.19.0+1`
 :::
 
+***
 ### VM not in expected power state
 
 #### Cause
@@ -171,6 +172,16 @@ The XAPI database thinks that the VM is On / Off. But this is fake news ;-)
 
 #### Solution
 Restart toolstack on CLI with the command `xe-toolstack-restart`. This just restarts the management services, all running VMs are untouched.
+
+***
+
+### Host and Pool have incompatible Licenses
+
+#### Cause
+You may get this error when attempting to add a new host to an existing pool. This occurs when you mix products, for instance adding a XenServer/Citrix Hypervisor host to an XCP-ng pool, or vice versa. 
+
+#### Solution
+To solve this, simply get your pool "coherent" and do not mix products. Ensure all hosts in the pool as well as hosts you'd like to add to the pool are running XCP-ng. It is not recommended to mix XCP-ng hosts with XenServer hosts in the same pool.
 
 ***
 
@@ -202,7 +213,7 @@ Unknown, the system keeps listening to the hardware clock instead of trusting NT
 echo "xen" > /sys/devices/system/clocksource/clocksource0/current_clocksource
   printf '%s\n\t%s\n%s\n' 'if test -f /sys/devices/system/clocksource/clocksource0/current_clocksource; then' 'echo xen > /sys/devices/system/clocksource/clocksource0/current_clocksource' 'fi' >> /etc/rc.local
 ```
-
+***
 ### Async Tasks/Commands Hang or Execute Extremely Slowly
 
 #### Cause

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -205,6 +205,7 @@ This article describes how to proceed in order to convert your Citrix XenServer 
 * If HA (High Availability) is enabled, disable it before upgrading
 * Eject CDs from your VMs before upgrading [to avoid issues](https://xcp-ng.org/forum/topic/174/upgrade-from-xenserver-7-1-did-not-work): `xe vm-cd-eject --multiple`
 * **It is very important to make sure clustering is not enabled on your pool**. It's a functionality that relies on proprietary software and that is not available in XCP-ng, and having it enabled before the upgrade will lead to XAPI being unable to start due to unexpected data in the database. If it is enabled or you already upgraded, see [this comment](https://github.com/xcp-ng/xcp/issues/94#issuecomment-437838544).
+* If you already have an XCP-ng pool, do not try to add a slave running XenServer to it. You will get an "Incompatible License" error. Please upgrade the slave to XCP-ng first, then add it to your existing pool
 :::
 
 ### Before you start


### PR DESCRIPTION
As requested in: https://github.com/xcp-ng/xcp/issues/509

Add notes & solution to our XCP-ng docu regarding the "incompatible license" error that's generated when you try to add a xenserver host to an XCP-ng pool or vice versa

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://xcp-ng.org/docs/contributing.html#developer-certificate-of-origin-dco