### PR TITLE
Rune to run `koji` in a container

### DIFF
--- a/docs/project/development-process/koji-initial-setup.md
+++ b/docs/project/development-process/koji-initial-setup.md
@@ -62,6 +62,30 @@ In some cases, we've found that the `cert` directive in `~/.koji/config ` was no
 ## Test your connection
 `koji moshimoshi`. If it greats you (in any language), then your connection to the server works.
 
+## Koji in Docker container
+
+When your Linux distribution doesn't have a useable `koji`, you can always run it in a container.
+
+Prepare an image:
+```
+docker build -t koji:latest - <<EOF
+FROM fedora:41
+RUN dnf install -qy koji
+EOF
+```
+
+Then, to run koji with it, which will use the `~/.koji` directory that you've prepared outside the container:
+```
+docker run -it --rm -v$HOME/.koji:/root/.koji:ro koji:latest koji moshimoshi
+```
+
+### Alternative as a one-liner
+
+This command does the same as above, but relies on docker caching the result of a `docker build`:
+```
+docker run -it --rm -v$HOME/.koji:/root/.koji:ro $(docker build -q - <<<$'FROM fedora:41\nRUN dnf install -qy koji') koji moshimoshi
+```
+
 ## Useful commands
 
 Just a quick list. Make sure to have read and understood our [development process tour](../../../category/development-process).


### PR DESCRIPTION
Adding runes to explain how one can run `koji` in a container. The feature to read a dockerfile from stdin is somewhat recent, but hopefully old enough for most people. The one-liner is just to be able to always run `koji`, without needed to prepare a container image before.

These runes don't allow to load a specfile or other from the current directory.

