### PR TITLE
Improve root password description

### DIFF
--- a/docs/answerfile.md
+++ b/docs/answerfile.md
@@ -237,10 +237,15 @@ If `protov6` is static then the following elements must be present:
 
 #### Root password
 
-Specifies the root password. The value `!!` and a type of "hash" defers setting a password until first boot. Default: type="hash", `!!`.
+Specifies the root password. The value `!!` and a SHA-512 "hash" defers setting a password until first boot. Default: type="plaintext", `!!`.
 
 ```xml
   <root-password type="plaintext|hash">passwd</root-password>
+```
+How to create a hash.
+```
+mkpasswd -m SHA-512 'Password1'
+$6$Vv6DgmVWmbZ.SdRl$AUWzbpE5luuNQIyW.CUEztWLKEJkSrBhfTKFdMaX1eJhPrtXworF4RIG.GQ9cBtxE0yNBI4weakgnHdGjljFg/
 ```
 
 #### Name Server


### PR DESCRIPTION
Signed-off-by: dredknight <jordankostow@gmail.com>

- added hash type requirement
- how to create hash example
- changed default type from "hash" to "plaintext" as that is the default behaviour in 8,2



> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://xcp-ng.org/docs/contributing.html#developer-certificate-of-origin-dco
