### PR TITLE
updates.md: add critical warning for pool master update order

### DIFF
--- a/docs/management/updates.md
+++ b/docs/management/updates.md
@@ -90,6 +90,12 @@ XCP-ng 8.2 is EOL. This 8.2-specific information is retained solely to assist wi
 
 ## 🚸 Precautions
 
+:::warning
+**Always update the pool master first. Other pool members must never run a higher version than the master.**
+
+If you update any other host before the pool master, **it will lose the ability to connect to the pool master and will become completely unusable**.
+:::
+
 * Disable HA during the whole update process to avoid accidental fencing (automatically handled by [Xen Orchestra RPU](updates.md#from-xen-orchestra))
 * Avoid applying updates while XAPI tasks are running (`xe task-list`).
 * Some updates may probe SCSI devices. If your devices are sensitive to that kind of thing, plug them off before updating (see [this unfortunate story](https://github.com/xcp-ng/xcp/issues/232) of dead tape robots).


### PR DESCRIPTION
This pull request adds a prominent warning to the XCP-ng doc (in the [Management and Backup → Updates → Precautions](https://docs.xcp-ng.org/management/updates/#-precautions) section) regarding the pool update sequence.

As suggested by @Fohdeesha, we emphasize that the pool master must always be updated first, and we clarify that updating a subordinate host before the master will break its connection to the pool, and make that host unusable.