### PR TITLE
fix(XCP-ng): Darkmode scheme for multipathing guideline

### DIFF
--- a/docs/storage/multipathing.md
+++ b/docs/storage/multipathing.md
@@ -46,7 +46,7 @@ This could have an impact on expected performance.
 ```mermaid
 ---
 config:
-  look: handDrawn
+  look: normal
   theme: default
 ---
 flowchart LR
@@ -203,7 +203,7 @@ Make sure not to mix Fibre Channel speeds.
 ```mermaid
 ---
 config:
-  look: handDrawn
+  look: normal
   theme: default
 ---
 flowchart LR


### PR DESCRIPTION
Fix the darkmode scheme for multipathing guideline

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
