### PR TITLE
doc(contributing):  add Translations section

### DIFF
--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -16,7 +16,7 @@ We are happy about every helping hand!
 
 ## 🌍 Translations
 
-[Help us translate built-in web interface (XO-lite) in more languages!](http://translate.vates.tech/engage/xen-orchestra/)
+[Help us translate the built-in web interface (XO Lite) in more languages!](http://translate.vates.tech/engage/xen-orchestra/)
 
 ## ✍️ Write documentation
 

--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -1,7 +1,7 @@
 # Contributing
 
 How to contribute to XCP-ng? There are many ways of contributing:
-* by giving some of your time to work on the project. Code isn't the only way! Community support, documentation, testing…
+* by giving some of your time to work on the project. Code isn't the only way! Community support, translation, documentation, testing…
 * with money, by subscribing to [Pro Support](https://vates.tech), which funds further developments.
 
 ## 💁 Help others
@@ -13,6 +13,10 @@ You don't have to be a programmer/IT-nerd to help at this project. Just ask or o
 * Discord: [https://discord.gg/aNCR3yPaPn](https://discord.gg/aNCR3yPaPn)
 
 We are happy about every helping hand!
+
+## 🌍 Translations
+
+[Help us translate built-in web interface (XO-lite) in more languages!](http://translate.vates.tech/engage/xen-orchestra/)
 
 ## ✍️ Write documentation
 


### PR DESCRIPTION
Hello,
as XO-lite (and thus Web-core) is part of default install of hypervizor, would it be possible to add link how to translate it here please? (the same case as in https://github.com/vatesfr/xen-orchestra/pull/8531)

Thanks :-)



> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
 * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
 * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
