### PR TITLE
Remove gendered term from Advanced Xen section of the docs

### DIFF
--- a/docs/compute.md
+++ b/docs/compute.md
@@ -311,7 +311,7 @@ VM anti-affinity is a feature that prevents VMs with the same user tags to run o
 
 On multi-socket and MCM systems, the NUMA affinity may benefit memory-bound applications by restricting a VM to a specific NUMA node. That way, memory and cache accesses are kept local.
 
-The Xen scheduler implements two types of affinity: `soft` and `hard`. By default, it uses `soft`, a best effort algorithm which tries to achieve the memory locality. Since there's no guarantee, if the sysadmin wants to make sure that a VM will only run on a certain node, he needs to configure the hard affinity through the `VCPUs-params:mask` VM attribute.
+The Xen scheduler implements two types of affinity: `soft` and `hard`. By default, it uses `soft`, a best effort algorithm which tries to achieve the memory locality. Since there's no guarantee, if the sysadmin wants to make sure that a VM will only run on a certain node they will need to configure the hard affinity through the `VCPUs-params:mask` VM attribute.
 
 Taking a **8C/16T** dual socket as example, the topology would be:
 


### PR DESCRIPTION
Not all sysadmins would be a "he", update to use a more generic term.

Signed-off-by: Jacek <jacek@kuzemczak.co.uk>

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [X] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [X] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://xcp-ng.org/docs/contributing.html#developer-certificate-of-origin-dco
