### PR TITLE
docs(storage): add single-subnet iSCSI multipathing section

### DIFF
--- a/docs/storage/multipathing.md
+++ b/docs/storage/multipathing.md
@@ -186,6 +186,154 @@ If this is not the case:
 #### 3. Configure the SR
 Proceed with the iSCSI SR configuration as indicated in the [storage documentation](../../storage/#iscsi).
 
+### Single-subnet iSCSI multipathing
+
+Use this configuration when your storage array exposes all its target ports on a **single subnet**, for example when separate VLANs or switches are not available. The standard multi-subnet setup described above does not apply here.
+
+:::warning
+This configuration is only supported for storage arrays that expose multiple iSCSI targets through a single subnet. Check your vendor documentation to confirm this is the case before proceeding.
+:::
+
+#### Requirements
+
+* Two different network interfaces on the XCP-ng host, both connected to the same subnet.
+* Multiple target ports on your storage array on the same subnet.
+* Multipathing enabled on the pool (see [Prepare the pool](#2-prepare-the-pool) above).
+
+#### Target architecture
+
+##### Configuration example
+
+| Path | Subnet | XCP-ng Host PIF address | Storage Controller 1 address | Storage Controller 2 address |
+| :---: | :---: | :---: | :---: | :---: |
+| 🔵 | 10.42.1.0/24 | 10.42.1.11 | 10.42.1.101 | 10.42.1.102 |
+| 🟢 | 10.42.1.0/24 | 10.42.1.12 | 10.42.1.101 | 10.42.1.102 |
+
+:::info
+Both paths share the same subnet. Redundancy comes from separate physical NICs and separate storage ports, not from network isolation.
+:::
+
+##### Target architecture diagram
+
+```mermaid
+---
+config:
+  look: normal
+  theme: default
+---
+flowchart LR
+  classDef blueNode fill:#A7C8F0,stroke:#2C6693,color:#000000;
+  classDef greenNode fill:#A8E6A2,stroke:#3E8E41,color:#000000;
+  classDef grayNode fill:#D6D6D6,stroke:#8C8C8C,color:#000000;
+
+  subgraph server[XCP-ng host]
+    direction LR
+    subgraph nics[Network cards]
+      pif1[pif1]
+      pif2[pif2]
+    end
+  end
+
+  subgraph switch[Switch - 10.42.1.0/24]
+    sw[ ]:::grayNode
+  end
+
+  subgraph storage[Storage unit]
+    direction LR
+    subgraph ctrl1[Controller 1]
+      port1[port1]
+    end
+    subgraph ctrl2[Controller 2]
+      port2[port1]
+    end
+    lun1@{ shape: lin-cyl, label: "LUN" }
+  end
+
+  pif1:::blueNode <--> sw
+  pif2:::greenNode <--> sw
+  sw <--> port1:::blueNode
+  sw <--> port2:::greenNode
+  ctrl1 <--> lun1
+  ctrl2 <--> lun1
+
+linkStyle 0 stroke:#4A90E2,stroke-width:2px;
+linkStyle 1 stroke:#5CB85C,stroke-width:2px;
+linkStyle 2 stroke:#4A90E2,stroke-width:2px;
+linkStyle 3 stroke:#5CB85C,stroke-width:2px;
+```
+
+#### Operating procedure
+
+##### 1. Create custom iSCSI interfaces
+
+Connect to the XCP-ng host via SSH and create two custom iSCSI interfaces.
+
+:::warning
+Interface names **must** start with `c_`. Without this prefix, open-iSCSI falls back to single-interface mode and only one path will be used, regardless of how many NICs are configured.
+:::
+
+```bash
+iscsiadm -m iface --op new -I c_iface1
+iscsiadm -m iface --op new -I c_iface2
+```
+
+##### 2. Bind each interface to a network bridge
+
+Replace `xenbr1` and `xenbr2` with the bridge names corresponding to your two iSCSI NICs. You can list available bridges with `ovs-vsctl list-br`.
+
+```bash
+iscsiadm -m iface --op update -I c_iface1 -n iface.net_ifacename -v xenbr1
+iscsiadm -m iface --op update -I c_iface2 -n iface.net_ifacename -v xenbr2
+```
+
+##### 3. Discover targets
+
+Run discovery against one of the storage target IP addresses. This populates the node database for both interfaces.
+
+```bash
+iscsiadm -m discovery -t st -p <IP of storage target>
+```
+
+##### 4. Log in to all targets
+
+```bash
+iscsiadm -m node -L all
+```
+
+Verify that two sessions are established per target:
+
+```bash
+iscsiadm -m session
+```
+
+You should see one session per interface per target portal. Example with two interfaces and two target portals:
+
+```
+tcp: [1] 10.42.1.101:3260,1 iqn.2024-02.com.acme:ultrasan.lun01 (non-flash)
+tcp: [2] 10.42.1.102:3260,1 iqn.2024-02.com.acme:ultrasan.lun01 (non-flash)
+tcp: [3] 10.42.1.101:3260,2 iqn.2024-02.com.acme:ultrasan.lun01 (non-flash)
+tcp: [4] 10.42.1.102:3260,2 iqn.2024-02.com.acme:ultrasan.lun01 (non-flash)
+```
+
+##### 5. Reattach the SR
+
+For multipathing changes to take effect on an existing SR, unplug and replug the PBD. In Xen Orchestra, go to **Storage, your SR, Advanced, Unplug**, then **Plug**. From the host:
+
+```bash
+xe pbd-unplug uuid=<PBD_UUID>
+xe pbd-plug uuid=<PBD_UUID>
+```
+
+Verify multipathing is active:
+
+```bash
+multipath -ll
+```
+
+:::info
+The custom interface definitions are stored in `/var/lib/iscsi/ifaces/` and persist across reboots. If paths do not come back after a reboot, confirm that the bridge names (`xenbr1`, `xenbr2`) still match your current network configuration.
+:::
+
 ## Fibre Channel (HBA)
 ### Requirements
 * Check that the Fibre Channel cards model(s) is supported via the [HCL](../../installation/hardware/#-hardware-compatibility-list-hcl).


### PR DESCRIPTION
## What this adds

A new `### Single-subnet iSCSI multipathing` section in `docs/storage/multipathing.md`, covering the case where all iSCSI target ports sit on a single subnet and separate VLANs or switches are not available.

The existing section already covers the recommended multi-subnet setup. This fills the gap for users who cannot follow that architecture.

## Why it matters

This scenario regularly surfaces on the forum. Users attempt to configure iSCSI multipathing on a single subnet but their configuration reverts on reboot or only one path is used. The root cause is that open-iSCSI requires custom interfaces with a `c_` prefix to enable multi-connection mode on a single subnet. Without documentation, users either give up or apply workarounds that do not survive reboots.

## Reference

The `c_` prefix approach and the core `iscsiadm` sequence are documented for XenServer at:
https://docs.xenserver.com/en-us/xenserver/8/storage/multipath.html#iscsi-multipathing-on-a-single-subnet

The procedure here has been adapted to follow the XCP-ng documentation style, with XCP-ng-specific steps (XAPI PBD commands, OVS bridge names, Mermaid diagram).

## What is covered

- When to use single-subnet vs multi-subnet setup
- Requirements
- Architecture diagram (Mermaid, matching existing style)
- Step-by-step procedure: create ifaces, bind to bridges, discover, login, reattach SR
- Reboot persistence note (ifaces stored in `/var/lib/iscsi/ifaces/`)

## Needs validation

- Correct bridge names for a typical XCP-ng iSCSI PIF setup (`xenbr1`/`xenbr2` assumed)
- Confirmation that iface definitions survive reboots on XCP-ng 8.x
- Adjustment if the target portal count in the session example does not match real-world EqualLogic/similar arrays

---

* [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
* [x] "My contribution complies with the Developer Certificate of Origin [2]."

[1] https://creativecommons.org/licenses/by-sa/2.0/
[2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco