### PR TITLE
Note that integrated GPUs are not currently supported for passthrough

### DIFF
--- a/docs/compute.md
+++ b/docs/compute.md
@@ -188,6 +188,10 @@ It will be back in the Dom0 after a reboot.
 ## 🎮 GPU Passthrough
 To passthrough a complete graphics card to a VM (not virtualize it into multiple virtual vGPUs, which is different, see the vGPU section below), just follow the regular PCI passthrough instructions, no special steps are needed. Most Nvidia and AMD video cards should work without issue.  
 
+:::warning
+Passthrough of an integrated GPU (for example the iGPU of an AMD APU) is not currently supported. An integrated GPU keeps its option ROM in the motherboard firmware rather than on the card, so there is no ROM to expose to the VM. Work is in progress.
+:::
+
 :::tip
 Previously, Nvidia would block the use of gaming/consumer video cards for passthrough (the Nvidia installer would throw an **Error 43** when installing the driver inside your VM). They lifted this restriction in 2021 with driver R465 and above, so be sure to use the latest driver. [Details from Nvidia here.](https://nvidia.custhelp.com/app/answers/detail/a_id/5173/)
 :::

--- a/docs/compute.md
+++ b/docs/compute.md
@@ -189,7 +189,7 @@ It will be back in the Dom0 after a reboot.
 To passthrough a complete graphics card to a VM (not virtualize it into multiple virtual vGPUs, which is different, see the vGPU section below), just follow the regular PCI passthrough instructions, no special steps are needed. Most Nvidia and AMD video cards should work without issue.  
 
 :::warning
-Passthrough of an integrated GPU (for example the iGPU of an AMD APU) is not currently supported. An integrated GPU keeps its option ROM in the motherboard firmware rather than on the card, so there is no ROM to expose to the VM. Work is in progress.
+Passthrough of an AMD APU's integrated GPU is not currently supported. An integrated GPU keeps its option ROM in the motherboard firmware rather than on the card, so there is no ROM to expose to the VM. Support for this feature is currently under development.
 :::
 
 :::tip


### PR DESCRIPTION
The GPU Passthrough section says most Nvidia and AMD cards work without issue, and doesn't mention integrated GPUs at all. People with an AMD APU hide the iGPU from dom0 successfully, see it in `xl pci-assignable-list`, and only find out it won't work when the VM refuses to start. That's a few reboots spent before the wall.

The reason is that an integrated GPU keeps its option ROM in the motherboard firmware rather than on the card, so there's no ROM to hand the guest.

This came up again on the forum: https://xcp-ng.org/forum/topic/12330 (Ryzen 9 7900).

Two deliberate choices in the wording, happy to be overruled on either:

- "not currently supported" rather than "not capable" — virtio GPU is the real path here, so a flat "not capable" would age badly.
- no issue link. I first thought this was tracked in xcp-ng/xcp#806, but having read it, #806 is about the lack of a per-device `romfile` on xen-pci-passthrough and never mentions iGPUs. As far as I can tell the ongoing work has no public ticket, so linking anything would point readers somewhere that looks stalled.
