### PR TITLE
Fix Windows boot recovery instructions

### DIFF
--- a/docs/troubleshooting/windows-pv-tools.md
+++ b/docs/troubleshooting/windows-pv-tools.md
@@ -136,8 +136,8 @@ This is often caused by the Windows boot loader failing to find the Windows part
 From the recovery menu, open Command Prompt, then use `diskpart` to assign drive letters to the EFI system partition:
 
 ```
-list vol
-sel vol N  # N = number of volume with info = "System"
+list volume
+select volume N  # N = number of volume with info = "System"
 assign letter=S
 exit
 ```
@@ -145,8 +145,8 @@ exit
 After exiting Diskpart, use the following commands:
 
 ```bat
-bcdedit /store S:\EFI\Microsoft\Boot /set {default} device=partition=C:
-bcdedit /store S:\EFI\Microsoft\Boot /set {default} osdevice=partition=C:
+bcdedit /store S:\EFI\Microsoft\Boot\BCD /set {default} device=partition=C:
+bcdedit /store S:\EFI\Microsoft\Boot\BCD /set {default} osdevice=partition=C:
 ```
 
 After exiting to Windows, your system should boot successfully.


### PR DESCRIPTION
The BCD path was not correctly specified.

Also write the full Diskpart command instead of abbreviating.

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
