### PR TITLE
Fix bad doc: "xe sr-introduce" must be used instead of "xe sr-attach

### DIFF
--- a/docs/storage.md
+++ b/docs/storage.md
@@ -136,7 +136,7 @@ The concept is simple: tell XCP-ng which disk or partition you want to use, and 
 As XCP-ng will handle everything for you, be aware that the device or partition will be formatted.
 
 * Don't create a SR over a device or partition that contains important data.
-* If you want to attach an existing SR to your pool, don't create a new local SR over it, else your virtual disks will be deleted. Instead, use the `xe sr-attach` command.
+* If you want to attach an existing SR to your pool, don't create a new local SR over it, else your virtual disks will be deleted. Instead, use the `sr-introduce` command. Further explanation can be found here: https://support.citrix.com/article/CTX121896/how-to-introduce-a-local-storage-repository-in-xenserver
 :::
 
 In [Xen Orchestra](management.md#xen-orchestra):


### PR DESCRIPTION
Updated xe command to add an existing SR and link to Citrix documentation. 

Signed-off-by: Trufax <github.com@ukit.cc>



> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://xcp-ng.org/docs/contributing.html#developer-certificate-of-origin-dco
