### PR TITLE
doc(XCP-ng): Mention RPU compatibility with XOSTOR

### DIFF
--- a/docs/management/updates.md
+++ b/docs/management/updates.md
@@ -154,6 +154,30 @@ Also known as RPU, **this is the advised way to update your pool**. By just clic
 This powerful and fully automated mechanism requires some prerequisites: all your VMs disks must be on a one (or more) shared storage. Also, high-availability will be automatically disabled, as the XO load balancer plugin and backup jobs. Everything will be enabled back when it's done!
 :::
 
+**XCP-ng 8.3**
+
+Starting with XCP-ng 8.3, Rolling Pool Updates (RPUs) now handle pools that utilize XOSTOR. If there is no LINSTOR Storage Repository (SR), the RPU proceeds as usual. However, if a LINSTOR SR is present, the update process includes additional steps to ensure compatibility before performing the standard rolling update.
+
+**XCP-ng 8.2**
+
+:::warning
+
+On XCP-ng 8.2, RPU is disabled for pools with XOSTOR SRs. The reason is that after a reboot of a just updated host, it's possible that it can no longer communicate with other hosts through LINSTOR satellites. In fact LINSTOR expects that we always use satellites and controllers with the same version.
+
+To avoid problems, it is strongly recommended to update the satellites, controllers packages of each host without rebooting:
+```
+yum update linstor-satellite linstor-controller
+```
+
+After updating all hosts without reboot:
+```
+systemctl stop linstor-controller # "stop" is not a typo, it will auto restart the controller.
+systemctl restart linstor-satellite
+```
+
+Then you can follow the instructions in the documentation to manually update the pool.
+:::
+
 ![](../../assets/img/rpu1.png)
 
 #### Pool updates

--- a/docs/management/updates.md
+++ b/docs/management/updates.md
@@ -154,17 +154,15 @@ Also known as RPU, **this is the advised way to update your pool**. By just clic
 This powerful and fully automated mechanism requires some prerequisites: all your VMs disks must be on a one (or more) shared storage. Also, high-availability will be automatically disabled, as the XO load balancer plugin and backup jobs. Everything will be enabled back when it's done!
 :::
 
-**XCP-ng 8.3**
+##### XOSTOR support
 
-Starting with XCP-ng 8.3, Rolling Pool Updates (RPUs) now handle pools that utilize XOSTOR. If there is no LINSTOR Storage Repository (SR), the RPU proceeds as usual. However, if a LINSTOR SR is present, the update process includes additional steps to ensure compatibility before performing the standard rolling update.
-
-**XCP-ng 8.2**
+Rolling Pool Updates (RPUs) can now handle pools that utilize XOSTOR. If there is no LINSTOR Storage Repository (SR), the RPU proceeds as usual. However, if a LINSTOR SR is present, and the prerequisites below are met, the update process includes additional steps to ensure compatibility before performing the standard rolling update.
 
 :::warning
 
 **Prerequisites**
 
-On XCP-ng 8.2, Rolling Pool Updates (RPUs) can handle pools that utilize XOSTOR if the following conditions are met:
+Rolling Pool Updates (RPUs) can handle pools that utilize XOSTOR, if:
 
 - your host uses `xcp-ng-xapi-plugins-1.12.0` or a later version.\
     To verify your XAPI plugins version, run `rpm -q xcp-ng-xapi-plugins` on your host.

--- a/docs/management/updates.md
+++ b/docs/management/updates.md
@@ -162,7 +162,16 @@ Starting with XCP-ng 8.3, Rolling Pool Updates (RPUs) now handle pools that util
 
 :::warning
 
-On XCP-ng 8.2, RPU is disabled for pools with XOSTOR SRs. The reason is that after a reboot of a just updated host, it's possible that it can no longer communicate with other hosts through LINSTOR satellites. In fact LINSTOR expects that we always use satellites and controllers with the same version.
+**Prerequisites**
+
+On XCP-ng 8.2, Rolling Pool Updates (RPUs) can handle pools that utilize XOSTOR if the following conditions are met:
+
+- your host uses `xcp-ng-xapi-plugins-1.12.0` or a later version
+- XO is on version 5.105 or later
+
+**What about older versions?**
+
+What happens with older versions of the XAPI plugins is that, after rebooting a recently updated host, it might no longer be able to communicate with other hosts through LINSTOR satellites. In fact, LINSTOR expects that we always use satellites and controllers with the same version.
 
 To avoid problems, it is strongly recommended to update the satellites, controllers packages of each host without rebooting:
 ```

--- a/docs/management/updates.md
+++ b/docs/management/updates.md
@@ -166,7 +166,8 @@ Starting with XCP-ng 8.3, Rolling Pool Updates (RPUs) now handle pools that util
 
 On XCP-ng 8.2, Rolling Pool Updates (RPUs) can handle pools that utilize XOSTOR if the following conditions are met:
 
-- your host uses `xcp-ng-xapi-plugins-1.12.0` or a later version
+- your host uses `xcp-ng-xapi-plugins-1.12.0` or a later version.\
+    To verify your XAPI plugins version, run `rpm -q xcp-ng-xapi-plugins` on your host.
 - XO is on version 5.105 or later
 
 **What about older versions?**


### PR DESCRIPTION
Since the Xen Orchestra 5.105 release (march 2025), rolling pool updates (RPU) support XOSTOR. 
[The XCP-ng documentation](https://docs.xcp-ng.org/management/updates/#from-xen-orchestra) (**Management and Backup → Updates**) is updated accordingly, to reflect the announcement in the [XO 5.105 release blog post](https://xen-orchestra.com/blog/xen-orchestra-5-105/).