### PR TITLE
Update koji config in koji-initial-setup.md

### DIFF
--- a/docs/project/development-process/koji-initial-setup.md
+++ b/docs/project/development-process/koji-initial-setup.md
@@ -52,6 +52,9 @@ cert = ~/.koji/client.crt
 
 ;certificate of the CA that issued the HTTP server certificate
 serverca = ~/.koji/serverca.crt
+
+; select authentication type
+authtype = ssl
 ```
 
 In some cases, we've found that the `cert` directive in `~/.koji/config ` was not used if there was no such directive in `/etc/koji.conf`. Workaround: add a `cert = ~/.koji/client.crt` to `/etc/koji.conf`, or possibly even `cp ~/.koji/config /etc/koji.conf`.


### PR DESCRIPTION
On a Fedora installation, `/etc/koji.conf` has `authtype = kerberos` by default. To make it possible to connect to our koji server without changing the system config add `authtype` in the user's config.

Without it, we just have a mystic error:
```
2025-02-20 13:17:02,921 [ERROR] koji: (gssapi auth failed: requests.exceptions.SSLError: HTTPSConnectionPool(host='kojihub.xcp-ng.org', port=443): Max retries exceeded with url: /ssllogin (Caused by SSLError(SSLError(1, '[SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] ssl/tls alert handshake failure (_ssl.c:2648)'))))
Use following documentation to debug kerberos/gssapi auth issues. https://docs.pagure.org/koji/kerberos_gssapi_debug/
2025-02-20 13:17:02,922 [ERROR] koji: GSSAPIAuthError: unable to obtain a session (gssapi auth failed: requests.exceptions.SSLError: HTTPSConnectionPool(host='kojihub.xcp-ng.org', port=443): Max retries exceeded with url: /ssllogin (Caused by SSLError(SSLError(1, '[SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] ssl/tls alert handshake failure (_ssl.c:2648)'))))
Use following documentation to debug kerberos/gssapi auth issues. https://docs.pagure.org/koji/kerberos_gssapi_debug/
```