### PR TITLE
doc: Update vCPUs limitation in UEFI mode

### DIFF
--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -122,7 +122,7 @@ Below are the supported limits for virtual machines on XCP-ng.
 
 - **Virtual CPUs (vCPUs) per VM**:
   - For untrusted VMs, the security-supported limit is **32 vCPUs**.
-  - For trusted VMs, the theoretical limit is **254 vCPUs**. Linux VMs with **128 vCPUs** have been successfully tested.
+  - For trusted VMs, the tested limits are **128 vCPUs** in BIOS mode and **96 vCPUs** in UEFI mode. Developments are planned to increase these limits.
 
 Guest OS support is also an important factor to consider.
 


### PR DESCRIPTION
Limit is 96 vCPUs for VMs in UEFI mode so update the installation doc accordingly.



> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
