### PR TITLE
Update download link for latest dbx from Microsoft

### DIFF
--- a/docs/guides/guest-UEFI-Secure-Boot.md
+++ b/docs/guides/guest-UEFI-Secure-Boot.md
@@ -154,7 +154,7 @@ The default certificates are sourced as follows:
 | PK          |  Provided by XCP-ng, already present on disk.                                                                     | `default` |
 | KEK         |  [Microsoft Corporation KEK CA 2011](https://www.microsoft.com/pkiops/certs/MicCorKEKCA2011_2011-06-24.crt)       | `default` |
 | db          |  [Microsoft Corporation UEFI CA 2011](https://www.microsoft.com/pkiops/certs/MicCorUEFCA2011_2011-06-27.crt) and [Microsoft Windows Production PCA 2011](https://www.microsoft.com/pkiops/certs/MicWinProPCA2011_2011-10-19.crt) | `default` |
-| dbx         |  [UEFI Revocation List](https://uefi.org/sites/default/files/resources/dbxupdate_x64.bin)                         | `latest`  |
+| dbx         |  [UEFI Revocation List](https://github.com/microsoft/secureboot_objects/raw/refs/heads/main/PostSignedObjects/DBX/amd64/DBXUpdate.bin)                         | `latest`  |
 
 **With varstored >= 1.2.0-3.4:**
 


### PR DESCRIPTION
### Update download link to get latest dbx from Microsoft

The link was updated in the secureboot-certs script about six months ago to fetch the latest dbx from Microsoft:

https://github.com/xcp-ng-rpms/varstored/commit/e903bbd96578efb9998300a04eb910ab798381f6

Now, let's also update the link in the Guest UEFI Secure Boot Guide to the latest Microsoft release because currently the UEFI Secure Boot Guide points to an older outdated release of Microsoft's dbx that is hosted on uefi.org which has not been updated with the most recent revoked hashes, and it looks like uefi.org is not going to keep their release of dbx up to date with the latest Microsoft release.



> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
