### PR TITLE
ha.md: explain how to prevent automatic reboots on HA-protected VMs

### DIFF
--- a/docs/management/ha.md
+++ b/docs/management/ha.md
@@ -175,8 +175,6 @@ The **default timeout is 60 seconds**, but you can adjust this value using the f
 xe pool-param-set uuid=<pool UUID> other-config:default_ha_timeout=<timeout in seconds>
 ```
 
-
-
 ## 🔧 Updates/maintenance
 
 Before any update or host maintenance, planned reboot and so on, **ALWAYS** put your host in maintenance mode. If you don't do that, XAPI will think it's an unplanned failure, and will act accordingly.
@@ -195,9 +193,13 @@ If you shut the VM down with `Xen Orchestra` or `xe`, the VM will be stopped nor
 
 However, if you halt the VM directly in the guest OS (via the console or in SSH), XCP-ng is NOT aware of what's going on. The system will think the VM is down and will consider that an anomaly. As a result, the VM will be **started automatically!**. This behavior prevents an operator from shutting down the system and leaving the VM unavailable for a long time.
 
+#### Configure VM shutdown behavior
+
+##### For an entire pool
+
 :::tip
 
-Starting with XAPI 25.16.0, VM restart behavior can be changed. To do this, run this command:
+Starting with XAPI 25.16.0, VM restart behavior can be changed on a pool-wide basis. To do this, run this command:
 
 ```
 xe pool-param-set uuid=... ha-reboot-vm-on-internal-shutdown=false
@@ -206,39 +208,21 @@ As a result, VMs that are shut down internally or through the API will restart t
 
 :::
 
-#### Configure VM shutdown behavior
+##### For specific VMs
 
