### PR TITLE
Document error with VDIs live migration

### DIFF
--- a/docs/troubleshooting/common-problems.md
+++ b/docs/troubleshooting/common-problems.md
@@ -271,3 +271,28 @@ It should be empty, but if you have the bug, you got `check_update`.
 Remove `/var/lib/xcp-ng-xapi-plugins/updater.py.lock` and that should fix it.
 
 ---
+
+## Unable to live migrate VDI between SRs
+
+### Cause
+
+Upgrading from 8.2 to 8.3 can cause an issue where `/etc/stunnel/xapi-pool-ca-bundle.pem` is empty or missing
+You can check this with `ls -l /etc/stunnel/xapi-pool-ca-bundle.pem` on the host.
+It will cause issues when live-migrating VDIs between SRs (even if the VM remains on the same host).
+The migration fails with:
+```
+Xenops_interface.Xenopsd_error([S(Internal_error);S(Sys_error(\"Connection reset by peer\"))])
+```
+
+### Solution
+
+To fix this, create the file with the following command:
+```
+xe host-refresh-server-certificate host=<host name>
+```
+This will create the correct file on the host.
+You will need to run the command on all hosts of the pool.
+
+To know more about certificates in XAPI, check out the [XAPI documentation](https://xapi-project.github.io/new-docs/design/pool-certificates/index.html)
+
+---


### PR DESCRIPTION
An issue with upgrade from 8.2 to 8.3 can cause an issue with a stunnel pool certificate being empty. It end up creating an error during VDI live migration that can be hard to understand and the solution is to recreate the file using a XAPI command documented in the commit.



> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [X] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [X] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
