### PR TITLE
Fix(doc): missing space in command for 

### DIFF
--- a/docs/compute.md
+++ b/docs/compute.md
@@ -115,7 +115,7 @@ To remove the parameter from Xen command line:
 
 ### 5. Put this PCI device 'into' your VM
 
-`[root@xen ~]# xe vm-param-set`**`other-config:pci=0/0000:04:01.0`**`uuid=<vm uuid>`
+`[root@xen ~]# xe vm-param-set`**` other-config:pci=0/0000:04:01.0`**`uuid=<vm uuid>`
 
 > You can also pass through multiple devices. If you wanted to pass through another device at `00:19.0` just append it to the parameter.
 >


### PR DESCRIPTION

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
