### PR TITLE
[depends on #514] Document NTP as the canonical clock reference, with yum "HTTPS Error 301" as one symptom

### DIFF
--- a/docs/management/hosts-pools.md
+++ b/docs/management/hosts-pools.md
@@ -192,6 +192,14 @@ Lost the root password? See the [reset procedure](../troubleshooting/common-prob
 
 Correct and consistent clocks across the pool matter more than on ordinary servers: XAPI coordination, live migration, HA heartbeats, logs correlation and Windows guests (which get their initial time from the host) all rely on it. NTP servers are normally configured at [installation time](../installation/install-xcp-ng.md).
 
+A wrong date rarely fails where you would expect. It usually surfaces as an error that names something else:
+
+* Repository access stops working. Repositories are served over HTTPS, and a host whose date falls outside the mirror's certificate validity period cannot complete the TLS handshake. `yum` reports the redirect it followed instead of the certificate: see [yum fails with "HTTPS Error 301 - Moved Permanently"](../troubleshooting/common-problems.md#yum-fails-with-https-error-301---moved-permanently).
+* The installer refuses the repository keys, with `Signature Key Import Failed`.
+* Hosts that disagree on the time cause problems across the pool, from live migration to HA.
+
+### Configuring the NTP servers {#configuring-the-ntp-servers}
+
 To change them afterwards on XCP-ng 8.3, edit `/etc/chrony.conf`, then:
 
 <Terminal shell title="Time synchronization (NTP)">{`
@@ -200,6 +208,41 @@ chronyc sources
 `}</Terminal>
 
 On XCP-ng 8.2, the NTP daemon is `ntpd`: edit `/etc/ntp.conf`, then `systemctl restart ntpd` and check with `ntpq -p`. In both cases, `xsconsole` also offers an NTP configuration menu under **Network and Management Interface**.
+
+### Correcting a wrong clock {#correcting-a-wrong-clock}
+
+Check the sources before anything else. `chronyd` can be both running and enabled while having **no time source configured at all**, which is what happens when the date was set manually during installation:
+
+<Terminal shell title="root@xcp-ng-host — Check the clock and its sources">{`
+date
+systemctl status chronyd
+chronyc sources
+`}</Terminal>
+
+`210 Number of sources = 0` means the service is working exactly as configured, and doing nothing. Add time sources to `/etc/chrony.conf`:
+
+```
+server 0.centos.pool.ntp.org iburst
+server 1.centos.pool.ntp.org iburst
+server 2.centos.pool.ntp.org iburst
+server 3.centos.pool.ntp.org iburst
+```
+
+On an isolated network, use a local time source instead of the public pool. Then restart chronyd and confirm a source is reachable: in `chronyc sources`, a line whose second column is `*` or `+`, not `?`.
+
+With a reachable source, step the clock and check the result:
+
+<Terminal shell title="root@xcp-ng-host — Step the clock">{`
+chronyc makestep
+date
+`}</Terminal>
+
+`chronyc makestep` is needed because chrony corrects an offset by slewing the clock gradually by default, which never converges for an offset of months or years. It does nothing useful while there are no sources: it reports success and moves the clock nowhere, having no measured offset to step to.
+
+:::note
+* There is no need to copy the corrected time to the hardware clock by hand. The shipped `/etc/chrony.conf` enables `rtcsync`, so chronyd keeps the hardware clock in step and the correction survives a reboot.
+* If `date` is wrong again after every power cycle, the motherboard's RTC battery is probably dead and should be replaced.
+:::
 
 ## 🔌 Remote host power-on {#remote-host-power-on}
 

--- a/docs/management/hosts-pools.md
+++ b/docs/management/hosts-pools.md
@@ -192,13 +192,7 @@ Lost the root password? See the [reset procedure](../troubleshooting/common-prob
 
 Correct and consistent clocks across the pool matter more than on ordinary servers: XAPI coordination, live migration, HA heartbeats, logs correlation and Windows guests (which get their initial time from the host) all rely on it. NTP servers are normally configured at [installation time](../installation/install-xcp-ng.md).
 
-A wrong date rarely fails where you would expect. It usually surfaces as an error that names something else:
-
-* Repository access stops working. Repositories are served over HTTPS, and a host whose date falls outside the mirror's certificate validity period cannot complete the TLS handshake. `yum` reports the redirect it followed instead of the certificate: see [yum fails with "HTTPS Error 301 - Moved Permanently"](../troubleshooting/common-problems.md#yum-fails-with-https-error-301---moved-permanently).
-* The installer refuses the repository keys, with `Signature Key Import Failed`.
-* Hosts that disagree on the time cause problems across the pool, from live migration to HA.
-
-### Configuring the NTP servers {#configuring-the-ntp-servers}
+See [Time synchronization](time-synchronization.md) for what a wrong clock breaks, how to check whether `chronyd` has any time sources, and how to correct a clock that is already wrong.
 
 To change them afterwards on XCP-ng 8.3, edit `/etc/chrony.conf`, then:
 
@@ -208,41 +202,6 @@ chronyc sources
 `}</Terminal>
 
 On XCP-ng 8.2, the NTP daemon is `ntpd`: edit `/etc/ntp.conf`, then `systemctl restart ntpd` and check with `ntpq -p`. In both cases, `xsconsole` also offers an NTP configuration menu under **Network and Management Interface**.
-
-### Correcting a wrong clock {#correcting-a-wrong-clock}
-
-Check the sources before anything else. `chronyd` can be both running and enabled while having **no time source configured at all**, which is what happens when the date was set manually during installation:
-
-<Terminal shell title="root@xcp-ng-host — Check the clock and its sources">{`
-date
-systemctl status chronyd
-chronyc sources
-`}</Terminal>
-
-`210 Number of sources = 0` means the service is working exactly as configured, and doing nothing. Add time sources to `/etc/chrony.conf`:
-
-```
-server 0.centos.pool.ntp.org iburst
-server 1.centos.pool.ntp.org iburst
-server 2.centos.pool.ntp.org iburst
-server 3.centos.pool.ntp.org iburst
-```
-
-On an isolated network, use a local time source instead of the public pool. Then restart chronyd and confirm a source is reachable: in `chronyc sources`, a line whose second column is `*` or `+`, not `?`.
-
-With a reachable source, step the clock and check the result:
-
-<Terminal shell title="root@xcp-ng-host — Step the clock">{`
-chronyc makestep
-date
-`}</Terminal>
-
-`chronyc makestep` is needed because chrony corrects an offset by slewing the clock gradually by default, which never converges for an offset of months or years. It does nothing useful while there are no sources: it reports success and moves the clock nowhere, having no measured offset to step to.
-
-:::note
-* There is no need to copy the corrected time to the hardware clock by hand. The shipped `/etc/chrony.conf` enables `rtcsync`, so chronyd keeps the hardware clock in step and the correction survives a reboot.
-* If `date` is wrong again after every power cycle, the motherboard's RTC battery is probably dead and should be replaced.
-:::
 
 ## 🔌 Remote host power-on {#remote-host-power-on}
 

--- a/docs/management/time-synchronization.md
+++ b/docs/management/time-synchronization.md
@@ -4,17 +4,17 @@ sidebar_position: 8
 
 # Time synchronization
 
-XCP-ng keeps the dom0 clock with `chronyd`. A host whose date is wrong carries on working
-normally until something needs to trust that date, and the failures it produces then rarely
-mention time at all. This page covers why the clock matters, how to configure NTP, and how
-to check and correct it.
+XCP-ng keeps the dom0 clock synchronized using `chronyd`. A host whose date is wrong keeps
+working normally until something needs to trust that date. When that happens, the resulting
+failures rarely point to the clock as the cause. This page explains why the clock matters, how
+to configure NTP, and how to check and correct it.
 
 ## ⏰ Why the clock must be correct {#why-the-clock-must-be-correct}
 
 - **Access to the repositories.** Updates are fetched over HTTPS, and TLS validates the
-  server's certificate against the host's own date. A host set far in the past cannot
-  complete the handshake, because from where it is standing the mirror's certificate is not
-  valid yet. The error `yum` prints in that situation does not mention time.
+  server's certificate against the host's own date. If the host's clock is set too far in the
+  past, the TLS handshake fails because, from the host's perspective, the mirror's certificate
+  is not yet valid. The error `yum` prints in that situation does not mention time.
 - **Pool membership.** A host joining a pool must have its clock synchronized with the pool
   master. See [Pool Requirements](../../installation/requirements#pool-requirements).
 - **Certificates.** Certificates are only valid inside a validity window. A host whose date
@@ -28,16 +28,16 @@ to check and correct it.
 
 The time daemon on dom0 is `chronyd`, configured through `/etc/chrony.conf`.
 
-The shipped configuration enables `rtcsync`, so chronyd keeps the hardware clock in step
-with the system clock on its own. There is no need to copy a corrected time to the hardware
-clock by hand, and a correction survives a reboot.
+The default configuration enables `rtcsync`, allowing chronyd to keep the hardware clock
+synchronized with the system clock automatically. There is no need to manually update the
+hardware clock after correcting the system time, and the correction persists across reboots.
 
 ## 🔧 Configuring the time sources {#configuring-the-time-sources}
 
 ### During installation
 
-The installer asks for the timezone and the time at step 11, and lets you either give it NTP
-servers or set the time manually. Always give it an NTP server. See
+At step 11, the installer prompts you to enter the time, select a time zone and either
+configure NTP servers or set the time manually. Always configure at least one NTP server. See
 [Install XCP-ng](../../installation/install-xcp-ng).
 
 :::warning
@@ -73,13 +73,17 @@ enabled while having **no time sources configured at all**:
 210 Number of sources = 0
 ```
 
-The service is then behaving exactly as configured, and doing nothing. Every other check an
+Then, the service behaves exactly as configured, and does nothing. Every other check an
 operator would normally run looks healthy, which is what makes this one worth running early
 rather than late.
 
 When sources are configured, `chronyc sources` lists them. In the `MS` column, the second
-character is the state of that source: `*` marks the one currently being used, `+` marks
-another acceptable source being combined with it, and `?` means the source is unreachable.
+character is the state of that source:
+
+- `*` marks the one currently being used.
+- `+` marks another acceptable source being combined with it.
+- `?` means the source is unreachable.
+
 At least one source should reach the `*` state.
 
 To see the offset chrony believes it has, and whether it has settled:
@@ -102,35 +106,37 @@ chronyc makestep
 date
 ```
 
-`chronyc makestep` is what does the work here. By default chrony corrects an offset by
-slewing the clock gradually, which never converges for an offset of months or years.
+`chronyc makestep` is what does the work here. By default, chrony corrects time offsets by
+gradually slewing the system clock, which never converges for an offset of months or years.
 
 ### If `Number of sources = 0`
 
 Do not start with `makestep`. It will report success and move nothing, because chrony has no
-measured offset to step to. Add time sources to `/etc/chrony.conf` first:
+measured offset to step to.
 
-```
-server 0.centos.pool.ntp.org iburst
-server 1.centos.pool.ntp.org iburst
-server 2.centos.pool.ntp.org iburst
-server 3.centos.pool.ntp.org iburst
-```
+1. Add time sources to `/etc/chrony.conf`:
 
-Then restart the service and confirm that a source has become reachable, as described in
-[Checking the time sources](#checking-the-time-sources):
+   ```
+   server 0.pool.ntp.org iburst
+   server 1.pool.ntp.org iburst
+   server 2.pool.ntp.org iburst
+   server 3.pool.ntp.org iburst
+   ```
 
-```bash
-systemctl restart chronyd
-chronyc sources
-```
+2. Restart the service and confirm that a source has become reachable, as described in
+   [Checking the time sources](#checking-the-time-sources):
 
-Once a source is reachable, correct the clock:
+   ```bash
+   systemctl restart chronyd
+   chronyc sources
+   ```
 
-```bash
-chronyc makestep
-date
-```
+3. Once a source is reachable, correct the clock:
+
+   ```bash
+   chronyc makestep
+   date
+   ```
 
 :::note
 Correcting the date does not invalidate the host's own certificate. XAPI issues it with a
@@ -146,16 +152,15 @@ host is running; it cannot help a clock that loses its value when the power goes
 
 ## 🌐 Isolated networks {#isolated-networks}
 
-Hosts without access to the internet cannot reach the public NTP pool, and the symptom is
-the same as having no sources at all: `chronyc sources` lists servers that never leave the
-`?` state.
+Hosts without Internet access cannot reach the public NTP pool. The result is the same as
+having no sources at all: `chronyc sources` lists servers that never leave the `?` state.
 
-On such a network, point `/etc/chrony.conf` at a time source that hosts can actually reach,
+On such networks, point `/etc/chrony.conf` at a time source that hosts can actually reach,
 such as an appliance on the same network or a local server that is itself synchronized.
 
 ## 🎱 Pools {#pools}
 
 Keep every host in a pool synchronized, ideally against the same sources. A host whose clock
-disagrees with the pool master is not merely inconvenient: clock synchronization is one of
-the requirements for joining a pool in the first place, alongside the others listed in
+differs from the pool master is not just inconvenient: clock synchronization is one of
+the requirements for joining a pool, along with the other requirements listed in
 [Pool Requirements](../../installation/requirements#pool-requirements).

--- a/docs/management/time-synchronization.md
+++ b/docs/management/time-synchronization.md
@@ -150,13 +150,14 @@ dead and should be replaced. `rtcsync` can only keep the hardware clock in step 
 host is running; it cannot help a clock that loses its value when the power goes.
 :::
 
-## 🌐 Isolated networks {#isolated-networks}
+## 🌐 Networks without internet access {#networks-without-internet-access}
 
 Hosts without Internet access cannot reach the public NTP pool. The result is the same as
 having no sources at all: `chronyc sources` lists servers that never leave the `?` state.
 
-On such networks, point `/etc/chrony.conf` at a time source that hosts can actually reach,
-such as an appliance on the same network or a local server that is itself synchronized.
+On such networks, point `/etc/chrony.conf` to a time source that hosts can actually reach,
+such as an appliance on the same network, or a local server that is itself synchronized and
+acts as the reference time for the network.
 
 ## 🎱 Pools {#pools}
 

--- a/docs/management/time-synchronization.md
+++ b/docs/management/time-synchronization.md
@@ -1,0 +1,161 @@
+---
+sidebar_position: 8
+---
+
+# Time synchronization
+
+XCP-ng keeps the dom0 clock with `chronyd`. A host whose date is wrong carries on working
+normally until something needs to trust that date, and the failures it produces then rarely
+mention time at all. This page covers why the clock matters, how to configure NTP, and how
+to check and correct it.
+
+## ⏰ Why the clock must be correct {#why-the-clock-must-be-correct}
+
+- **Access to the repositories.** Updates are fetched over HTTPS, and TLS validates the
+  server's certificate against the host's own date. A host set far in the past cannot
+  complete the handshake, because from where it is standing the mirror's certificate is not
+  valid yet. The error `yum` prints in that situation does not mention time.
+- **Pool membership.** A host joining a pool must have its clock synchronized with the pool
+  master. See [Pool Requirements](../../installation/requirements#pool-requirements).
+- **Certificates.** Certificates are only valid inside a validity window. A host whose date
+  falls outside that window will reject, or be rejected by, connections that would otherwise
+  succeed.
+- **Logs and scheduled operations.** Correlating events across the hosts of a pool, and
+  anything that runs on a schedule such as backups, depend on the hosts agreeing on what
+  time it is.
+
+## 🕰️ How XCP-ng keeps time {#how-xcp-ng-keeps-time}
+
+The time daemon on dom0 is `chronyd`, configured through `/etc/chrony.conf`.
+
+The shipped configuration enables `rtcsync`, so chronyd keeps the hardware clock in step
+with the system clock on its own. There is no need to copy a corrected time to the hardware
+clock by hand, and a correction survives a reboot.
+
+## 🔧 Configuring the time sources {#configuring-the-time-sources}
+
+### During installation
+
+The installer asks for the timezone and the time at step 11, and lets you either give it NTP
+servers or set the time manually. Always give it an NTP server. See
+[Install XCP-ng](../../installation/install-xcp-ng).
+
+:::warning
+If you set the time manually at this step, the host can end up with `chronyd` running but no
+time source configured at all. It will keep whatever date it was installed with. See
+[Checking the time sources](#checking-the-time-sources) below.
+:::
+
+### During an automated installation
+
+The installation answer file accepts one or more NTP servers through the `<ntp-server>`
+element. See [Answer file](../../appendix/answerfile).
+
+### On an installed host
+
+You can configure NTP from `xsconsole`, or by editing `/etc/chrony.conf` directly and
+restarting the service.
+
+## 🔍 Checking the time sources {#checking-the-time-sources}
+
+Check that the service is running, and that it actually has something to synchronize with:
+
+```bash
+systemctl status chronyd
+chronyc sources
+```
+
+Both matter, and the second is the one that gets skipped. `chronyd` can be running and
+enabled while having **no time sources configured at all**:
+
+```
+# chronyc sources
+210 Number of sources = 0
+```
+
+The service is then behaving exactly as configured, and doing nothing. Every other check an
+operator would normally run looks healthy, which is what makes this one worth running early
+rather than late.
+
+When sources are configured, `chronyc sources` lists them. In the `MS` column, the second
+character is the state of that source: `*` marks the one currently being used, `+` marks
+another acceptable source being combined with it, and `?` means the source is unreachable.
+At least one source should reach the `*` state.
+
+To see the offset chrony believes it has, and whether it has settled:
+
+```bash
+chronyc tracking
+```
+
+## 🛠️ Correcting a wrong clock {#correcting-a-wrong-clock}
+
+Start with `chronyc sources`, because the answer decides which of the two paths below
+applies.
+
+### If sources are listed
+
+Correct the clock and check the result:
+
+```bash
+chronyc makestep
+date
+```
+
+`chronyc makestep` is what does the work here. By default chrony corrects an offset by
+slewing the clock gradually, which never converges for an offset of months or years.
+
+### If `Number of sources = 0`
+
+Do not start with `makestep`. It will report success and move nothing, because chrony has no
+measured offset to step to. Add time sources to `/etc/chrony.conf` first:
+
+```
+server 0.centos.pool.ntp.org iburst
+server 1.centos.pool.ntp.org iburst
+server 2.centos.pool.ntp.org iburst
+server 3.centos.pool.ntp.org iburst
+```
+
+Then restart the service and confirm that a source has become reachable, as described in
+[Checking the time sources](#checking-the-time-sources):
+
+```bash
+systemctl restart chronyd
+chronyc sources
+```
+
+Once a source is reachable, correct the clock:
+
+```bash
+chronyc makestep
+date
+```
+
+:::note
+Correcting the date does not invalidate the host's own certificate. XAPI issues it with a
+ten-year validity, so a host installed with a wrong date still holds a certificate that
+covers the corrected date. `xe host-refresh-server-certificate` is not needed for this.
+:::
+
+:::tip
+If `date` is wrong again after every power cycle, the motherboard's RTC battery is probably
+dead and should be replaced. `rtcsync` can only keep the hardware clock in step while the
+host is running; it cannot help a clock that loses its value when the power goes.
+:::
+
+## 🌐 Isolated networks {#isolated-networks}
+
+Hosts without access to the internet cannot reach the public NTP pool, and the symptom is
+the same as having no sources at all: `chronyc sources` lists servers that never leave the
+`?` state.
+
+On such a network, point `/etc/chrony.conf` at a time source that hosts can actually reach,
+such as an appliance on the same network or a local server that is itself synchronized.
+
+## 🎱 Pools {#pools}
+
+Keep every host in a pool synchronized, ideally against the same sources. A host whose clock
+disagrees with the pool master is not merely inconvenient: clock synchronization is one of
+the requirements for joining a pool in the first place, alongside the others listed in
+[Pool Requirements](../../installation/requirements#pool-requirements).

--- a/docs/management/updates.md
+++ b/docs/management/updates.md
@@ -28,6 +28,10 @@ If your version is lower than `8.3`, it will not receive updates anymore. To kee
 
 Your dom0 system must either have access to the internet, or to a local mirror. In the second case, make sure to update the `baseurl` values in `/etc/yum.repos.d/xcp-ng.repo` to make them point at the local mirror, and keep the mirror regularly synced.
 
+:::warning
+The host clock must also be correct. Repository access uses HTTPS, and a host whose date is wrong cannot validate the mirrors' TLS certificates. The error `yum` reports in that case is misleading, because it names a redirect instead of the certificate: see [yum fails with "HTTPS Error 301 - Moved Permanently"](../../troubleshooting/common-problems#yum-fails-with-https-error-301---moved-permanently).
+:::
+
 #### Proxy configuration
 
 If your hosts require a proxy to access the repositories, you have several options depending on your needs:

--- a/docs/troubleshooting/common-problems.md
+++ b/docs/troubleshooting/common-problems.md
@@ -119,6 +119,60 @@ chmod +x /etc/rc.d/rc.local
 
 ---
 
+## 📦 yum fails with "HTTPS Error 301 - Moved Permanently" {#yum-fails-with-https-error-301---moved-permanently}
+
+Every `yum` command on dom0 fails, most often on a freshly installed host:
+
+```
+Loaded plugins: fastestmirror
+ * xcp-ng-base: mirrors.xcp-ng.org
+http://mirrors.xcp-ng.org/8/8.3/base/x86_64/repodata/repomd.xml: [Errno 14] HTTPS Error 301 - Moved Permanently
+Trying other mirror.
+...
+failure: repodata/repomd.xml from xcp-ng-base: [Errno 256] No more mirrors to try.
+```
+
+### Cause
+
+In almost every reported case, **the system clock on dom0 is wrong**, usually set far in the past.
+
+`mirrors.xcp-ng.org` redirects HTTP to HTTPS, then to a mirror close to you. That redirect is normal and is not the problem. But if the host's date is earlier than the start of the mirror's TLS certificate validity period, the HTTPS connection cannot be established: from the host's point of view, the certificate is not yet valid.
+
+The message names the redirect rather than the certificate because of the way `yum` reports errors. When a transfer fails *after* a redirect, it prints the redirect's status code and discards the underlying error. The `301` is genuine, and it is the last thing that succeeded.
+
+To confirm the diagnosis before changing anything, you can temporarily change the repository URL in `/etc/yum.repos.d/xcp-ng.repo` from `http://` to `https://`. This does not fix the download, but it removes the redirect, so `yum` reports the real error:
+
+```
+https://mirrors.xcp-ng.org/8/8.3/base/x86_64/repodata/repomd.xml: [Errno 14] curl#60 - "SSL certificate problem: certificate is not yet valid"
+```
+
+### Solution
+
+Check the date on dom0:
+
+<Terminal shell title="root@xcp-ng-host — Check the date">{`
+date
+`}</Terminal>
+
+If it is wrong, fix the time synchronization: see [Time synchronization (NTP)](../management/hosts-pools.md#time-synchronization-ntp) for how to check the chrony sources and step the clock. On a host whose date was set manually at installation, `chronyd` is often running with no time source at all, and correcting the clock then takes an extra step.
+
+Once the clock is correct:
+
+<Terminal shell title="root@xcp-ng-host — Solution">{`
+yum clean all
+yum check-update
+`}</Terminal>
+
+:::tip
+Revert any change you made to `/etc/yum.repos.d/xcp-ng.repo` while investigating. With a correct clock, the default `http://mirrors.xcp-ng.org` URL works. Pinning a single mirror by hand takes the host out of the automatic mirror selection, and out of failover if that mirror becomes unavailable. See [Mirrors](../project/mirrors.md).
+:::
+
+:::note
+Correcting the date does not invalidate the host's own certificate. XAPI issues it with a ten-year validity, so a host installed with a wrong date still holds a certificate that covers the corrected date. `xe host-refresh-server-certificate` is not needed here.
+:::
+
+---
+
 ## 🐌 Async Tasks/Commands Hang or Execute Extremely Slowly {#async-taskscommands-hang-or-execute-extremely-slowly}
 
 ### Cause

--- a/docs/troubleshooting/common-problems.md
+++ b/docs/troubleshooting/common-problems.md
@@ -154,7 +154,7 @@ Check the date on dom0:
 date
 `}</Terminal>
 
-If it is wrong, fix the time synchronization: see [Time synchronization (NTP)](../management/hosts-pools.md#time-synchronization-ntp) for how to check the chrony sources and step the clock. On a host whose date was set manually at installation, `chronyd` is often running with no time source at all, and correcting the clock then takes an extra step.
+If it is wrong, fix the time synchronization: see [Time synchronization](../management/time-synchronization.md#correcting-a-wrong-clock) for how to check the chrony sources and step the clock. On a host whose date was set manually at installation, `chronyd` is often running with no time source at all, and correcting the clock then takes an extra step.
 
 Once the clock is correct:
 
@@ -163,7 +163,7 @@ yum clean all
 yum check-update
 `}</Terminal>
 
-:::tip
+:::warning
 Revert any change you made to `/etc/yum.repos.d/xcp-ng.repo` while investigating. With a correct clock, the default `http://mirrors.xcp-ng.org` URL works. Pinning a single mirror by hand takes the host out of the automatic mirror selection, and out of failover if that mirror becomes unavailable. See [Mirrors](../project/mirrors.md).
 :::
 


### PR DESCRIPTION
> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]."
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco

> [!IMPORTANT]
> **Stacked on #514, and should be merged after it.** The first commit here is that PR's
> `docs/management/time-synchronization.md` page, so the diff shows it too. It cannot be
> left out: `onBrokenLinks` is `throw`, and this PR links to that page. Once #514 merges,
> a rebase drops it from this diff. Review the last two commits.
>
> This replaces the earlier approach of expanding the NTP section in `hosts-pools.md`.
> @stormi asked for the clock details to live in one place with the yum topic linking to
> it, and that is the page in #514, so the material moved there rather than being written
> twice. `hosts-pools.md` keeps its short section and gains a link.

Adds the troubleshooting entry @olivierlambert asked for in https://xcp-ng.org/forum/topic/11558 back in November 2025:

> Classic 🙂 Maybe we should even provide a documentation about this in our troubleshooting section

The symptom is this, and it is one of the first things a fresh install can throw at someone:

```
http://mirrors.xcp-ng.org/8/8.3/base/x86_64/repodata/repomd.xml: [Errno 14] HTTPS Error 301 - Moved Permanently
Trying other mirror.
...
failure: repodata/repomd.xml from xcp-ng-base: [Errno 256] No more mirrors to try.
```

Read as an operator, that says our mirrors moved and the repo file is stale. So people edit `xcp-ng.repo`, run `yum clean all`, wipe `/var/cache/yum`, and none of it helps.

**The mirrors are fine.** `mirrors.xcp-ng.org` → HTTPS → geo-local mirror ends in a 200; `curl -L` walks it happily. What fails is the TLS leg. A host whose date precedes the mirror certificate's `notBefore` cannot complete the handshake, because from where it is standing the certificate is not yet valid.

The message blames the redirect because of how yum reports errors. In urlgrabber, `_hdr_retrieve` rewrites `self.scheme`/`self.url` the moment it sees a `Location:` header, before anything is attempted at the new address; the `pycurl.error` handler then formats from `RESPONSE_CODE`, which is still `301` from the hop that succeeded, and drops the real libcurl string. So the `301` you are shown is the last thing that went *right*. Generally: in yum, a transport failure after a redirect is reported as the redirect.

### Why it seems worth a page rather than a forum answer

https://xcp-ng.org/forum/topic/9560 is the same symptom on 8.2, from 2024, and it ends with nobody knowing. That is the thread search returns for this error string. Meanwhile 11558 was solved by the reporter themselves, so it never became a support exchange either. Two threads, no landing page.

### One thing I had not seen before, included in the page

On the host I looked at, `chronyd` was **both running and enabled**, network and DNS fine, and this was the whole of `/etc/chrony.conf`:

```
driftfile /var/lib/chrony/drift
makestep 1.0 3
rtcsync
logdir /var/log/chrony
```

No `server`, no `pool`. `chronyc sources` returned `Number of sources = 0`. Every check an operator would normally run comes back healthy; the only one that reveals it is `chronyc sources`, which nobody runs until they already suspect the clock. The host just keeps its installation date, and the first symptom shows up months later as a yum error about a redirect. Likely origin is setting the time manually at install.

That is also why the page says to add the servers to `chrony.conf`, not merely to run `makestep` — otherwise the fix is lost at the next boot.

### Changes

- `docs/management/hosts-pools.md`: the existing **Time synchronization (NTP)** section becomes the reference for clocks: what a wrong date actually breaks, how to configure the servers, and how to check the sources and step the clock. Two sub-headings so the troubleshooting entries can link straight at the fix.
- `docs/troubleshooting/common-problems.md`: new section for the yum error, placed next to the existing **Server loses time on 14th gen Dell hardware** entry so the two clock problems sit together. It carries the diagnosis and the `301` explanation, and hands off to the NTP section for the fix.
- `docs/management/updates.md`: a warning under **Prerequisites → Access to the repository**, since that is the page people are reading when they hit this.

### Checked

- Verified absent before writing: no page under `docs/` contained `301`, `Moved Permanently` or `certificate is not yet valid`.
- Anchor `#yum-fails-with-https-error-301---moved-permanently` generated with the repo's own `github-slugger`, not guessed.
- `npm run build` passes, which matters here because `onBrokenLinks` and `onBrokenAnchors` are both set to `throw`, and this PR now crosses between three pages.
- Fix verified end to end on a host that was stuck on 2024-09-08: after correcting the clock, `yum check-update` returned the full July 2026 #1 batch for 8.3 LTS, exit 0, **with the repository file exactly as shipped**.

### Updated after review

- @stormi asked for one place that covers NTP properly, with this topic linking to it for details. The chrony material moved into **Time synchronization (NTP)** in `hosts-pools.md`, which already existed and was thin. It now opens with why a wrong clock matters, including two symptoms that name something other than the clock: this `301`, and the installer's `Signature Key Import Failed`.
- @thomas-dkmt asked for one note with bullets instead of two notes. Both of those notes turned out to be generic clock facts, so they moved to the NTP section and are a single bulleted note there. The yum entry keeps one note.
- Command blocks now use `<Terminal>` like the rest of these files. Error output stays in plain fences.
- Rebased on master, and the four commits are squashed into one since the content was restructured anyway.

### One thing I would still like a second opinion on

I state that correcting the date does not invalidate the host's own certificate, since XAPI issues it with a ten-year validity. Checked on one host (`notBefore` 2026-06-10, `notAfter` 2036-06-07). Worth someone confirming that is the rule and not that host's history.

Separately, and out of scope here: should the installer or `xsconsole` warn when a host ends up with zero configured time sources? Happy to open that somewhere else if it is worth raising.


