### PR TITLE
docs(xcp-ng): add missing DNS part to LACP guide

### DIFF
--- a/docs/guides/lacp-install-upgrade.md
+++ b/docs/guides/lacp-install-upgrade.md
@@ -67,6 +67,8 @@ dhclient bond0
 ip addr add aaa.bbb.ccc.ddd/NN dev bond0
 ip route add default via aaa.bbb.ccc.1
 ip link set bond0 up
+# if doing a netinstall, set DNS too
+echo "nameserver aaa.bbb.ccc.1" > /etc/resolv.conf
 ```
 
 For example:\
@@ -128,7 +130,11 @@ xe bond-create mode=lacp network-uuid=<network_uuid> pif-uuids=<pif_uuid#1>,<pif
 3. Set the previously created bond as your management interface:
 
 ```bash
-xe pif-reconfigure-ip uuid=<bond_pif_uuid> netmask=255.255.255.0 gateway=192.168.1.1 IP=192.168.1.5 mode=static
+# for example, to set a static IP:
+xe pif-reconfigure-ip uuid=<bond_pif_uuid> netmask=255.255.255.0 gateway=192.168.1.1 IP=192.168.1.5 DNS=192.168.1.1 mode=static
+# or, for DHCP:
+xe pif-reconfigure-ip uuid=<bond_pif_uuid> mode=dhcp
+# then set it as management interface:
 xe host-management-reconfigure pif-uuid=<bond_pif_uuid>
 ```
 


### PR DESCRIPTION
When creating that guide I forgot to mention the DNS parts, adding them as requested by @Fohdeesha.

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
