### PR TITLE
doc(XCP-ng): Correct wrong GitHub link in footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -137,7 +137,7 @@ const config = {
               },
               {
                 label: 'GitHub',
-                href: 'https://github.com/facebook/docusaurus',
+                href: 'https://github.com/xcp-ng/xcp-ng-org',
               },
             ],
           },


### PR DESCRIPTION
In the XCP-ng documentation, the GitHub link in the footer was the default one used by the Docusaurus template.

This PR changes the link so that it points to the XCP-ng GitHub repository instead.