### PR TITLE
Update TLS cert for XCP-ng guide to use host-server-certificate-install command

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -514,6 +514,18 @@ Then, you have to restart xapi :
 systemctl restart xapi
 ```
 
+### Install the certificate chain (for XCP-ng v8.2+)
+
+Upload the certificates to your XCP-ng host, then use the following command to install the certificates:
+
+```
+xe host-server-certificate-install certificate=<path>/cert.pem private-key=<path>/privkey.pem certificate-chain=<path>/chain.pem
+```
+
+:::tip
+You can use [Let's Encrypt](https://letsencrypt.org/) to generate free and browser-trusted certificates. 
+:::
+
 ## Dom0 memory
 
 :::tip

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -487,44 +487,43 @@ That's it, you're good to go!  Go to your interfaces > assignments in pfSense, s
 
 ## TLS certificate for XCP-ng
 
-After installing XCP-ng, access to xapi via XCP-ng Center or XenOrchestra is protected by TLS with a [self-signed certificate](https://en.wikipedia.org/wiki/Self-signed_certificate) : this means that you have to either verify the certificate signature before allowing the connection (comparing against signature shown on the console of the server), either work on trust-on-first-use basis (i.e. assume that the first time you connect to the server, nobody is tampering with the connection).
+After installing XCP-ng, access to xapi via XCP-ng Center or XenOrchestra is protected by TLS with a [self-signed certificate](https://en.wikipedia.org/wiki/Self-signed_certificate): this means that you have to either verify the certificate signature before allowing the connection (comparing against signature shown on the console of the server), either work on trust-on-first-use basis (i.e. assume that the first time you connect to the server, nobody is tampering with the connection).
 
 If you would like to replace this certificate by a valid one, either from an internal Certificate Authority or from a public one, you'll find here some indications on how to do that.
 
-Note that if you use an non-public certificate authority and XenOrchestra, you have [additional configuration to specify on XenOrchestra side](https://xen-orchestra.com/docs/configuration.html#custom-certificate-authority)
-
-:::warning
-This indication is valid for XCP-ng up to v8.1. Version 8.2 is expected to improve deployment of new certificates, like [Citrix did for XenServer 8.2](https://docs.citrix.com/en-us/citrix-hypervisor/hosts-pools.html#install-a-tls-certificate-on-your-server).
-:::
+Note that if you use an non-public certificate authority and XenOrchestra, you have [additional configuration to specify on XenOrchestra side](https://xen-orchestra.com/docs/configuration.html#custom-certificate-authority).
 
 ### Generate certificate signing request
 
-You can use the auto-generated key to create a certificate signing request :
+You can use the auto-generated key to create a certificate signing request:
 
 ```
 openssl req -new -key /etc/xensource/xapi-ssl.pem -subj '/CN=XCP-ng hypervisor/' -out xcp-ng.csr
 ```
 
-### Install the certificate chain
+### Install the certificate chain (for XCP-ng v8.2+)
 
-The certificate, intermediate certificates (if needed), certificate authority and private key are stored in `/etc/xensource/xapi-ssl.pem`, in that order. You have to replace all lines before `-----BEGIN RSA PRIVATE KEY-----̀` with the certificate and the chain you got from your provider, using your favorite editor (`nano` is present on XCP-ng by default).
+Once you have your certificates, upload the certificates to your XCP-ng host, then use the following command to install the certificates:
+
+```
+xe host-server-certificate-install certificate=<path to certificate> private-key=<path to key> certificate-chain=<path to chain>
+```
+
+:::tip
+The `certificate-chain` parameter is optional. The private key can be deleted after certificate is installed for additional security. For additional details check Citrix [documentation](https://docs.citrix.com/en-us/citrix-hypervisor/hosts-pools.html#install-a-tls-certificate-on-your-server).
+:::
+
+Done! Visit your XCP-ng host ip using a browser and validate the certificate is correct.
+
+
+### Install the certificate chain (for XCP-ng up to v8.1)
+
+The certificate, intermediate certificates (if needed), certificate authority and private key are stored in `/etc/xensource/xapi-ssl.pem`, in that order. You have to replace all lines before `-----BEGIN RSA PRIVATE KEY----` with the certificate and the chain you got from your provider, using your favorite editor (`nano` is present on XCP-ng by default).
 
 Then, you have to restart xapi :
 ```
 systemctl restart xapi
 ```
-
-### Install the certificate chain (for XCP-ng v8.2+)
-
-Upload the certificates to your XCP-ng host, then use the following command to install the certificates:
-
-```
-xe host-server-certificate-install certificate=<path>/cert.pem private-key=<path>/privkey.pem certificate-chain=<path>/chain.pem
-```
-
-:::tip
-You can use [Let's Encrypt](https://letsencrypt.org/) to generate free and browser-trusted certificates. 
-:::
 
 ## Dom0 memory
 


### PR DESCRIPTION
For my XCP-ng host (v 8.2.1), I am using `xe host-server-certificate-install` to load certificates from Let's Encrypt.

Updating the guide here to reflect this option.

Signed-off-by: adrsham <7330099+adrsham@users.noreply.github.com>



> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://xcp-ng.org/docs/contributing.html#developer-certificate-of-origin-dco
