### PR TITLE
Minor clarification in networking.md - Static Routes

### DIFF
--- a/docs/networking/networking.md
+++ b/docs/networking/networking.md
@@ -289,7 +289,7 @@ xe network-param-set uuid=<network UUID> other-config:static-routes=10.88.0.0/14
 ```
 
 :::tip
-You **must** restart the toolstack on the host for the new route to be added!
+You **must** restart the toolstack on **all hosts in the pool** for the new route to be added!
 :::
 
 You can check the result with a `route -n` afterwards to see if the route is now present. If you must add multiple static routes, it must be in one command, and the routes separated by commas. For example, to add both 10.88.0.0/14 via 10.88.113.193 *and* 10.0.0.0/24 via 192.168.1.1, you would use this:
@@ -302,7 +302,7 @@ To **remove** static routes you have added, stick the same network UUID from bef
 ```
 xe network-param-remove uuid=<network UUID> param-key=static-routes param-name=other-config
 ```
-A toolstack restart is needed as before.
+A toolstack restart is needed as before, on all hosts in the pool.
 
 :::tip
 XAPI might not remove the already-installed route until the host is rebooted. If you need to remove it ASAP,  you can use `ip route del 10.88.0.0/14 via 10.88.113.193`. Check that it's gone with `route -n`.


### PR DESCRIPTION
Minor clarification in wording: add/remove routes requires toolstack restart on all pool hosts.



> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
