### PR TITLE
doc(XCP-ng): Correct sidebar order for Project → Dev process category

### DIFF
--- a/docs/project/development-process/ISO-modification.md
+++ b/docs/project/development-process/ISO-modification.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 10
+---
+
 # ISO modification
 
 How to modify the installation ISO.

--- a/docs/project/development-process/build-system.md
+++ b/docs/project/development-process/build-system.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 6
+---
+
 # Build system
 
 Details on our build system.

--- a/docs/project/development-process/commit-message-conventions.md
+++ b/docs/project/development-process/commit-message-conventions.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 11
+---
+
 # Commit message conventions
 
 Our conventions on commit messages.

--- a/docs/project/development-process/development.md
+++ b/docs/project/development-process/development.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 3
+---
+
 # Development
 
 How XCP-ng is developed.

--- a/docs/project/development-process/kernel-module-policy.md
+++ b/docs/project/development-process/kernel-module-policy.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 9
+---
+
 # Kernel module policy
 
 Our policity about kernel modules.

--- a/docs/project/development-process/koji-initial-setup.md
+++ b/docs/project/development-process/koji-initial-setup.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 14
+---
+
 # Koji initial setup
 
 How to configure Koji as a user.

--- a/docs/project/development-process/local-rpm-build.md
+++ b/docs/project/development-process/local-rpm-build.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 7
+---
+
 # Local RPM build
 
 How to build RPMs locally.

--- a/docs/project/development-process/local-xapi-build.md
+++ b/docs/project/development-process/local-xapi-build.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 8
+---
+
 # Local XAPI build
 
 How to build [XAPI](https://github.com/xcp-ng/xen-api) locally.

--- a/docs/project/development-process/performance-tests.md
+++ b/docs/project/development-process/performance-tests.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 13
+---
+
 # Performance Tests
 
 Basic ways to test XCP-ng performances.

--- a/docs/project/development-process/release-process-overview.md
+++ b/docs/project/development-process/release-process-overview.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 2
+---
+
 # Release process overview
 
 How we make a release process.

--- a/docs/project/development-process/rpm-packaging.md
+++ b/docs/project/development-process/rpm-packaging.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 5
+---
+
 # RPM packaging
 
 Creating packages that can be installed on the user's system is called **packaging**.

--- a/docs/project/development-process/tags-maintenance-branches-in-our-code.md
+++ b/docs/project/development-process/tags-maintenance-branches-in-our-code.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 4
+---
+
 # Tags, maintenance branches in our code repositories
 
 The way we use tags and branches.

--- a/docs/project/development-process/tests.md
+++ b/docs/project/development-process/tests.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 12
+---
+
 # Tests
 
 How and what to test in XCP-ng.

--- a/docs/project/development-process/what-xcp-ng-is-made-of.md
+++ b/docs/project/development-process/what-xcp-ng-is-made-of.md
@@ -1,3 +1,7 @@
+---
+sidebar_position: 1
+---
+
 # What XCP-ng is made of
 
 What's inside XCP-ng?


### PR DESCRIPTION
**Note:** This PR does the same as [this old PR](https://github.com/xcp-ng/xcp-ng-org/pull/309) but cleaner, following [this recommendation](https://github.com/xcp-ng/xcp-ng-org/pull/309#issuecomment-2592097783).

After migrating the XCP-ng documentation to Docusaurus, some sidebar links went out of order, especially the **Project** directory. The sidebar was generated automatically by Docusaurus without consideration to the recommended order, so now we have forced the correct order using the [`sidebar_position` metadata](https://docusaurus.io/docs/next/api/plugins/@docusaurus/plugin-content-docs#sidebar_position) for Markdown files.

The desired order for the Project → Development process category is as follows:

1. What XCP-ng is made of
2. Release process overview
3. Development
4.  Tags, maintenance branches in our code repositories
5. RPM packaging
6. Build system
7. Local RPM build
8. Local XAPI build
9. Kernel module policy
10. ISO modification
11. Commit message conventions
12. Tests
13. Performance tests
14. Koji initial setup
