### PR TITLE
Fix link to Wikipedia's FLOSS page

### DIFF
--- a/docs/project/licenses.md
+++ b/docs/project/licenses.md
@@ -2,7 +2,7 @@
 
 XCP-ng is Free Software.
 
-It is built on top of various components including the Linux kernel (GPLv2), Xen (GPLv2, LGPLv2+ or BSD, depending on the components) and many more [F/OSS](https://fr.wikipedia.org/wiki/Free/Libre_Open_Source_Software) components (the license for each is defined in the License tag of each RPM).
+It is built on top of various components including the Linux kernel (GPLv2), Xen (GPLv2, LGPLv2+ or BSD, depending on the components) and many more [F/OSS](https://en.wikipedia.org/wiki/Free/Libre_Open_Source_Software) components (the license for each is defined in the License tag of each RPM).
 
 A file compiling the texts of the licenses is available at [https://github.com/xcp-ng/branding-xcp-ng/blob/master/branding/LICENSES](https://github.com/xcp-ng/branding-xcp-ng/blob/master/branding/LICENSES). For the licenses of a specific release of XCP-ng, use the select box on the top and select the tag that corresponds to the release you are interested it.
 


### PR DESCRIPTION
the link to Wikipedia's FLOSS page was pointing to its french version.
Make it point to its English version.

Signed-off-by: Seb Hinderer <sebastien.hinderer@vates.tech>