### PR TITLE
Remove OpenStack cloud feat reference

### DIFF
--- a/docs/management/cloud.md
+++ b/docs/management/cloud.md
@@ -53,11 +53,3 @@ Apache CloudStack is open source software designed to deploy and manage large ne
 **XCP-ng is a certified and compatible platform for CloudStack.**
 
 See the [dedicated documentation](https://docs.cloudstack.apache.org/en/4.17.2.0/installguide/hypervisor/xenserver.html?highlight=xcp-ng) on how to install CloudStack on top of XCP-ng.
-
-## 📚 OpenStack
-
-:::warning
-Unlike Cloudstack, we do not know the level of compatibility with OpenStack. Take time to ask OpenStack community about their support for XAPI-based hosts
-:::
-
-Documentation can be found [on this page](https://wiki.openstack.org/wiki/XenServer/XenAndXenServer).


### PR DESCRIPTION
Remove OpenStack reference on Cloud features page as OpenStack nova compute no longer supports the xen hypervisor.



> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
