### PR TITLE
doc: upgrade docusaurus to v3.10.0

### DIFF
--- a/docs/installation/hardware.md
+++ b/docs/installation/hardware.md
@@ -12,7 +12,7 @@ XCP-ng comes with a large range of hardware support.
 A given device may be supported at one of two levels:
 
 1. Presence on the [Hardware Compatibility List](#-hardware-compatibility-list-hcl) guarantees support by XCP-ng. With some exceptions described in the next section.
-2. Many devices outside the HCL are also supported, but are not tested routinely. See [Supported hardware outside the HCL](#-supported-hardware-outside-the-hcl).
+2. Many devices outside the HCL are also supported, but are not tested routinely. See [Supported hardware outside the HCL](#%EF%B8%8F-supported-hardware-outside-the-hcl).
 
 ## 📖 Hardware Compatibility List (HCL)
 

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.9.2",
-    "@docusaurus/preset-classic": "^3.9.2",
-    "@docusaurus/theme-mermaid": "^3.9.2",
+    "@docusaurus/core": "^3.10.0",
+    "@docusaurus/preset-classic": "^3.10.0",
+    "@docusaurus/theme-mermaid": "^3.10.0",
     "@mdx-js/react": "^3.0.0",
     "docusaurus-lunr-search": "^3.6.0",
     "docusaurus-plugin-image-zoom": "^3.0.1",
@@ -25,8 +25,8 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.9.2",
-    "@docusaurus/types": "^3.9.2"
+    "@docusaurus/module-type-aliases": "^3.10.0",
+    "@docusaurus/types": "^3.10.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
This pull request upgrades the [XCP-ng documentation](https://docs.xcp-ng.org/) from Docusaurus v3.9.2 to v3.10.0.

The changes include:
- future flags in anticipation of Docusaurus v4
- various security measures, particularly against npm [supply chain attacks](https://en.wikipedia.org/wiki/Supply_chain_attack).

To know more, check out the [Docusaurus 3.10 release notes](https://docusaurus.io/fr/blog/releases/3.10).

In addition, the PR fixes a broken anchor which caused Docusaurus to throw a warning at build time.