### PR TITLE
Remove XOSAN from the doc

### DIFF
--- a/docs/guides/xcpng-in-a-vm.md
+++ b/docs/guides/xcpng-in-a-vm.md
@@ -108,7 +108,7 @@ Once your host's network is set up, we'll look at configuring the XCP-ng virtual
      * **LSI Logic SAS** controller is chosen to maximize at possible the compatibility and the performance. vNVMe
        controller works too, it can reduce CPU overhead and latency. **PVSCSI controller won't work**.
      * **Unlike the PVSCSI controller, the VMXNET3 controller works with XCP-ng**. It will be useful if heavy network
-       loads are planned between different XCP-ng virtual machines (XOSAN)
+       loads are planned between different XCP-ng virtual machines (XOSTOR)
 
    * Finally, install XCP-ng as usual, everything should work as expected. After installation, your XCP-ng virtual machine
      is manageable from XCP-ng Center or Xen Orchestra.

--- a/docs/project/ecosystem.md
+++ b/docs/project/ecosystem.md
@@ -67,7 +67,7 @@ More to come soon on this side!
 In order to build the best platform with multiple storage options, we are also working with companies being expert in storage solutions.
 
 :::tip
-We are integrating storage solution available directly from Xen Orchestra (XOSAN and XOSTOR). Don't forget to take a look at [XO website](https://xen-orchestra.com) to learn more!
+We are integrating storage solution available directly from Xen Orchestra (XOSTOR). Don't forget to take a look at [XO website](https://xen-orchestra.com) to learn more!
 :::
 
 ### LINBIT

--- a/docs/storage/storage.md
+++ b/docs/storage/storage.md
@@ -13,7 +13,7 @@ Storage in XCP-ng is quite a large topic. This section is dedicated to it. Keywo
 Please take into consideration, that Xen API (XAPI) via their storage module (`SMAPI`) is doing all the heavy lifting on your storage. **You don't need to format drives manually**.
 
 :::tip
-We encourage people to use file based SR (local ext, NFS, XOSAN…) because it's easier to deal with. If you want to know more, read the rest.
+We encourage people to use file based SR (local ext, NFS, XOSTOR…) because it's easier to deal with. If you want to know more, read the rest.
 :::
 
 ## 📑 Storage types
@@ -56,7 +56,7 @@ There are storage types that are officially supported, and others that are provi
     <td>X (use with caution)</td>
   </tr>
   <tr>
-    <td>XOSAN v2</td>
+    <td>XOSTOR</td>
     <td>X</td>
     <td>X</td>
     <td>Soon</td>
@@ -178,14 +178,14 @@ xe sr-create host-uuid=<host UUID> type=file content-type=user name-label="Local
 
 Avoid using it with mountpoints for remote storage: if for some reason the filesystem is not mounted when the SR is scanned for virtual disks, the `file` driver will believe that the SR is empty and drop all VDI metadata for that storage.
 
-### XOSANv2
+### XOSTOR
 
 Shared, thin-provisioned storage.
 
-XOSANv2 is an hyperconvergence solution. In short, your local storage are combined into a big shared storage.
+XOSTOR is an hyperconvergence solution. In short, your local storage are combined into a big shared storage.
 
 :::tip
-XOSANv2 is coming soon in XCP-ng. Hang on!
+XOSTOR is coming soon in XCP-ng. Hang on!
 :::
 
 ### ZFS


### PR DESCRIPTION
This PR updates the XCP-ng.org documentation to replace XOSAN instances with XOSTOR.

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
