### PR TITLE
guests.md: Focal Fossa is not the last ubuntu having guest tools anymore

### DIFF
--- a/docs/guests.md
+++ b/docs/guests.md
@@ -147,8 +147,7 @@ rc-service xe-guest-utilities start
 apt install xe-guest-utilities
 ```
 
-The last known package was published for the LTS release Focal Fossa. It was dropped from more recent releases. We enjoin you to contact ubuntu packagers for them to start packaging it again. In the meantime you can install the guest tools from our guest tools ISO image, as explained below.
-
+Some older versions of Ubuntu, now EOL, may not have this package available in their repositories. Known such releases are 20.10 to 21.10. The best solution is to upgrade to a supported release. If this is really not possible, you may install the tools from the guest tools ISO.
 
 *Feel free to add other distros to the above list if they provide the tools in their repositories.*
 


### PR DESCRIPTION
Supported versions of Ubuntu have guest tools in their repositories.

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [X] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [X] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://xcp-ng.org/docs/contributing.html#developer-certificate-of-origin-dco
