### PR TITLE
Remove Google Analytics tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,6 @@
 <html lang="en">
 
 <head>
-    <!-- Temp test Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-KG7RR84');</script>
-    <!-- End Google Tag Manager -->
-
     <!-- Required meta tags -->
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -45,15 +41,6 @@
         })();
     </script>
     <!-- End Matomo Code -->
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-112481698-1"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-
-        gtag('config', 'UA-112481698-1');
-    </script>
 
     <nav id="xcp-ng-navbar" class="navbar navbar-expand-sm fixed-top bg-light">
         <div id="xcp-ng-menu" class="container-fluid">


### PR DESCRIPTION
We continue our quest to remove deps on non-EU providers. The effort is
made to keep data safe inside Vates (we do NOT share data), even by
keeping it on our own hardware, hosted in France.