### PR TITLE
docs(xo-lite.md): clarify management scope from host to pool

### DIFF
--- a/docs/management/manage-locally/xo-lite.md
+++ b/docs/management/manage-locally/xo-lite.md
@@ -4,7 +4,7 @@ sidebar_position: 2
 
 # XO Lite
 
-Xen Orchestra Lite is a lightweight version of the Xen Orchestra meant for single-host administration, running directly from your browser without having to deploy anything, hosted on XCP-ng directly.
+Xen Orchestra Lite is a lightweight version of the Xen Orchestra meant for single-pool administration, running directly from your browser without having to deploy anything, hosted on XCP-ng directly.
 You can access it directly on the default https port, by following this URL pattern: https://[XCP-NGHOSTNAME]OR[XCP-NGIP ADDRESS].
 For example:
 - If my XCP-ng machine has the DNS hostname `mycloud.local`, I will access XO-lite at https://mycloud.local.


### PR DESCRIPTION
This pull request clarifies that XO Lite is designed for single-pool management rather than just single-host administration.

As per @olivierlambert, an instance of XO Lite manages a single XAPI, which can represent either a standalone master host or a cluster/pool containing multiple servers. This aligns the documentation with the [official Vates platform definition](https://vates.tech/fr/plateforme-de-virtualisation/xen-orchestra-lite/).

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
