### PR TITLE
doc(XCP-ng): update Guest Utilities install in OPNsense via WebUI

### DIFF
--- a/docs/guides/pfsense.md
+++ b/docs/guides/pfsense.md
@@ -26,8 +26,8 @@ service xenguest start
 
 Option 2 is via the Web GUI (only available on OPNsense):
 Open the web UI on `http(s)://your-configured-ip` and go to:
-*System -> Firmware -> Plugins*
-Scroll down to **os-xen** and click the plus sign next to it to install them.  
+*System -> Firmware -> Plugins*, 
+above the list header (in center) tick **Show (Tier 3) community plugins** (otherwise it will not be shown even via search box), scroll down to / search **os-xen** and click the plus sign next to it to install them.  
 Next: Reboot the system to have the guest tools started (installer doesn't do this the first time):
 *Power -> Reboot*
 


### PR DESCRIPTION
Hello,

now there is extra step (ticking show community maintained plugins box) needed to show os-xen plugin in list (at least since recent OPNsense v25.7.x) - see these screenshots please:

Without it, it is not even searchable:
<img width="1672" height="410" alt="image" src="https://github.com/user-attachments/assets/d2b1a501-1c97-4a6b-8138-ba89907d32c7" />

With mentioned option ticked:
<img width="1672" height="410" alt="image" src="https://github.com/user-attachments/assets/89d9b1e3-65fc-4fc4-ac59-3bf6057e4f13" />

Hope it will save others some confusion and definitely feel free to reformulate to fit into overall documentation style. 

Thanks :-)

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
