### PR TITLE
docs(networking.md): document the --rename option for interface-rename

### DIFF
--- a/docs/networking/networking.md
+++ b/docs/networking/networking.md
@@ -126,6 +126,11 @@ If for some reason the NIC order between hosts doesn't match up, you can fix it 
 These commands are meant to be done on non-active interfaces. Typically this will be done directly after install, before even joining a pool.
 :::
 
+:::warning
+Always reboot the host after applying these changes.
+Using the commands below without rebooting can cause errors, as many system components will still be tied to the old interface names.
+:::
+
 ```
 interface-rename --help
 ```
@@ -142,10 +147,10 @@ ifconfig eth4 down
 ifconfig eth8 down
 ```
 
-The most common use will be an update statement like the following:
-```
-interface-rename --update eth4=00:24:81:80:19:63 eth8=00:24:81:7f:cf:8b
-```
+The most common use will be an update statement like:
+
+`interface-rename --update eth4=00:24:81:80:19:63 eth8=00:24:81:7f:cf:8b`
+
 This example will set the mac-address for eth4 & eth8, switching them in the process.
 
 The XAPI database needs the old PIFs removed. First list your PIFs for the affected NICs:


### PR DESCRIPTION
This PR updates the [networking documentation](https://docs.xcp-ng.org/networking/#renaming-nics) to clarify that users can use the `--rename` option to modify network interface names on XCP-ng hosts.

Previously, only the `--update` option was documented, which caused confusion and sometimes prevented users from effectively renaming their NICs, [as discussed on the XCP-ng forum](https://xcp-ng.org/forum/topic/3759/rename-networks-on-xo-hosts/25).