### PR TITLE
docs: Removed dead link

### DIFF
--- a/docs/installation/upgrade.md
+++ b/docs/installation/upgrade.md
@@ -145,8 +145,6 @@ Check them carefully.
 
 #### Upgrade instructions
 
-If for some reason you want to upgrade to the unsupported XCP-ng 7.6 from an earlier release, see [Yum Upgrade towards XCP ng 7.6](https://github.com/xcp-ng/xcp/wiki/Yum-Upgrade-towards-XCP-ng-7.6).
-
 :warning: **Proceed one host at a time. Do not `yum update` all hosts at once to "save time".** :warning:
 
 :warning: **ALWAYS START WITH THE POOL MASTER.** :warning:


### PR DESCRIPTION
This markdown page was removed from the wiki in 2021 by commit ab2555e0db60 (from: https://github.com/xcp-ng/xcp.wiki.git). So, remove the text referencing this page.



> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
