### PR TITLE
Fix broken links in the XCP-ng documentation

### DIFF
--- a/docs/installation/hardware.md
+++ b/docs/installation/hardware.md
@@ -12,7 +12,7 @@ XCP-ng comes with a large range of hardware support.
 A given device may be supported at one of two levels:
 
 1. Presence on the [Hardware Compatibility List](#-hardware-compatibility-list-hcl) guarantees support by XCP-ng. With some exceptions described in the next section.
-2. Many devices outside the HCL are also supported, but are not tested routinely. See [Supported hardware outside the HCL](#-supported-hardware-outside-the-hcl).
+2. Many devices outside the HCL are also supported, but are not tested routinely. See [Supported hardware outside the HCL](#%EF%B8%8F-supported-hardware-outside-the-hcl).
 
 ## 📖 Hardware Compatibility List (HCL)
 

--- a/docs/installation/hardware.md
+++ b/docs/installation/hardware.md
@@ -12,7 +12,7 @@ XCP-ng comes with a large range of hardware support.
 A given device may be supported at one of two levels:
 
 1. Presence on the [Hardware Compatibility List](#-hardware-compatibility-list-hcl) guarantees support by XCP-ng. With some exceptions described in the next section.
-2. Many devices outside the HCL are also supported, but are not tested routinely. See [Supported hardware outside the HCL](#%EF%B8%8F-supported-hardware-outside-the-hcl).
+2. Many devices outside the HCL are also supported, but are not tested routinely. See [Supported hardware outside the HCL](#-supported-hardware-outside-the-hcl).
 
 ## 📖 Hardware Compatibility List (HCL)
 
@@ -20,7 +20,7 @@ XCP-ng 8.3 shares a compatibility list with XenServer 8.4. Thus, devices listed 
 
 Exceptions include devices which require *proprietary* software components to operate (closed source drivers, for example). Such devices do not impede the use of XCP-ng, but their features cannot be exploited.
 
-## ♻️ Supported hardware outside the HCL
+## ♻ Supported hardware outside the HCL
 
 Many devices outside the HCL actually work perfectly with XCP-ng. Contrarily to some hypervisors, XCP-ng does not demand the use of servers from a curated short list. Most of the hardware support depends on the Linux kernel drivers plus vendor drivers covering a very large range of devices.
 

--- a/docs/installation/upgrade.md
+++ b/docs/installation/upgrade.md
@@ -30,7 +30,7 @@ Read the [Release Notes and Known Issues](../../releases#xcp-ng-release-history)
 * DON'T use the `Maintenance Mode` in XCP-ng Center. It moves the pool master to another host, which has to be avoided in the upgrade procedure.
 * If HA (High Availability) is enabled, disable it before upgrading.
 * Eject CDs from your VMs before upgrading [to avoid issues](https://xcp-ng.org/forum/topic/174/upgrade-from-xenserver-7-1-did-not-work): `xe vm-cd-eject --multiple`.
-* Read [Handling alternate drivers or kernel](#%EF%B8%8F-handling-alternate-drivers-or-kernel) if your host depends on them.
+* Read [Handling alternate drivers or kernel](#-handling-alternate-drivers-or-kernel) if your host depends on them.
 * [Update your pool with the latest updates](../../management/updates) **before** upgrading, and reboot or restart the toolstack, depending on the nature of the installed updates.
 * [Install the latest updates](../../management/updates) **after** upgrading.
 :::
@@ -352,7 +352,7 @@ Live migration **should work** from any older XenServer/XCP-ng toward the latest
 
 If a live migration doesn't work, Xen Orchestra is able to do a warm migration for you. It's safer and still have a reasonable downtime. [Read this dedicated article](https://xen-orchestra.com/blog/warm-migration-with-xen-orchestra/) to learn more about it.
 
-## ☣️ Handling alternate drivers or kernel
+## ☣ Handling alternate drivers or kernel
 
 If - before the upgrade - your host depends on [alternate drivers](../../installation/hardware#-alternate-drivers) or on the [alternate kernel](../../installation/hardware#-alternate-kernel) to function, then it is possible that the upgraded system doesn't need such alternatives anymore. It is also possible that it still needs them.
 

--- a/docs/storage/storage.md
+++ b/docs/storage/storage.md
@@ -594,9 +594,9 @@ devices {
 ```
 
 :::warning
-This configuration must be re-applied after each [XCP-NG Upgrade]("https://docs.xcp-ng.org/installation/upgrade/") / reinstall.
+This configuration must be re-applied after each [XCP-NG Upgrade](/installation/upgrade/) / reinstall.
 
-[Updates](https://docs.xcp-ng.org/management/updates/) should not affect the LVM configuration.
+[Updates](/management/updates/) should not affect the LVM configuration.
 :::
 
 Create the CephRBD SR.


### PR DESCRIPTION
In the XCP-ng documentation, an external link enclosed by quotation marks caused builds to fail. Additionally, a malformed internal link caused a warnings at build time.

This pull request fixes both links to ensure the documentation can build flawlessly.

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
