### PR TITLE
Fixed a repeated sentence in the XOSTOR CLI update doc

### DIFF
--- a/docs/management/updates.md
+++ b/docs/management/updates.md
@@ -109,7 +109,7 @@ Check prerequisites and precautions above.
 #### 2. Additional steps regarding XOSTOR SRs
 
 LINSTOR expects that we always use satellites and controllers with the same version.
-Without precautions and after a reboot of a just updated host, it's possible that a machine can no longer communicate with other hosts through LINSTOR satellites. In fact LINSTOR expects that we always use satellites and controllers with the same version.
+Without precautions and after a reboot of a just updated host, it's possible that a machine can no longer communicate with other hosts through LINSTOR satellites.
 
 To avoid problems, it is strongly recommended to update all satellites, controllers packages of each host without rebooting:
 ```


### PR DESCRIPTION

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
