### PR TITLE
Add "-p" to ISO SR command example

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -485,7 +485,7 @@ From the CLI:
 
 Here's an example creating a Shared ISO SR named "ISO Repository" that will be stored in /opt/var/iso_repository:
 ```
-mkdir /opt/var/iso_repository
+mkdir -p /opt/var/iso_repository
 
 xe sr-create name-label="ISO Repository" type=iso device-config:location=/opt/var/iso_repository device-config:legacy_mode=true content-type=iso
 a6732eb5-9129-27a7-5e4a-8784ac45df27


### PR DESCRIPTION
mkdir without -p can't create several directories:

```
[11:13 chouffe ~]# mkdir /opt/var/iso_repository
mkdir: cannot create directory ‘/opt/var/iso_repository’: No such file or directory
[11:13 chouffe ~]# mkdir -p /opt/var/iso_repository
[11:13 chouffe ~]# 
```



> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://xcp-ng.org/docs/contributing.html#developer-certificate-of-origin-dco
