### PR TITLE
fix `mirrors.md` codeblock

### DIFF
--- a/docs/mirrors.md
+++ b/docs/mirrors.md
@@ -92,7 +92,8 @@ HTTP(S) URL: https://mymirror.example.com/
 RSYNC URL: rsync://mymirror.example.com/xcp-ng/
 Workaround for Let's Encrypt certificates: applied (or "not required" if you're not using L.E.)
 Other prerequisites from https://xcp-ng.org/docs/mirrors.html checked: yes
-Main contact: John Doe <john.doe@...> ```
+Main contact: John Doe <john.doe@...>
+```
 
 "Source mirror" is the mirror you will sync from. At this stage, we suggest that the source always be `updates.xcp-ng.org` which is the main, most up to date, mirror. Rsync is restricted by default on this mirror, so we need you to provide either a hostname or an IP address access that will be allowed to sync from it (Hence the "Host or IP to authorize:..." line above). You may sync from another mirror if you prefer: [choose one close to you that updates quickly](https://mirrors.xcp-ng.org/?mirrorstats) and review your choice from time to time.
 


### PR DESCRIPTION
Good day,

This PR aims to solve a bad formatting of the Markdown on the `mirrors.md` page of the documentation.
The ' ``` ' at the end of the email format for submitting a new mirror were not processed correctly by the parser.
putting them at a new line right after solves the issue and prevents an ugly formatting of what remains.

Before PR: https://i.imgur.com/1nhBDo6.png
After PR: https://i.imgur.com/WFnDSCR.png

Thank you in advance and have a good day!

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://xcp-ng.org/docs/contributing.html#developer-certificate-of-origin-dco
