### PR TITLE
Fix OPNsense / pfSense mixup

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -78,7 +78,7 @@ pfSense and OPNsense do work great in a VM, but there are a few extra steps that
 
 ### 2. Install Guest Utilities
 
-There are 2 ways of doing that, either using the CLI (pfSense or OPNsense) or the Web UI (pfSense).
+There are 2 ways of doing that, either using the CLI (pfSense or OPNsense) or the Web UI (OPNsense).
 
 Option 1 via console/ssh:
 Now that you have the VM running, we need to install guest utilities and tell them to run on boot. SSH (or other CLI method) to the VM and perform the following:
@@ -90,10 +90,11 @@ ln -s /usr/local/etc/rc.d/xenguest /usr/local/etc/rc.d/xenguest.sh
 service xenguest start
 ```
 
-Option 2 is via Web GUI (only for pfSense):
-Open management page under http(s)://your-configured-ip and go to:
+Option 2 is via the Web GUI (only available on OPNsense):
+Open the web UI on `http(s)://your-configured-ip` and go to:
 *System -> Firmware -> Plugins*
-Scroll down to **os-xen** and let the gui do the steps needed. Next: Reboot the system to have the guest started (installer doesn't do that):
+Scroll down to **os-xen** and click the plus sign next to it to install them.  
+Next: Reboot the system to have the guest tools started (installer doesn't do this the first time):
 *Power -> Reboot*
 
 Guest Tools are now installed and running, and will automatically run on every boot of the VM.


### PR DESCRIPTION
Signed-off-by: Jon Sands jon@fohdeesha.com
> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://xcp-ng.org/docs/contributing.html#developer-certificate-of-origin-dco

The current guide page outlines the method of installing the xen-tools in *sense projects via the web UI, but has them backwards. It says the guest tools are only available to install from the web UI in pfSense, but it's only in OPNsense where they are a package installable via web UI. Switched these to fix the confusion, and put the faux-url in `code brackets`, because our docu build is currently turning the `:/` part of the url into an emoji