### PR TITLE
doc: update dead link to xenserver doc

### DIFF
--- a/docs/storage/storage.md
+++ b/docs/storage/storage.md
@@ -146,7 +146,7 @@ The concept is simple: tell XCP-ng which disk or partition you want to use, and 
 As XCP-ng will handle everything for you, be aware that the device or partition will be formatted.
 
 * Don't create a SR over a device or partition that contains important data.
-* If you want to attach an existing SR to your pool, don't create a new local SR over it, else your virtual disks will be deleted. Instead, use the `xe sr-introduce` command. Further explanation can be found in the official XenServer documentation: https://support.citrix.com/article/CTX121896/how-to-introduce-a-local-storage-repository-in-xenserver
+* If you want to attach an existing SR to your pool, don't create a new local SR over it, else your virtual disks will be deleted. Instead, use the `xe sr-introduce` command. Further explanation can be found in the official XenServer documentation: https://support.citrix.com/external/article?articleUrl=CTX121896-how-to-introduce-a-local-storage-repository-in-xenserver
 :::
 
 In [Xen Orchestra](../management#%EF%B8%8F-manage-at-scale):


### PR DESCRIPTION
The XenServer documentation explaining how to introduce a local storage repository was moved some time ago. 

This PR updates the [Storage](https://docs.xcp-ng.org/storage/) section of the XCP-ng documentation, so that the link to that XenServer document points to the [new location](https://support.citrix.com/external/article?articleUrl=CTX121896-how-to-introduce-a-local-storage-repository-in-xenserver), addressing issue https://github.com/xcp-ng/xcp-ng-org/issues/376.