### PR TITLE
Update documentation for 8.2 End Of Life

### DIFF
--- a/docs/compute.md
+++ b/docs/compute.md
@@ -26,6 +26,8 @@ Internal error: xenopsd internal error: Device.PCI.Cannot_add(_, _)
 
 :::warning
 You may not be able to passthrough USB controllers on XCP-ng 8.2
+
+Note: XCP-ng 8.2 is EOL. This 8.2-specific information is retained solely to assist with the transition from 8.2 to a supported release.
 :::
 
 When attempting to enable PCI passthrough on USB controllers on XCP-ng 8.2, you may see an error when starting the VM in your logs similar to
@@ -77,7 +79,19 @@ Run `xe pci-list`.
 
 To hide the device from dom0:
 
+##### XCP-ng 8.3
+
+Run the following XAPI command:
+
+```
+xe pci-disable-dom0-access uuid=<pci uuid>
+```
+
 ##### XCP-ng 8.2
+
+:::note
+XCP-ng 8.2 is EOL. This 8.2-specific information is retained solely to assist with the transition from 8.2 to a supported release.
+:::
 
 Add the **`xen-pciback.hide`** parameter to the kernel boot parameters:
 ```bash
@@ -87,20 +101,9 @@ Add the **`xen-pciback.hide`** parameter to the kernel boot parameters:
 >
 > `/opt/xensource/libexec/xen-cmdline --set-dom0 "xen-pciback.hide=(0000:04:01.0)(0000:00:19.0)"`
 
-##### XCP-ng 8.3
-
-Run the following XAPI command:
-
-```
-xe pci-disable-dom0-access uuid=<pci uuid>
-```
-
 #### Enabling the device
 
 To unhide the device from dom0:
-
-##### XCP-ng 8.2
-`/opt/xensource/libexec/xen-cmdline --delete-dom0 xen-pciback.hide`
 
 ##### XCP-ng 8.3
 
@@ -111,6 +114,14 @@ Run the following XAPI command:
 :::warning
 This kernel parameter is not retained when you upgrade an XCP-ng host [using the installation ISO](../installation/upgrade#-upgrade-via-installation-iso-recommended). Remember to re-do this step after the upgrade.
 :::
+
+##### XCP-ng 8.2
+
+:::note
+XCP-ng 8.2 is EOL. This 8.2-specific information is retained solely to assist with the transition from 8.2 to a supported release.
+:::
+
+`/opt/xensource/libexec/xen-cmdline --delete-dom0 xen-pciback.hide`
 
 
 :::tip

--- a/docs/guides/TLS-certificates-xcpng.md
+++ b/docs/guides/TLS-certificates-xcpng.md
@@ -33,6 +33,10 @@ Done! Visit your XCP-ng host ip using a browser and validate the certificate is 
 
 ## Install the certificate chain (for XCP-ng up to v8.1)
 
+:::note
+This information about deprecated releases is retained solely to assist with the transition to a supported release.
+:::
+
 The certificate, intermediate certificates (if needed), certificate authority and private key are stored in `/etc/xensource/xapi-ssl.pem`, in that order. You have to replace all lines before `-----BEGIN RSA PRIVATE KEY----` with the certificate and the chain you got from your provider, using your favorite editor (`nano` is present on XCP-ng by default).
 
 Then, you have to restart xapi :

--- a/docs/installation/hardware.md
+++ b/docs/installation/hardware.md
@@ -75,8 +75,6 @@ There are several USB 5Gbps NICs based on this chipset available on the market. 
 
 The kernel module is just a repackage for XCP-ng of [the AQC111U drivers available for Linux Kernel 3.10 on the Marvell website](https://www.marvell.com/support/downloads.html).
 
-The kernel module has been tested in a homelab environment with XCP-ng version `8.2`.
-
 To install the driver follow the instructions provided in the [**Alternate drivers** section below](#-alternate-drivers) and use `aqc111u-module` as `package-name` _(`module-name` would be `aqc111u`)_.
 
 Known compatible NICs are [^1]:

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -64,6 +64,10 @@ Similarly, installing XCP-ng on SD cards is highly discouraged. A basic SSD offe
 
 XCP-ng 8.2 requires an IPv4 network for management and storage traffic. Starting from XCP-ng 8.3, the management network supports IPv6.
 
+:::note
+XCP-ng 8.2 is EOL. This 8.2-specific information is retained solely to assist with the transition from 8.2 to a supported release.
+:::
+
 :::info
 Set the server's BIOS clock to the current UTC time. For debugging support cases, serial console access may be required. Consider configuring serial console access for XCP-ng. For systems without physical serial ports, explore embedded management devices like Dell DRAC or HP iLO. See [CTX228930 - How to Configure Serial Console Access on XenServer 7.0 and later](https://support.citrix.com/article/CTX228930).
 :::
@@ -88,13 +92,17 @@ In XCP-ng 8.3, Xen theoretically supports up to 12 TiB with security support, an
 The maximum number of supported logical processors may vary depending on the CPU. For more information, see the [Hardware Compatibility List (HCL)](../../installation/hardware).
 :::
 
+#### XCP-ng 8.3 LTS
+
+:::note
+XCP-ng 8.2 is EOL. This 8.2-specific information is retained solely to assist with the transition from 8.2 to a supported release.
+:::
+
+- Up to 960 logical processors, depending on CPU support (theoretical, untested: 1024).
+
 #### XCP-ng 8.2 LTS
 
 - Up to 448 logical processors (theoretical, untested: 512).
-
-#### XCP-ng 8.3 LTS
-
-- Up to 960 logical processors, depending on CPU support (theoretical, untested: 1024).
 
 ### Virtual Network Interface Cards (vNICs)
 
@@ -110,12 +118,6 @@ Below are the supported limits for virtual machines on XCP-ng.
 
 ### CPU
 
-#### XCP-ng 8.2 LTS
-
-- **Virtual CPUs (vCPUs) per VM**: Up to **32 vCPUs**.
-
-Ensure that your guest OS supports this configuration.
-
 #### XCP-ng 8.3 LTS
 
 - **Virtual CPUs (vCPUs) per VM**:
@@ -124,15 +126,21 @@ Ensure that your guest OS supports this configuration.
 
 Guest OS support is also an important factor to consider.
 
+#### XCP-ng 8.2 LTS
+
+:::note
+XCP-ng 8.2 is EOL. This 8.2-specific information is retained solely to assist with the transition from 8.2 to a supported release.
+:::
+
+- **Virtual CPUs (vCPUs) per VM**: Up to **32 vCPUs**.
+
+Ensure that your guest OS supports this configuration.
+
 ### GPU
 
 - **Virtual GPUs per VM**: Up to **8**.
 
 ### Memory
-
-#### XCP-ng 8.2 LTS
-
-- **Maximum RAM per VM**: **1.5 TiB**.
 
 #### XCP-ng 8.3 LTS
 
@@ -142,6 +150,14 @@ Guest OS support is also an important factor to consider.
   - Theoretical limit without security support: **16 TiB** (minus the RAM allocated to Xen and the controller domain).
 
 Keep in mind that the actual usable memory depends on the guest OS limits. In some cases, going beyond what the OS can manage efficiently may lead to performance drops.
+
+#### XCP-ng 8.2 LTS
+
+:::note
+XCP-ng 8.2 is EOL. This 8.2-specific information is retained solely to assist with the transition from 8.2 to a supported release.
+:::
+
+- **Maximum RAM per VM**: **1.5 TiB**.
 
 ### Storage
 

--- a/docs/installation/upgrade.md
+++ b/docs/installation/upgrade.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 Discover how to upgrade from an older release.
 
-We assume your goal is to get to the latest version of XCP-ng from a previous release, e.g. 8.0 to 8.2.1 or 8.2.1 to 8.3.
+We assume your goal is to get to a newer version of XCP-ng from a previous release, e.g. 8.0 to 8.2.1 or 8.2.1 to 8.3.
 
 For updates that don't change the version numbers (bugfixes, security fixes), see [the updates section](../../management/updates).
 
@@ -103,6 +103,10 @@ A.k.a. yum-style upgrade.
 
 :::warning
 This upgrade procedure is **not** supported to upgrade to XCP-ng 8.3.
+:::
+
+:::note
+This information about EOL releases is retained solely to assist with the transition to a supported release, for example an upgrade to 8.2.1 (now EOL) as an intermediary step towards release 8.3.
 :::
 
 Though it's been successfully tested by numerous people, this method is still considered *riskier* than using the installation ISO:

--- a/docs/management/additional-packages.md
+++ b/docs/management/additional-packages.md
@@ -11,7 +11,6 @@ It may be useful to add more packages to it, with precaution. The XCP-ng project
 :::note
 Best effort support is provided for additional packages provided by the XCP-ng project. No support is provided for other additional packages, even if installed from our repositories, as they contain build dependencies not supposed to be installed in production.
 * [supported list for XCP-ng 8.3](http://reports.xcp-ng.org/8.3/extra_installable.txt)
-* [supported list for XCP-ng 8.2](http://reports.xcp-ng.org/8.2/extra_installable.txt)
 :::
 
 ## 📜 Rules
@@ -34,7 +33,7 @@ To disable a repository, edit `/etc/yum.repos.d/name_of_repo.repo` and set `enab
 
 We offer a number of additional packages ranging from ZFS support, [newer drivers](../../installation/hardware#-alternate-drivers) or [newer kernel](../../installation/hardware#-alternate-kernel), to small utilities such as `vim`, `joe`, `iperf`, `mc`, etc.).
 
-A regularly updated list of such utilities for XCP-ng 8.2 is available at [http://reports.xcp-ng.org/8.2/extra_installable.txt](http://reports.xcp-ng.org/8.2/extra_installable.txt), and at [http://reports.xcp-ng.org/8.3/extra_installable.txt](http://reports.xcp-ng.org/8.3/extra_installable.txt) for XCP-ng 8.3.
+A regularly updated list of such utilities is available at [http://reports.xcp-ng.org/8.3/extra_installable.txt](http://reports.xcp-ng.org/8.3/extra_installable.txt) for XCP-ng 8.3.
 
 The packages from this list are supported on a best-effort basis.
 
@@ -64,28 +63,6 @@ The controller domain is not an all-purpose Linux system. It must remain minimal
 :::tip
 Additional packages are not meant to be in the base installation. They are only present for convenience. Unless considered truly critical, the security updates on these packages is best effort.
 :::
-
-#### Libreswan
-
-If you are using encrypted tunnels on an 8.2 host using `openvswitch-ipsec` and `libreswan`, for example through [Xen Orchestra's SDN Controller](https://xen-orchestra.com/docs/sdn_controller.html) there are security advisories you need to know about, there are 3 CVEs that are affecting our current libreswan version:
-- [CVE-2023-38712](https://libreswan.org/security/CVE-2023-38712/CVE-2023-38712.txt): Invalid IKEv1 repeat IKE SA delete causes crash and libreswan to restart
-- [CVE-2023-38710](https://libreswan.org/security/CVE-2023-38710/CVE-2023-38710.txt): Invalid IKEv2 REKEY proposal causes libreswan to restart
-- [CVE-2024-3652](https://libreswan.org/security/CVE-2024-3652/CVE-2024-3652.txt): IKEv1 default AH/ESP responder can crash and restart
-
-Patches for these are not really backportable, we therefore kept it as is and target updating packages in the next major release.
-
-You can find information about all Libreswan CVEs on their [security page](https://libreswan.org/security/).
-
-##### Resulting security issue
-
-The `pluto` daemon may be crashed by malformed IKE (both v1 and v2) delete/notify requests, resulting in a DoS on the keying service. If the daemon is restarted in loop quickly enough, this could as well lead to a DoS of the whole host.
-
-##### Vulnerability Perimeter
-
-Various point regarding how critical this is:
-- these packages are not installed by default, and only required for encrypted tunnels
-- no privilege escalation
-- `pluto` will only process these packets if they are coming from an authenticated peer, limiting the possible sources
 
 #### wpa_supplicant
 

--- a/docs/management/updates.md
+++ b/docs/management/updates.md
@@ -17,10 +17,10 @@ All our updates are explained in details inside a dedicated blog post. Don't for
 ## ♻️ Support cycle
 
 We maintain one or several releases in parallel:
-* LTS releases (currently `8.2` and `8.3`).
+* LTS releases (currently `8.3`).
 * Non-LTS releases, which receive rolling updates (currently none, as `8.3` is now a LTS).
 
-If your version is lower than `8.2`, it will not receive updates anymore. To keep benefiting from bugfixes and security fixes you need to [upgrade](../../installation/upgrade).
+If your version is lower than `8.3`, it will not receive updates anymore. To keep benefiting from bugfixes and security fixes you need to [upgrade](../../installation/upgrade).
 
 ## ℹ️ Prerequisites
 
@@ -64,9 +64,8 @@ More at [Additional packages](../../management/additional-packages).
 
 ## 💡 Get information about the updates
 
-Every update is first tested and discussed on a forum thread. We highly recommend to subscribe to these threads (activate e-mail notifications in your forum settings if you want to be notified of new messages). You will thus know about coming updates in advance and be able to help us validate them. No one would like updates to be delayed because of lack of feedback there.
+Every update is first tested and discussed on a forum thread dedicated to update candidates for a given XCP-ng release. We highly recommend to subscribe to these threads (activate e-mail notifications in your forum settings if you want to be notified of new messages). You will thus know about coming updates in advance and be able to help us validate them. No one would like updates to be delayed because of lack of feedback there.
 
-* [XCP-ng 8.2 updates announcements and testing](https://xcp-ng.org/forum/topic/365/xcp-ng-8-2-updates-announcements-and-testing)
 * [XCP-ng 8.3 updates announcements and testing](https://xcp-ng.org/forum/topic/9964/xcp-ng-8-3-updates-announcements-and-testing)
 
 Important updates - especially security updates - are announced [on the blog](https://xcp-ng.org/blog/) and the most important ones are also announced through [the newsletter](https://xcp-ng.us13.list-manage.com/subscribe?u=f1ab72021fb8816f4d5e72773&id=4d17393549).
@@ -80,6 +79,10 @@ A comprehensive list of updates is available on our build system's web interface
 * [List of **testing** packages prepared for a future update](https://koji.xcp-ng.org/builds?inherited=0&tagID=66&order=-build_id&latest=1)
 
 #### Updates for XCP-ng 8.2
+
+:::note
+XCP-ng 8.2 is EOL. This 8.2-specific information is retained solely to assist with the transition from 8.2 to a supported release.
+:::
 
 * [List of official **updates**](https://koji.xcp-ng.org/builds?inherited=0&tagID=42&order=-build_id&latest=1)
 * [List of immediate **update candidates**](https://koji.xcp-ng.org/builds?inherited=0&tagID=89&order=-build_id&latest=1)

--- a/docs/project/development-process/ISO-modification.md
+++ b/docs/project/development-process/ISO-modification.md
@@ -135,7 +135,7 @@ To achieve this:
 From the `iso/` directory:
 ```
 OUTPUT=/path/to/destination/iso/file # change me
-VERSION=8.2 # change me
+VERSION=8.3 # change me
 genisoimage -o $OUTPUT -v -r -J --joliet-long -V "XCP-ng $VERSION" -c boot/isolinux/boot.cat -b boot/isolinux/isolinux.bin \
             -no-emul-boot -boot-load-size 4 -boot-info-table -eltorito-alt-boot -e boot/efiboot.img -no-emul-boot .
 isohybrid --uefi $OUTPUT

--- a/docs/releases/release-8-2.md
+++ b/docs/releases/release-8-2.md
@@ -1,8 +1,14 @@
 ---
-sidebar_position: 2
+sidebar_class_name: hidden
 ---
 
 # XCP-ng 8.2 LTS
+
+:::danger
+XCP-ng 8.2 is EOL (End Of Life) since September 16th, 2025. Please check the [currently supported release(s)](releases.md).
+
+XCP-ng 8.2.1 is EOL too. It's the same release: XCP-ng 8.2 LTS was first released as 8.2.0, then the version number was updated to 8.2.1 in 2022 when we released a signficant maintenance update, but it's all XCP-ng 8.2 LTS in the end.
+:::
 
 XCP-ng 8.2 is an [LTS Release](../#xcp-ng-release-history). [Download the installation ISO](https://mirrors.xcp-ng.org/isos/8.2/xcp-ng-8.2.1-20231130.iso?https=1).
 
@@ -10,10 +16,6 @@ SHA256 checksums, GPG signatures and net-install ISO are available [here](https:
 
 :::info
 LTS means **Long Term Support**: more information in [this section](../#-lts-releases).
-:::
-
-:::warning
-Support for XCP-ng 8.2 LTS ends on September 16th, 2025. Upgrade to XCP-ng 8.3 LTS.
 :::
 
 ## Release information

--- a/docs/releases/releases.md
+++ b/docs/releases/releases.md
@@ -5,7 +5,7 @@
 | Version                   | Released   | Status               | Support until                                | Release notes                        |
 | ---                       | ---        | ---                  | ---                                          | ---                                  |
 | [8.3 LTS](release-8-3.md)     | 2024-10-07 | Full support, LTS    | 2028-11-30                                   | [8.3 Release notes](release-8-3.md)  |
-| [8.2 LTS](release-8-2.md) | **8.2.0**:&nbsp;2020-11-18<br/>**8.2.1**:&nbsp;2022-02-28 | Full support, LTS    | ~~2025-06-25~~ 2025-09-16 (*)           | [8.2 Release notes](release-8-2.md)  |
+| [8.2 LTS](release-8-2.md) | **8.2.0**:&nbsp;2020-11-18<br/>**8.2.1**:&nbsp;2022-02-28 | EOL | ~~2025-06-25~~ 2025-09-16 (*)           | [8.2 Release notes](release-8-2.md)  |
 | [8.1](release-8-1.md)     | 2020-03-31 | EOL                  | 2021-03-31                                   | [8.1 Release notes](release-8-1.md)  |
 | 8.0                       | 2019-07-25 | EOL                  | 2020-11-13                                   |                                      |
 | 7.6                       | 2018-10-31 | EOL                  | 2020-03-30                                   |                                      |

--- a/docs/storage/storage.md
+++ b/docs/storage/storage.md
@@ -298,8 +298,6 @@ Local, thin-provisioned storage.
 
 :::tip
 [Additional package](../management/additional-packages) required and available in our repositories: `xfsprogs`.
-
-On XCP-ng before 8.2, you also need `sm-additional-drivers`.
 :::
 
 Works in the same way as the Local EXT storage driver: you hand it a device and it will format it and prepare it for your VMs automatically.

--- a/docs/troubleshooting/common-problems.md
+++ b/docs/troubleshooting/common-problems.md
@@ -47,7 +47,7 @@ Can be a `yum` update process interrupted while rebuilding the `initrd`, such as
 3. Reboot on the latest kernel, it works!
 
 :::tip
-Here is an example of `dracut` command on a 8.2 host: `dracut -f /boot/initrd-4.19.0+1.img 4.19.0+1`
+Here is an example of `dracut` command on a 8.3 host: `dracut -f /boot/initrd-4.19.0+1.img 4.19.0+1`
 :::
 
 ---

--- a/docs/troubleshooting/storage/disk-failure-softwaire-RAID.md
+++ b/docs/troubleshooting/storage/disk-failure-softwaire-RAID.md
@@ -88,4 +88,4 @@ This might happen for various reasons. If you haven't backed-up the contents of 
 
 It has been reported to us that some non-enterprise motherboards may have limited UEFI firmware that does not cope well with disk changes.
 
-In most cases, you should be able to restore the bootloader by upgrading your host to the same version it is already running (e.g upgrade 8.2 to 8.2 using the 8.2 install ISO). Check [the upgrade docs](../../installation/upgrade.md) for the usual instructions and warnings. Another, custom solution is to run the appropriate `efibootmgr` commands from the installer's shell. Refer to [its documentation](https://linux.die.net/man/8/efibootmgr).
+In most cases, you should be able to restore the bootloader by upgrading your host to the same version it is already running (e.g upgrade 8.3 to 8.3 using the 8.3 install ISO). Check [the upgrade docs](../../installation/upgrade.md) for the usual instructions and warnings. Another, custom solution is to run the appropriate `efibootmgr` commands from the installer's shell. Refer to [its documentation](https://linux.die.net/man/8/efibootmgr).

--- a/docs/vms/vms.md
+++ b/docs/vms/vms.md
@@ -270,7 +270,7 @@ We developed two features to help you handle these vulnerabilities.
 * A warning :warning: sign next to affected VMs and a `vulnerable?` filter in Xen Orchestra. These features are available in Xen Orchestra 5.107.0 (latest channel) and 5.106.4 (stable channel).
 
 :::note
-This detection depends on XAPI accurately reporting PV driver versions. Prior to the recent XCP-ng 8.2 and 8.3 updates released in May 2025, this was not the case. As a result, the detection tools cannot assess VMs that have not been run since the updates were applied. If no driver information is available, a warning will be displayed.
+This detection depends on XAPI accurately reporting PV driver versions. Prior to the XCP-ng 8.2 and 8.3 updates released in May 2025, this was not the case. As a result, the detection tools cannot assess VMs that have not been run since the updates were applied. If no driver information is available, a warning will be displayed.
 :::
 
 :::warning


### PR DESCRIPTION
* Mark XCP-ng 8.2(.1) as having reached End Of Life
* Remove some mentions of 8.2 from the docs
* Retain other mentions, assorted with a note telling that's it is only to assist with the upgrade.
* Small changes made while looking at the docs for mentions of 8.2.