### PR TITLE
Update guides/logs 'xensource.log' specific config

### DIFF
--- a/docs/guides/logs.md
+++ b/docs/guides/logs.md
@@ -24,6 +24,12 @@ Because a file must be rotated if a log exceeds 100 MiB, the `rsyslog` daemon is
 
 ## Specific config: `xensource.log`
 
+:::tip No longer applicable since update released in June 2024 for XCP-ng 8.2 LTS. 
+
+The `xensource.log` file is still rotated but the `config+script+cron` files mentioned bellow are deleted during this update process.
+It is now part of the normal log rotation, with its configuration moved to `/etc/logrotate.d/xapi` (and without the cron task).
+:::
+
 `xensource.log` has many particular and different configuration parameters, so another `logrotate` config is used: `/etc/xensource/xapi-logrotate.conf` in a shell script `/opt/xensource/libexec/xapi-logrotate.sh` that executes `logrotate` with this specific config.
 
 There is normally no need to run it manually, a cron task `/etc/cron.d/xapi-logrotate.cron` is present to schedule it each hour.


### PR DESCRIPTION
- Added TIP information regarding changes to specific log rotation configuration for 'xensource.log'
- Checkout upstream 'xen-api' [pull #5507](https://github.com/xapi-project/xen-api/pull/5507) / [CA-389496](https://github.com/xapi-project/xen-api/pull/5507/commits/51521bf11de3617b6e43557a9a4d9fe908920fcc)

The above changes follow investigations of an 'unexpected' missing file `/etc/cron.d/xapi-logrotate.cron` on a new install.
We concluded this is normal/expected and is (probably) related to the update released in June 2024 for XCP-ng 8.2 LTS.
The upstream code changes were merged in March 2024 for 'xen-api' version > [v24.12.0](https://github.com/xapi-project/xen-api/releases/tag/v24.12.0)

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
