### PR TITLE
Correct typo and order for restarting XOSTOR services

### DIFF
--- a/docs/management/updates.md
+++ b/docs/management/updates.md
@@ -125,8 +125,8 @@ yum update linstor-satellite linstor-controller
 
 After updating all hosts without reboot:
 ```
-systemctl restart linstor-satellites
 systemctl stop linstor-controller # "stop" is not a typo, it will auto restart the controller.
+systemctl restart linstor-satellite
 ```
 
 Then you can follow the instructions in the documentation to manually update the pool.


### PR DESCRIPTION
Signed-off-by: Dan Pollak <danpollak2@gmail.com>



> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
