### PR TITLE
docs(xcp-ng): fix broken anchor

### DIFF
--- a/docs/guides/winpv-update.md
+++ b/docs/guides/winpv-update.md
@@ -87,7 +87,7 @@ Once the update finishes, you should no longer see the vulnerability warning in 
 ## Useful links
 
 - If you want to remove existing Xen drivers, refer to the [XenClean guide](/vms/#fully-removing-xen-pv-drivers-with-xenclean).
-- Refer to the [XenBootFix guide](/troubleshooting/windows-pv-tools/#windows-fails-to-boot-hanging-at-boot-or-bsod-with-stop-code-inaccessible_boot_device) if you encounter VM boot issues after the update.
+- Refer to the [XenBootFix guide](/troubleshooting/windows-pv-tools/#windows-fails-to-boot-hangs-inaccessible_boot_device) if you encounter VM boot issues after the update.
 
 ## Appendix: Blocking vulnerable Xen drivers with Application Control for Windows
 


### PR DESCRIPTION
A malformed anchor in an internal link caused Docusaurus to throw a warning at build time. This pull request updates the link so that we don't get the warning, while readers are still directed to the correct location.