### PR TITLE
Update doc about Local ISO SR

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -492,6 +492,15 @@ a6732eb5-9129-27a7-5e4a-8784ac45df27
 
 xe sr-scan uuid=a6732eb5-9129-27a7-5e4a-8784ac45df27
 ```
+If your host are in a pool, you need to get the host uuid first:
+```
+xe host-list
+#Get the uuid of the one your are connected to
+xe sr-create name-label="ISO Repository" type=iso device-config:location=/opt/var/iso_repository device-config:legacy_mode=true content-type=iso host-uuid=uuid-previously-retrieved
+
+953fcd3b-a4d5-1092-c4eb-1782cee0ff0b
+xe sr-scan uuid=953fcd3b-a4d5-1092-c4eb-1782cee0ff0b
+```
 
 :::tip
 Don't forget to rescan your SR after adding, changing, or deleting ISO files. Rescan is done automatically every 10 minutes otherwise.


### PR DESCRIPTION
I just have come across the following use case:
2 hosts in a pool, and wanted to create a Local ISO SR
If l follow the doc, I have this error:
```
[19:33 Delirium ~]# xe sr-create name-label="ISO Repository" type=iso device-config:location=/opt/var/iso_repository device-config:legacy_mode=true content-type=iso
Error: Required parameter not found: host-uuid
```
So with xe host-list, I retrieve my host uuid:
```
[19:34 Delirium ~]# xe host-list 
uuid ( RO)                : 7b84f233-8aa3-468d-b254-fd585194da21
          name-label ( RW): Delirium
    name-description ( RW): ❤️ 🍺
```

Then I can create my SR:

```
[19:34 Delirium ~]# xe sr-create name-label="ISO Repository" type=iso device-config:location=/opt/var/iso_repository device-config:legacy_mode=true content-type=iso host-uuid=7b84f233-8aa3-468d-b254-fd585194da21 
953fcd3b-a4d5-1092-c4eb-1782cee0ff0b
```
I don't remember if a standalone XCP-ng have the same behavior (I don't think so), but I can test it if you want :)

Thank you for all your work !

Signed-off-by: Cécile Morange  <contact@ataxya.net>



> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://xcp-ng.org/docs/contributing.html#developer-certificate-of-origin-dco
