### PR TITLE
doc: fix duplicate markdown declaration in config file

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,6 +14,8 @@ const config = {
   favicon: 'img/xcpcrop128.png',
   trailingSlash: true,
   markdown: {
+    // Mermaid graphs
+    mermaid: true,
     hooks: {
       onBrokenMarkdownLinks: 'warn',
     },
@@ -32,10 +34,6 @@ const config = {
     locales: ['en'],
   },
 
-  // Mermaid graphs
-  markdown: {
-    mermaid: true,
-  },
   themes: ['@docusaurus/theme-mermaid'],
 
   scripts: [


### PR DESCRIPTION
This pull request regroups all the Markdown parameter declarations within the same code block, instead of declaring Markdown parameters twice. This should prevent former declarations from being overwritten by the latter, and keeps code tidier.

