### PR TITLE
Add missing option when mounting /dev/urandom

### DIFF
--- a/docs/develprocess.md
+++ b/docs/develprocess.md
@@ -787,7 +787,7 @@ To use `yum` or `rpm`, you'll also need to mount `urandom` in your chrooted dir.
 From outside the chroot run:
 ```
 touch install/dev/urandom
-mount /dev/urandom install/dev/urandom # As root!
+mount -B /dev/urandom install/dev/urandom # As root!
 ```
 Then useful commands will be available to you in the context of that filesystem, such as `rpm`, `yum`, etc.
 


### PR DESCRIPTION
Missing -B option for mounting /dev/urandom in installer filesystem

Signed-off-by: oculartechie <oculartechie@users.noreply.github.com>



> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://xcp-ng.org/docs/contributing.html#developer-certificate-of-origin-dco
