### PR TITLE
Doc: Fix broken links and anchors

### DIFF
--- a/docs/installation/migrate-to-xcp-ng.md
+++ b/docs/installation/migrate-to-xcp-ng.md
@@ -160,7 +160,7 @@ If you were not using the `latest` channel previously:
 
 :::tip
 - **Backup method:** The migration will use the default backup migration. Check if the XOA VM can access it.
-- **Task timeout:** Note that XAPI tasks are limited to 24 hours by default. To increase that limitation, refer to the **24h task timeout** section of [this page](/management/manage-locally/api#_24h-task-timeout).
+- **Task timeout:** Note that XAPI tasks are limited to 24 hours by default. To increase that limitation, refer to the **24h task timeout** section of [this page](/management/manage-locally/api#24h-task-timeout).
 :::
 
 From this point onward, the process varies depending on the type of datastore you're using.

--- a/docs/releases/release-8-2.md
+++ b/docs/releases/release-8-2.md
@@ -153,7 +153,7 @@ There exists no easy way to convert an existing storage repository from a given 
 
 Plans are laid out for simpler installation and maintenance of Windows guest tools. Unfortunately, we haven't found people yet to implement them so the current state remains that of 8.1. ***If you're a developer on the Windows platforms, we're hiring! (full time or part time, contracts or hires) - Contact us.***
 
-Using the Windows guest tools is [documented here](../../../vms#windows).
+Using the Windows guest tools is [documented here](/vms#windows-guest-tools).
 
 ## Update: what's new in XCP-ng 8.2.1
 

--- a/docs/vms/vms.md
+++ b/docs/vms/vms.md
@@ -161,7 +161,7 @@ xe vm-param-get param-name=has-vendor-device uuid={VM-UUID}
 ###### Install the XCP-ng drivers
 0. Snapshot your VM before installing (just in case)
 1. Check the above prerequisite about the "Manage Citrix PV drivers via Windows Update" option
-2. [Verify that no other guest tools are currently installed](#how-to-know-if-tools-are-already-installed-and-working). Our installer will block installation when other Xen tools are already present anyway. Use [XenClean](#Fully-removing-Xen-PV-drivers-with-XenClean) to remove any tools present. Do not uninstall the drivers in any other way: it may lead to BSOD at reboot (at least when uninstalling XCP-ng 8.2.2 tools)
+2. [Verify that no other guest tools are currently installed](#how-to-know-if-tools-are-already-installed-and-working). Our installer will block installation when other Xen tools are already present anyway. Use [XenClean](#fully-removing-xen-pv-drivers-with-xenclean) to remove any tools present. Do not uninstall the drivers in any other way: it may lead to BSOD at reboot (at least when uninstalling XCP-ng 8.2.2 tools)
 3. Unpack the ZIP file
 4. Start the installation MSI
 5. Follow the install wizard
@@ -506,8 +506,6 @@ The likeliness for the installation to work correctly will depend on how much th
 ##### Other Linux distributions
 
 For the remaining Linux distributions, mount the guest tools ISO as described above, then look for the `xe-guest-utilities_*_all.tgz` archive. Copy its contents on the system in `/etc` and `/usr`. It contains a System V init script by default but there's also a systemd unit file available on the ISO (`xe-linux-distribution.service`).
-
-See also [Contributing](#contributing) below.
 
 ##### Specific cases
 

--- a/docs/xostor/xostor.md
+++ b/docs/xostor/xostor.md
@@ -364,7 +364,7 @@ linstor controller set-property DrbdOptions/AutoEvictAllowEviction False
 For each host of the pool (starting with the master), follow the instructions given in [this guide](../installation/upgrade/#-upgrade-via-installation-iso-recommended).
 
 :::warning
-If you have this error during upgrade, you must download the right ISO version as documented in [this section](#2-download-xcp-ng-iso-with-linstor-support):
+If you have this error during upgrade, you must download the right ISO version as documented in [this section](#2-xcp-ng-iso-with-linstor-support):
 ```
 Cannot upgrade host with LINSTOR using a package source that does not have LINSTOR.  Please use as package source the repository on the dedicated ISO.
 ```


### PR DESCRIPTION
The XCP-ng technical documentation contained broken internal links and anchors, which caused warnings during Docusaurus builds and could prevent readers from finding the information they were looking for.

This PR updates the incorrect links with the correct target URLs

![Capture d'écran 2025-06-25 080342](https://github.com/user-attachments/assets/58ef7810-561d-4a48-84d7-876bbbfaf8f0)
