### PR TITLE
Update release-8-3.md

### DIFF
--- a/docs/releases/release-8-3.md
+++ b/docs/releases/release-8-3.md
@@ -231,6 +231,11 @@ To close port 80, run the following command:
 xe pool-param-set uuid=<pool-uuid> https-only=true
 ```
 
+If the pool wide settings don't close port 80, you may need to run the below command on each host to restrict the use of HTTP
+```
+xe host-param-set https-only=true uuid=<uuid of the host>
+```
+
 ### Improvements in the installer
 
 Two years ago, development around XenServer's (and XCP-ng's) installer [was opened](https://github.com/xenserver/host-installer), allowing us to introduce several improvements and fixes (while previously we could modify the installer, contributing upstream reduces the long-term maintenance burden of divergence between our version and theirs).


### PR DESCRIPTION
Outlines the steps required to close port 80 on a per host basis if the pool wide option doesn't address the issue.



> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [ x ] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [ x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
