### PR TITLE
Fix LINSTOR satellite LS_KEEP_RES regex

### DIFF
--- a/docs/xostor/xostor.md
+++ b/docs/xostor/xostor.md
@@ -268,7 +268,7 @@ It is configured using:
 ```
 > cat /etc/systemd/system/linstor-satellite.service.d/override.conf
 [Service]
-Environment=LS_KEEP_RES=^xcp-persistent*
+Environment=LS_KEEP_RES=^xcp-persistent.*
 
 [Unit]
 After=drbd.service


### PR DESCRIPTION
The regex is not correct, see: https://github.com/xcp-ng/sm/pull/90

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
