### PR TITLE
fix disable-webserver value-type

### DIFF
--- a/docs/management/manage-locally/xo-lite.md
+++ b/docs/management/manage-locally/xo-lite.md
@@ -37,7 +37,7 @@ First, let's emphasize that XO Lite is merely an XAPI client. While it is made r
 However, you might still want to prevent XCP-ng from offering XO Lite altogether. To do so, simply add the following line to a new file in `/etc/xapi.conf.d/`:
 
 ```
-disable-webserver=1
+disable-webserver=true
 ```
 
 Here's a one-liner to do that:


### PR DESCRIPTION
The value-type of the key "disable-webserver" must be a boolean



> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [ x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x ] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
