### PR TITLE
Ease user discovery of pw-hash & eula-auto-accept

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -360,6 +360,10 @@ Here's an example:
 ```
 
 :::tip
+Supplying a password of type="hash" will suppress the EULA prompt on first boot.
+:::
+
+:::tip
 Check [the full answerfile reference](answerfile.md).
 :::
 


### PR DESCRIPTION
Signed-off-by: Ewan Nisbet <93122210+enidice@users.noreply.github.com>

I was close to creating a post in https://xcp-ng.org/forum/ before stumbling on https://github.com/xcp-ng/host-installer/issues/18#issuecomment-609724966 - I suppose it is desirable to avoid posts where possible :)

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://xcp-ng.org/docs/contributing.html#developer-certificate-of-origin-dco
