### PR TITLE
Update koji-initial-setup.md with permission checks

### DIFF
--- a/docs/project/development-process/koji-initial-setup.md
+++ b/docs/project/development-process/koji-initial-setup.md
@@ -65,6 +65,12 @@ In some cases (with older versions of koji), we've found that the `cert` directi
 ## Get more permissions
 After your first connection, your user gets added by koji to its database. Now you need permissions to be able to tag builds. Ask an administrator for the `build` permission.
 
+You can verify the permissions for a given user `$USER` with:
+```
+koji list-users # Check if $USER is listed
+koji list-permissions --user=$USER # Adapt $USER if needed
+```
+
 ## Koji in Docker container
 
 This used to be useful when our koji server was a bit too old for recent crypto, but now **installing from `PyPi` is probably the best choice**.


### PR DESCRIPTION
Added instructions to check user permissions in koji.



> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
