### PR TITLE
improving install guide

### DIFF
--- a/docs/answerfile.md
+++ b/docs/answerfile.md
@@ -237,7 +237,7 @@ If `protov6` is static then the following elements must be present:
 
 #### Root password
 
-Specifies the root password. The value `!!` and a SHA-512 "hash" defers setting a password until first boot. Default: type="plaintext", `!!`.
+Specifies the root password. The value `!!` and a SHA-512 "hash" defers setting a password until first boot. Default: type="hash", `!!`.
 
 ```xml
   <root-password type="plaintext|hash">passwd</root-password>

--- a/docs/answerfile.md
+++ b/docs/answerfile.md
@@ -237,7 +237,7 @@ If `protov6` is static then the following elements must be present:
 
 #### Root password
 
-Specifies the root password. The value `!!` and a SHA-512 "hash" defers setting a password until first boot. Default: type="hash", `!!`.
+Specifies the root password. The value `!!` and a type of  "hash" defers setting a password until first boot. Default: type="hash", `!!`.
 
 ```xml
   <root-password type="plaintext|hash">passwd</root-password>

--- a/docs/answerfile.md
+++ b/docs/answerfile.md
@@ -237,10 +237,16 @@ If `protov6` is static then the following elements must be present:
 
 #### Root password
 
-Specifies the root password. The value `!!` and a type of "hash" defers setting a password until first boot. Default: type="hash", `!!`.
+Specifies the root password. The value `!!` and a SHA-512 "hash" defers setting a password until first boot. Default: type="plaintext", `!!`.
 
 ```xml
   <root-password type="plaintext|hash">passwd</root-password>
+```
+
+How to create a hash.
+```
+mkpasswd -m SHA-512 'Password1'
+$6$Vv6DgmVWmbZ.SdRl$AUWzbpE5luuNQIyW.CUEztWLKEJkSrBhfTKFdMaX1eJhPrtXworF4RIG.GQ9cBtxE0yNBI4weakgnHdGjljFg/
 ```
 
 #### Name Server

--- a/docs/answerfile.md
+++ b/docs/answerfile.md
@@ -237,7 +237,7 @@ If `protov6` is static then the following elements must be present:
 
 #### Root password
 
-Specifies the root password. The value `!!` and a type of  "hash" defers setting a password until first boot. Default: type="hash", `!!`.
+Specifies the root password. The value `!!` and a type of "hash" defers setting a password until first boot. Default: type="hash", `!!`.
 
 ```xml
   <root-password type="plaintext|hash">passwd</root-password>

--- a/docs/install.md
+++ b/docs/install.md
@@ -222,10 +222,43 @@ If you want to make an installation in UEFI mode, you need to have a slightly di
     module2 /EFI/xcp-ng/install.img
  }
 ```
-4. Copy this `grub.cfg` file to `EFI/xcp-ng` folder on the TFTP server
+4. Copy this `grub.cfg` file to `EFI/xenserver/xcp-ng` folder on the TFTP server
 5. Get the following files from XCP-ng ISO: `grubx64.efi`, `install.img` (from the root directory), `vmlinuz`, and `xen.gz` (from the /boot directory) to the new EFI/xcp-ng directory on the TFTP server.
 
+How TFTP folder looks like when configured
+```
+tree -L 1 /srv/tftp/
+srv/tftp
+└── EFI
+    ├── xcp-ng
+    │   ├── grubx64.efi
+    │   ├── install.img
+    │   ├── vmlinuz
+    │   └── xen.gz
+    └── xenserver
+        └── grub.cfg
+```
+
 On the FTP, NFS or HTTP serveur, get all the installation media content in there.
+How the HTTP dir looks like:
+```
+tree /var/www/html/ -L 2 -a
+/var/www/html/
+├── index.html
+└── xcp-ng
+    ├── boot
+    ├── client_install
+    ├── EFI
+    ├── EULA
+    ├── install.img
+    ├── LICENSES
+    ├── Packages
+    ├── repodata
+    ├── RPM-GPG-KEY-CH-8
+    ├── RPM-GPG-KEY-CH-8-LCM
+    ├── RPM-GPG-KEY-Platform-V1
+    └── .treeinfo
+ ```
 
 :::tip
 When you do copy the installation files, **DO NOT FORGET** the `.treeinfo` file. Double check your webserver isn't blocking it (like Microsoft IIS does).

--- a/docs/install.md
+++ b/docs/install.md
@@ -222,7 +222,7 @@ If you want to make an installation in UEFI mode, you need to have a slightly di
     module2 /EFI/xcp-ng/install.img
  }
 ```
-4. Copy this `grub.cfg` file to `EFI/xenserver/xcp-ng` folder on the TFTP server
+4. Copy this `grub.cfg` file to `EFI/xenserver` folder on the TFTP server
 5. Get the following files from XCP-ng ISO: `grubx64.efi`, `install.img` (from the root directory), `vmlinuz`, and `xen.gz` (from the /boot directory) to the new EFI/xcp-ng directory on the TFTP server.
 
 How TFTP folder looks like when configured
@@ -240,25 +240,8 @@ srv/tftp
 ```
 
 On the FTP, NFS or HTTP serveur, get all the installation media content in there.
-How the HTTP dir looks like:
-```
-tree /var/www/html/ -L 2 -a
-/var/www/html/
-├── index.html
-└── xcp-ng
-    ├── boot
-    ├── client_install
-    ├── EFI
-    ├── EULA
-    ├── install.img
-    ├── LICENSES
-    ├── Packages
-    ├── repodata
-    ├── RPM-GPG-KEY-CH-8
-    ├── RPM-GPG-KEY-CH-8-LCM
-    ├── RPM-GPG-KEY-Platform-V1
-    └── .treeinfo
- ```
+
+For layout example check the [offical repository](https://updates.xcp-ng.org/netinstall/latest).
 
 :::tip
 When you do copy the installation files, **DO NOT FORGET** the `.treeinfo` file. Double check your webserver isn't blocking it (like Microsoft IIS does).

--- a/docs/install.md
+++ b/docs/install.md
@@ -241,7 +241,7 @@ srv/tftp
 
 On the FTP, NFS or HTTP serveur, get all the installation media content in there.
 
-For layout example check the [offical repository](https://updates.xcp-ng.org/netinstall/latest).
+For layout example check the [official repository](https://mirrors.xcp-ng.org/netinstall/latest).
 
 :::tip
 When you do copy the installation files, **DO NOT FORGET** the `.treeinfo` file. Double check your webserver isn't blocking it (like Microsoft IIS does).

--- a/docs/install.md
+++ b/docs/install.md
@@ -218,7 +218,7 @@ If you want to make an installation in UEFI mode, you need to have a slightly di
  menuentry "XCP-ng Install (serial)" {
     multiboot2 /EFI/xcp-ng/xen.gz dom0_mem=2048M,max:2048M watchdog \
     dom0_max_vcpus=4 com1=115200,8n1 console=com1,vga
-    module2 /EFI/xcp-ng/vmlinuz console=hvc0
+    module2 /EFI/xcp-ng/vmlinuz console=hvc0 install
     module2 /EFI/xcp-ng/install.img
  }
 ```


### PR DESCRIPTION
Signed-off-by: dredknight <jordankostow@gmail.com>

answerfile "Root password":
- added hash type requirement
- how to create hash example
- changed default type from "hash" to "plaintext" as that is the default behaviour in 8,2

install - "PXE UEFI boot":
- adding some example dir structures

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://xcp-ng.org/docs/contributing.html#developer-certificate-of-origin-dco
