### PR TITLE
doc(XCP-NG): place SR on ZFS dataset instead of pool itself

### DIFF
--- a/docs/storage/storage.md
+++ b/docs/storage/storage.md
@@ -228,10 +228,14 @@ Due to the variety of parameters of ZFS, the SR driver does not automate everyth
 zpool create -o ashift=12 -m /mnt/zfs tank /dev/sda4
 ```
 
+```
+ zfs create tank/zfssr
+```
+
 Now you can create the SR on top of it:
 
 ```
-xe sr-create host-uuid=<HOST_UUID> type=zfs content-type=user name-label=LocalZFS device-config:location=/mnt/zfs/
+xe sr-create host-uuid=<HOST_UUID> type=zfs content-type=user name-label=LocalZFS device-config:location=/mnt/zfs/zfssr
 ```
 
 :::tip


### PR DESCRIPTION
Hello,
Storage Repository should be placed on ZFS dataset, not ZFS pool itself.
- if no dataset present, zfs kernel module will be not loaded automatically - see this [comment](https://github.com/xcp-ng/xcp/issues/192#issuecomment-501192530)
- summary - see this [comment](https://forum.level1techs.com/t/xcp-ng-and-zfs-needs-modprobe-and-remount-pool-every-boot/185690/3)
- it is even consistent with section "Better performance (advanced options)" below this part

Hope it will save others some confusion :-)

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
