### PR TITLE
Doc(XCP-ng): Fix obsolete link to NDJSON spec

### DIFF
--- a/docs/management/manage-at-scale/xo-api.md
+++ b/docs/management/manage-at-scale/xo-api.md
@@ -71,7 +71,7 @@ The following query parameters are supported:
 - `limit`: max number of objects returned
 - `fields`: if specified, instead of plain URLs, the results will be objects containing the requested fields
 - `filter`: a string that will be used to select only matching objects, see [the syntax documentation](https://xen-orchestra.com/docs/manage_infrastructure.html#live-filter-search)
-- `ndjson`: if specified, the result will be in [NDJSON format](http://ndjson.org/)
+- `ndjson`: if specified, the result will be in [NDJSON format](https://github.com/ndjson/ndjson-spec)
 
 Simple request:
 


### PR DESCRIPTION
Remove the old link to the NDJSON spec, which was deprecated and pointed to a casino/betting site -> Replace it with the [NDJSON GitHub homepage](https://github.com/ndjson/ndjson-spec).