### PR TITLE
fix(docs): increase xostor limit to 31 nodes

### DIFF
--- a/docs/xostor/xostor.md
+++ b/docs/xostor/xostor.md
@@ -316,7 +316,7 @@ RemainAfterExit=true
 :::
 
 :::important
-The maximum number of machines per pool is 7.
+The maximum number of machines per pool is 31.
 :::
 
 ## Update


### PR DESCRIPTION
Since https://xcp-ng.org/blog/2023/02/15/xostor/

It was announced the limit is now 31 hosts and not 7.



> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
