### PR TITLE
add missing console for UEFI example

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -234,7 +234,7 @@ If you want to make an installation in UEFI mode, you need to have a slightly di
  menuentry "XCP-ng Install (serial)" {
     multiboot2 /EFI/xcp-ng/xen.gz dom0_mem=2048M,max:2048M watchdog \
     dom0_max_vcpus=4 com1=115200,8n1 console=com1,vga
-    module2 /EFI/xcp-ng/vmlinuz console=hvc0 install
+    module2 /EFI/xcp-ng/vmlinuz console=hvc0 console=tty0 install
     module2 /EFI/xcp-ng/install.img
  }
 ```


### PR DESCRIPTION
Signed-off-by: Ewan Nisbet <93122210+enidice@users.noreply.github.com>

Based on the example provided for grub1, and experience attempting an install without this console setting, I suspect it is an omission.

I did wonder about proposing:
```
 menuentry "XCP-ng Install (serial)" {
    multiboot2 /EFI/xcp-ng/xen.gz dom0_mem=2048M,max:2048M watchdog \
    dom0_max_vcpus=4 com1=115200,8n1 com2=115200,8n1 console=com1,com2,vga
    module2 /EFI/xcp-ng/vmlinuz console=hvc0 console=tty0 console=ttyS1,115200,8n1 install
    module2 /EFI/xcp-ng/install.img
 }
```
instead, since in the case of a SOL/serial console being attached, it requires less configuration (and therefor, potentially more useful bug reports) but for now decided only to comment about it. If those com settings were accepted here, it might also make sense to make the same changes as an option to the main list at https://updates.xcp-ng.org/netinstall/8.2.1/EFI/xenserver/grub.cfg

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://xcp-ng.org/docs/contributing.html#developer-certificate-of-origin-dco
