### PR TITLE
Update pif-reconfigure-ip command options

### DIFF
--- a/docs/appendix/cli_reference.md
+++ b/docs/appendix/cli_reference.md
@@ -1673,7 +1673,7 @@ Attempt to bring up the specified physical interface.
 ### `pif-reconfigure-ip`
 
 ```
-pif-reconfigure-ip uuid=uuid_of_pif [mode=dhcp|mode=static|none] gateway=network_gateway_address IP=static_ip_for_this_pif netmask=netmask_for_this_pif [DNS=dns_address]
+pif-reconfigure-ip uuid=uuid_of_pif [mode=dhcp|mode=static|mode=none] gateway=network_gateway_address IP=static_ip_for_this_pif netmask=netmask_for_this_pif [DNS=dns_address]
 ```
 
 Modify the IP address of the PIF. For static IP configuration, set the `mode` parameter to `static`, with the `gateway`, `IP`, and `netmask` parameters set to the appropriate values. To use DHCP, set the `mode` parameter to `DHCP` and leave the static parameters undefined.


### PR DESCRIPTION
Added 'none' mode option for pif-reconfigure-ip command.

I saw in a test that mode could be set to `none` (https://github.com/xcp-ng/xcp-ng-tests/blob/master/tests/migration/test_host_evacuate.py#L81)
I thought we could document that then.

What happens when we set it to `none`?