### PR TITLE
docs(xcp-ng): fix broken anchor causing error at build time

### DIFF
--- a/docs/guides/amd-performance-improvements.md
+++ b/docs/guides/amd-performance-improvements.md
@@ -121,7 +121,7 @@ The real cause was fixed upstream. Don't hesitate to read the full [commit messa
 This issue occurred only on the front-end side. This means that the only way to improve network bandwidth is to upgrade the guest kernel, which limits spurious interrupts.
 
 Fix 1 (on grant-tables) and fix 2 work independently from each other. You can apply them both.
-The fixes don't guarantee better performance for every processor model (See [Future improvements below](#future-improvments-and-leads)) but we didn't detect any regression when applying them.
+The fixes don't guarantee better performance for every processor model (See [Future improvements below](#future-improvements-and-leads)) but we didn't detect any regression when applying them.
 The fix is not specific to AMD —it can improve internal network performance on Intel processors too.
 
 ### OS support


### PR DESCRIPTION
A malformed Markdown link was causing Docusaurus to throw an error during the build process. This pull request corrects the link syntax so that the build completes successfully while preserving access to the intended URL for readers.