### PR TITLE
Double quote attribute value to avoid invalid xml

### DIFF
--- a/docs/answerfile.md
+++ b/docs/answerfile.md
@@ -174,7 +174,7 @@ Create primary partitions before installation. Used by XenRT to test preservatio
 Specifies the target disks and md device for creating a software RAID 1 array. The md device can then be used in `<primary-disk>` below. Nnew in xcp-ng 7.5.0-2 and 7.6.
 
 ```xml
-  <raid device=dev>
+  <raid device="dev">
     <disk>dev1</disk>
     <disk>dev2</disk>
   </raid>


### PR DESCRIPTION
Signed-off-by: b3n <ben@tergology.com>

* [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
* [x] "My contribution complies with the Developer Certificate of Origin [2]." 

[1] https://creativecommons.org/licenses/by-sa/2.0/
[2] https://xcp-ng.org/docs/contributing.html#developer-certificate-of-origin-dco