### PR TITLE
docs: upgrade docusaurus from version 3.8 to 3.9

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,9 +11,13 @@ const config = {
   url: 'https://docs.xcp-ng.org',
   baseUrl: '/',
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
   favicon: 'img/xcpcrop128.png',
   trailingSlash: true,
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
+  },
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.7.0",
-    "@docusaurus/preset-classic": "^3.7.0",
-    "@docusaurus/theme-mermaid": "^3.7.0",
+    "@docusaurus/core": "^3.9.2",
+    "@docusaurus/preset-classic": "^3.9.2",
+    "@docusaurus/theme-mermaid": "^3.9.2",
     "@mdx-js/react": "^3.0.0",
     "docusaurus-lunr-search": "^3.6.0",
     "prism-react-renderer": "^2.1.0",
@@ -24,8 +24,8 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.7.0",
-    "@docusaurus/types": "^3.7.0"
+    "@docusaurus/module-type-aliases": "^3.9.2",
+    "@docusaurus/types": "^3.9.2"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
This pull request upgrades Docusaurus to version 3.9.2, from version 3.8.

Here are the main additions:

- Dropping Node.js 18
- Support for Algolia DocSearch v4
- i18n improvements
- Support for Mermaid ELK layouts

More at: https://docusaurus.io/fr/blog/releases/3.9

By the way, the PR updates the `onBrokenMarkdownLinks: warn` option, since that syntax has been deprecated and replaced with a new one: (`siteConfig.markdown.hooks.onBrokenMarkdownLinks`).