### PR TITLE
Add framebuffer workaround for installer black-screen on iGPU/APU hosts

### DIFF
--- a/docs/troubleshooting/installation-upgrade.md
+++ b/docs/troubleshooting/installation-upgrade.md
@@ -9,6 +9,7 @@ Upgrade here designates an upgrade using the installation ISO
   * alternate kernel
   * safe mode
 * Try to boot with the `iommu=0` xen parameter.
+* If the screen goes black and the installer hangs right after GRUB on a machine with only an integrated GPU (for example an AMD Ryzen APU), try the `vga=normal fb=false` kernel parameters to disable the framebuffer.
 
 :::tip
 **How to add or remove boot parameters from command line.**

--- a/docs/troubleshooting/installation-upgrade.md
+++ b/docs/troubleshooting/installation-upgrade.md
@@ -9,6 +9,7 @@ Upgrade here designates an upgrade using the installation ISO
   * alternate kernel
   * safe mode
 * Try to boot with the `iommu=0` xen parameter.
+* If the screen goes black and the installer hangs right after GRUB, try the `vga=normal fb=false` kernel parameters to disable the framebuffer. This is known to be necessary on some machines with integrated graphics only (such as an AMD Ryzen APU), but the full range of affected hardware is not known, so the parameters are worth trying whatever the graphics.
 
 :::tip
 **How to add or remove boot parameters from command line.**


### PR DESCRIPTION
* [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
* [x] "My contribution complies with the Developer Certificate of Origin [2]."

[1] https://creativecommons.org/licenses/by-sa/2.0/
[2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco

## What

Adds one line to the install troubleshooting "If the installer starts booting up then crashes or hangs" section: try `vga=normal fb=false` when the screen goes black right after GRUB on a host with only an integrated GPU.

## Why

A forum user hit a black screen and a hang right after GRUB during install on an AMD Ryzen APU box (integrated GPU only). The section already lists the ISO checksum, safe mode and `iommu=0`, but nothing for the framebuffer case, so there was no next step for it. acebmxer confirmed `vga=normal fb=false` brings the display back.

## Where

`docs/troubleshooting/installation-upgrade.md`, in the existing "crashes or hangs" section right after the `iommu=0` bullet, so it reuses the "how to add boot parameters" tip already there.

Thread: https://xcp-ng.org/forum/topic/12301