-If you don't want a VM to reboot automatically when it has been shut down from the guest OS: disable its HA protection, then adjust the VM reboot behavior with the parameter called `Pool.ha_reboot_vm_on_internal_shutdown` (see below).
-
-##### Disabling HA on specific VMs
-
-You can adjust the reboot behavior for a specific HA-protected VM:
-
-- **Using the `xe` cli:** :
-    - To disable HA features, run `xe vm-param-set uuid=<vm_uuid> ha-restart-priority=`.
-    - To (re-)enable HA features, run `xe vm-param-set uuid=<vm_uuid> ha-restart-priority=restart` or `xe vm-param-set uuid=<vm_uuid> ha-restart-priority=best-effort`.
-- **Using Xen Orchestra**:
-    To change the VM reboot behavior from Xen Orchestra, check out the instructions in the [Xen Orchestra documentation](https://docs.xen-orchestra.com/manage_infrastructure#vm-high-availability-ha).
+If you don't want a VM to reboot automatically when it has been shut down from the guest OS, adjust the VM reboot behavior with the parameter called `Pool.ha_reboot_vm_on_internal_shutdown`.
 
 :::warning
 Applying these changes means that your VMs will stay off after they have been shut down, until you restart them yourself.
 :::
 
-:::tip
-Once HA features have been disabled on your VM, shut the VM down. Once you have started the VM again, feel free to enable HA again.
-:::
+- **Using the `xe` cli:** :
+    - To disable automatic reboots, run `xe vm-param-set uuid=<vm_uuid> ha-restart-priority=`.
+    - To (re-)enable automatic reboots, run `xe vm-param-set uuid=<vm_uuid> ha-restart-priority=restart` or `xe vm-param-set uuid=<vm_uuid> ha-restart-priority=best-effort`.
+- **Using Xen Orchestra**:
+    To change the VM reboot behavior from Xen Orchestra, check out the instructions in the [Xen Orchestra documentation](https://docs.xen-orchestra.com/manage_infrastructure#vm-high-availability-ha).
 
-##### Disabling HA on the whole pool
-
-You can prevent automatic reboots on your entire pool. To do this, use the `xe` CLI to run this command:
-
-`xe pool-param-set uuid=$UUID ha-reboot-vm-on-internal-shutdown=false`.
-
-To enable automatic reboots again, set the parameter to `true` instead of `false`.
-
-:::warning
-By applying these changes to your entire pool, you disable the protection that prevents VMs from being shut down by their own guest OS.
-:::
+Once you've changed the reboot parameter, shut the VM down. After you have started the VM again, feel free to re-enable automatic reboots.
 
 ### Host failure
 

--- a/docs/management/ha.md
+++ b/docs/management/ha.md
@@ -208,13 +208,7 @@ As a result, VMs that are shut down internally or through the API will restart t
 
 #### Configure VM shutdown behavior
 
-If you don't want a VM to reboot automatically when it has been shut down from the guest OS:
-1. Disable its HA protection.
-2. Adjust the VM reboot behavior with the parameter called `Pool.ha_reboot_vm_on_internal_shutdown` (see below).
-
-:::warning
-Applying these changes on your entire VM pool means that your VMs will stay off after they have been shut down, until you restart them yourself. Your VMs will no longer be protected from accidental shutdowns. 
-:::
+If you don't want a VM to reboot automatically when it has been shut down from the guest OS: disable its HA protection, then adjust the VM reboot behavior with the parameter called `Pool.ha_reboot_vm_on_internal_shutdown` (see below).
 
 ##### Disabling HA on specific VMs
 
@@ -225,6 +219,10 @@ You can adjust the reboot behavior for a specific HA-protected VM:
     - To (re-)enable HA features, run `xe vm-param-set uuid=<vm_uuid> ha-restart-priority=restart` or `xe vm-param-set uuid=<vm_uuid> ha-restart-priority=best-effort`.
 - **Using Xen Orchestra**:
     To change the VM reboot behavior from Xen Orchestra, check out the instructions in the [Xen Orchestra documentation](https://docs.xen-orchestra.com/manage_infrastructure#vm-high-availability-ha).
+
+:::warning
+Applying these changes means that your VMs will stay off after they have been shut down, until you restart them yourself.
+:::
 
 :::tip
 Once HA features have been disabled on your VM, shut the VM down. Once you have started the VM again, feel free to enable HA again.
@@ -237,6 +235,10 @@ You can prevent automatic reboots on your entire pool. To do this, use the `xe` 
 `xe pool-param-set uuid=$UUID ha-reboot-vm-on-internal-shutdown=false`.
 
 To enable automatic reboots again, set the parameter to `true` instead of `false`.
+
+:::warning
+By applying these changes to your entire pool, you disable the protection that prevents VMs from being shut down by their own guest OS.
+:::
 
 ### Host failure
 

--- a/docs/management/ha.md
+++ b/docs/management/ha.md
@@ -195,8 +195,6 @@ However, if you halt the VM directly in the guest OS (via the console or in SSH)
 
 #### Configure VM shutdown behavior
 
-##### For an entire pool
-
 :::tip
 
 Starting with XAPI 25.16.0, VM restart behavior can be changed on a pool-wide basis. To do this, run this command:
@@ -204,25 +202,22 @@ Starting with XAPI 25.16.0, VM restart behavior can be changed on a pool-wide ba
 ```
 xe pool-param-set uuid=... ha-reboot-vm-on-internal-shutdown=false
 ```
-As a result, VMs that are shut down internally or through the API will restart the exact same way.
+
+The `ha-reboot-vm-on-internal-shutdown` parameter indicates whether an HA-protected VM that is shut down from inside (not through the API) should be automatically rebooted when HA is enabled.
 
 :::
-
-##### For specific VMs
-
-If you don't want a VM to reboot automatically when it has been shut down from the guest OS, adjust the VM reboot behavior with the parameter called `Pool.ha_reboot_vm_on_internal_shutdown`.
 
 :::warning
-Applying these changes means that your VMs will stay off after they have been shut down, until you restart them yourself.
+Setting the `ha-reboot-vm-on-internal-shutdown` to `false` means that your VMs will stay off after they have been shut down from the guest OS, until you restart them yourself.
+
+If you want to restore the default behavior (i.e. HA-protected VMs restart automatically after getting shut down from the guest OS), you will have to set the parameter to `true` again.
 :::
 
-- **Using the `xe` cli:** :
-    - To disable automatic reboots, run `xe vm-param-set uuid=<vm_uuid> ha-restart-priority=`.
-    - To (re-)enable automatic reboots, run `xe vm-param-set uuid=<vm_uuid> ha-restart-priority=restart` or `xe vm-param-set uuid=<vm_uuid> ha-restart-priority=best-effort`.
-- **Using Xen Orchestra**:
-    To change the VM reboot behavior from Xen Orchestra, check out the instructions in the [Xen Orchestra documentation](https://docs.xen-orchestra.com/manage_infrastructure#vm-high-availability-ha).
+:::note
+If you don't want a specific VM to reboot automatically, you can also disable HA protection for that VM entirely. To do so, read the instructions at the [Troubleshooting HA section](../troubleshooting/troubleshooting-ha.md#disabling-ha).
 
-Once you've changed the reboot parameter, shut the VM down. After you have started the VM again, feel free to re-enable automatic reboots.
+Once you have disabled HA for the VM, shut the VM down. After you start the VM again, feel free to re-enable HA.
+:::
 
 ### Host failure
 

--- a/docs/management/ha.md
+++ b/docs/management/ha.md
@@ -175,6 +175,8 @@ The **default timeout is 60 seconds**, but you can adjust this value using the f
 xe pool-param-set uuid=<pool UUID> other-config:default_ha_timeout=<timeout in seconds>
 ```
 
+
+
 ## 🔧 Updates/maintenance
 
 Before any update or host maintenance, planned reboot and so on, **ALWAYS** put your host in maintenance mode. If you don't do that, XAPI will think it's an unplanned failure, and will act accordingly.
@@ -203,6 +205,38 @@ xe pool-param-set uuid=... ha-reboot-vm-on-internal-shutdown=false
 As a result, VMs that are shut down internally or through the API will restart the exact same way.
 
 :::
+
+#### Configure VM shutdown behavior
+
+If you don't want a VM to reboot automatically when it has been shut down from the guest OS:
+1. Disable its HA protection.
+2. Adjust the VM reboot behavior with the parameter called `Pool.ha_reboot_vm_on_internal_shutdown` (see below).
+
+:::warning
+Applying these changes on your entire VM pool means that your VMs will stay off after they have been shut down, until you restart them yourself. Your VMs will no longer be protected from accidental shutdowns. 
+:::
+
+##### Disabling HA on specific VMs
+
+You can adjust the reboot behavior for a specific HA-protected VM:
+
+- **Using the `xe` cli:** :
+    - To disable HA features, run `xe vm-param-set uuid=<vm_uuid> ha-restart-priority=`.
+    - To (re-)enable HA features, run `xe vm-param-set uuid=<vm_uuid> ha-restart-priority=restart` or `xe vm-param-set uuid=<vm_uuid> ha-restart-priority=best-effort`.
+- **Using Xen Orchestra**:
+    To change the VM reboot behavior from Xen Orchestra, check out the instructions in the [Xen Orchestra documentation](https://docs.xen-orchestra.com/manage_infrastructure#vm-high-availability-ha).
+
+:::tip
+Once HA features have been disabled on your VM, shut the VM down. Once you have started the VM again, feel free to enable HA again.
+:::
+
+##### Disabling HA on the whole pool
+
+You can prevent automatic reboots on your entire pool. To do this, use the `xe` CLI to run this command:
+
+`xe pool-param-set uuid=$UUID ha-reboot-vm-on-internal-shutdown=false`.
+
+To enable automatic reboots again, set the parameter to `true` instead of `false`.
 
 ### Host failure
 

--- a/docs/management/ha.md
+++ b/docs/management/ha.md
@@ -203,7 +203,7 @@ Starting with XAPI 25.16.0, VM restart behavior can be changed on a pool-wide ba
 xe pool-param-set uuid=... ha-reboot-vm-on-internal-shutdown=false
 ```
 
-The `ha-reboot-vm-on-internal-shutdown` parameter indicates whether an HA-protected VM that is shut down from inside (not through the API) should be automatically rebooted when HA is enabled.
+The `ha-reboot-vm-on-internal-shutdown` parameter indicates whether VM-initiated shudotwns will trigger a restart for HA-protected VMs, for example, when a user clicks the shutdown in Windows.
 
 :::
 

--- a/docs/management/ha.md
+++ b/docs/management/ha.md
@@ -203,18 +203,18 @@ Starting with XAPI 25.16.0, VM restart behavior can be changed on a pool-wide ba
 xe pool-param-set uuid=... ha-reboot-vm-on-internal-shutdown=false
 ```
 
-The `ha-reboot-vm-on-internal-shutdown` parameter indicates whether VM-initiated shudotwns will trigger a restart for HA-protected VMs, for example, when a user clicks the shutdown in Windows.
+The `ha-reboot-vm-on-internal-shutdown` parameter indicates whether VM-initiated shutdowns will trigger a restart for HA-protected VMs, for example, when a user clicks the shutdown in Windows.
 
 :::
 
 :::warning
-Setting the `ha-reboot-vm-on-internal-shutdown` to `false` means that your VMs will stay off after they have been shut down from the guest OS, until you restart them yourself.
+Setting the `ha-reboot-vm-on-internal-shutdown` parameter to `false` means that your VMs will stay off after they have been shut down from the guest OS, until you restart them yourself.
 
-If you want to restore the default behavior (i.e. HA-protected VMs restart automatically after getting shut down from the guest OS), you will have to set the parameter to `true` again.
+If you want to restore the default behavior (i.e. HA-protected VMs restart automatically after getting shut down from the guest OS), set the parameter to `true` again.
 :::
 
 :::note
-If you don't want a specific VM to reboot automatically, you can also disable HA protection for that VM entirely. To do so, read the instructions at the [Troubleshooting HA section](../troubleshooting/troubleshooting-ha.md#disabling-ha).
+If you don't want a specific VM to reboot automatically, without changing the behavior for the whole pool, you can also temporarily disable HA protection for that VM. To do so, read the instructions at the [Troubleshooting HA section](../troubleshooting/troubleshooting-ha.md#disabling-ha).
 
 Once you have disabled HA for the VM, shut the VM down. After you start the VM again, feel free to re-enable HA.
 :::


### PR DESCRIPTION
By default, HA-protected VMs reboot automatically after being shut down. 

This pull request updates the[ XCP-ng documentation](https://docs.xcp-ng.org/management/ha/#%EF%B8%8F-behavior) to explain how to prevent HA-protected VMs from restarting automatically after getting shut down (from within the guest OS).

<img width="1519" height="1538" alt="Capture d&#39;écran 2026-04-22 104305" src="https://github.com/user-attachments/assets/d0ed118a-851e-4f44-affe-aae9c9ac788b" />
