### PR TITLE
Explain that autostart has no start order, and where order and start-delay apply

### DIFF
--- a/docs/guides/autostart-vm.md
+++ b/docs/guides/autostart-vm.md
@@ -39,7 +39,7 @@ xe vm-list
 5. Checking the output
 `# xe vm-param-list uuid=<VM_UUID> | grep other-config`
 
-## 🔢 Start order and delays {#start-order-and-delays}
+## Start order and delays {#start-order-and-delays}
 
 Autostart does not define a startup order. All VMs flagged for autostart are started when the
 host boots, in a single bulk call that never reads the `order` parameter, so you cannot choose

--- a/docs/guides/autostart-vm.md
+++ b/docs/guides/autostart-vm.md
@@ -45,7 +45,7 @@ Autostart does not define a startup order. All VMs flagged for autostart are sta
 host boots, in a single bulk call that never reads the `order` parameter, so you cannot choose
 which VM starts first.
 
-They are started one after another rather than all at once, so a `start-delay` on one VM does
+VMs are started one after another rather than all at once, so a `start-delay` on one VM does
 hold up the ones behind it. That spaces a boot out, but it does not sequence it, because which
 VMs end up behind the delay is not something you control.
 
@@ -78,8 +78,8 @@ let HA restart it after a failover.
 `start-delay` has been reported to interfere with autostart: one user found a VM that would
 not start at boot until the parameter was cleared
 ([forum thread](https://xcp-ng.org/forum/topic/12388)). A delayed start does hold up the VMs
-queued behind it, which explains one coming up late, but not one that never comes up at all.
-That part is unexplained. If a VM does not appear after a host reboot, checking its
-`start-delay` value, and waiting to see whether it is merely queued behind another VM's delay,
-are both worth doing.
+queued behind it, so it explains a VM coming up late. A VM that stays down for good is a
+different matter, and that part is unexplained. If a VM does not appear after a host reboot,
+it is worth checking its `start-delay` value and waiting to see whether it is simply queued
+behind another VM's delay.
 :::

--- a/docs/guides/autostart-vm.md
+++ b/docs/guides/autostart-vm.md
@@ -42,14 +42,20 @@ xe vm-list
 ## 🔢 Start order and delays {#start-order-and-delays}
 
 Autostart does not define a startup order. All VMs flagged for autostart are started when the
-host boots, so there is no way to sequence them.
+host boots, in a single bulk call that never reads the `order` parameter, so you cannot choose
+which VM starts first.
 
-To define a startup order or add delays, use [vApps](../vms/vm-lifecycle.md#vapps) instead.
-Two VM parameters apply when an appliance is started, and after an HA failover:
+They are started one after another rather than all at once, so a `start-delay` on one VM does
+hold up the ones behind it. That spaces a boot out, but it does not sequence it, because which
+VMs end up behind the delay is not something you control.
+
+To define a startup order, use [vApps](../vms/vm-lifecycle.md#vapps) instead. Two VM parameters
+apply when an appliance is started, and after an HA failover:
 
 - `order` sets the relative order in which the appliance's VMs start, lower values first.
 - `start-delay` specifies a delay in seconds. A call to start the VM does not return until the
-  delay has elapsed, so in a sequential appliance start the next VM waits that much longer.
+  delay has elapsed, so in a sequential appliance start the next VM waits that much longer. The
+  VM it is set on is already running by then. It is the call that waits, not the VM.
 
 <Terminal title="root@xcp-ng-host — Start order and delays">{`
 xe vm-param-set uuid=<VM_UUID> order=1
@@ -60,11 +66,20 @@ The parameter is `order`. `start-order` is rejected as an unknown field, and
 `other-config:start_order` is accepted without doing anything at all, since `other-config`
 holds arbitrary keys.
 
+:::warning
+An appliance is not started when the host boots. Nothing in the boot sequence calls
+`appliance-start`, so grouping VMs into an appliance does not on its own bring them up after a
+reboot. They also need `other-config:auto_poweron`, and once they have it they take the
+autostart path above, which ignores `order`. Start an appliance with `xe appliance-start`, or
+let HA restart it after a failover.
+:::
+
 :::note
 `start-delay` has been reported to interfere with autostart: one user found a VM that would
 not start at boot until the parameter was cleared
-([forum thread](https://xcp-ng.org/forum/topic/12388)). The delay does hold the start call
-open, which is measurable, but whether that is what kept the VM from starting has not been
-established. If a VM does not come up after a host reboot, checking its `start-delay` value
-is a simple troubleshooting step.
+([forum thread](https://xcp-ng.org/forum/topic/12388)). A delayed start does hold up the VMs
+queued behind it, which explains one coming up late, but not one that never comes up at all.
+That part is unexplained. If a VM does not appear after a host reboot, checking its
+`start-delay` value, and waiting to see whether it is merely queued behind another VM's delay,
+are both worth doing.
 :::

--- a/docs/guides/autostart-vm.md
+++ b/docs/guides/autostart-vm.md
@@ -38,3 +38,33 @@ xe vm-list
 
 5. Checking the output
 `# xe vm-param-list uuid=<VM_UUID> | grep other-config`
+
+## 🔢 Start order and delays {#start-order-and-delays}
+
+Autostart does not define an order. Every flagged VM is started in one go at host boot, so
+there is no way to sequence them.
+
+Ordering and delays belong to [vApps](../vms/vm-lifecycle.md#vapps) instead. Two VM
+parameters apply when an appliance is started, and after an HA failover:
+
+- `order` sets the relative order in which the appliance's VMs start, lower values first.
+- `start-delay` is a number of seconds. A call to start the VM does not return until the
+  delay has elapsed, so in a sequential appliance start the next VM waits that much longer.
+
+<Terminal title="root@xcp-ng-host — Start order and delays">{`
+xe vm-param-set uuid=<VM_UUID> order=1
+xe vm-param-set uuid=<VM_UUID> start-delay=30
+`}</Terminal>
+
+The parameter is `order`. `start-order` is rejected as an unknown field, and
+`other-config:start_order` is accepted without doing anything at all, since `other-config`
+holds arbitrary keys.
+
+:::note
+`start-delay` has been reported to interfere with autostart: one user found a VM that would
+not start at boot until the parameter was cleared
+([forum thread](https://xcp-ng.org/forum/topic/12388)). The delay does hold the start call
+open, which is measurable, but whether that is what kept the VM from starting has not been
+established. If a VM does not come up after a host reboot, checking `start-delay` costs
+nothing.
+:::

--- a/docs/guides/autostart-vm.md
+++ b/docs/guides/autostart-vm.md
@@ -41,14 +41,14 @@ xe vm-list
 
 ## 🔢 Start order and delays {#start-order-and-delays}
 
-Autostart does not define an order. Every flagged VM is started in one go at host boot, so
-there is no way to sequence them.
+Autostart does not define a startup order. All VMs flagged for autostart are started when the
+host boots, so there is no way to sequence them.
 
-Ordering and delays belong to [vApps](../vms/vm-lifecycle.md#vapps) instead. Two VM
-parameters apply when an appliance is started, and after an HA failover:
+To define a startup order or add delays, use [vApps](../vms/vm-lifecycle.md#vapps) instead.
+Two VM parameters apply when an appliance is started, and after an HA failover:
 
 - `order` sets the relative order in which the appliance's VMs start, lower values first.
-- `start-delay` is a number of seconds. A call to start the VM does not return until the
+- `start-delay` specifies a delay in seconds. A call to start the VM does not return until the
   delay has elapsed, so in a sequential appliance start the next VM waits that much longer.
 
 <Terminal title="root@xcp-ng-host — Start order and delays">{`
@@ -65,6 +65,6 @@ holds arbitrary keys.
 not start at boot until the parameter was cleared
 ([forum thread](https://xcp-ng.org/forum/topic/12388)). The delay does hold the start call
 open, which is measurable, but whether that is what kept the VM from starting has not been
-established. If a VM does not come up after a host reboot, checking `start-delay` costs
-nothing.
+established. If a VM does not come up after a host reboot, checking its `start-delay` value
+is a simple troubleshooting step.
 :::

--- a/docs/guides/autostart-vm.md
+++ b/docs/guides/autostart-vm.md
@@ -49,6 +49,10 @@ VMs are started one after another rather than all at once, so a `start-delay` on
 hold up the ones behind it. That spaces a boot out, but it does not sequence it, because which
 VMs end up behind the delay is not something you control.
 
+Measured on XCP-ng 8.3, with four autostart VMs and `start-delay=120` on one of them: the
+delayed VM was running about ten seconds after the host enabled itself, and the other three
+stayed halted for the next two minutes before starting together.
+
 To define a startup order, use [vApps](../vms/vm-lifecycle.md#vapps) instead. Two VM parameters
 apply when an appliance is started, and after an HA failover:
 
@@ -78,8 +82,8 @@ let HA restart it after a failover.
 `start-delay` has been reported to interfere with autostart: one user found a VM that would
 not start at boot until the parameter was cleared
 ([forum thread](https://xcp-ng.org/forum/topic/12388)). A delayed start does hold up the VMs
-queued behind it, so it explains a VM coming up late. A VM that stays down for good is a
-different matter, and that part is unexplained. If a VM does not appear after a host reboot,
-it is worth checking its `start-delay` value and waiting to see whether it is simply queued
-behind another VM's delay.
+queued behind it, so it explains a VM coming up late. It does not explain one that stays down,
+and that part is unexplained: in the measurement above, the delayed VM was the first to start.
+If a VM does not appear after a host reboot, it is worth checking its `start-delay` value and
+waiting to see whether it is simply queued behind another VM's delay.
 :::


### PR DESCRIPTION
> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]."
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco

Two forum threads ask the same question and neither gets an answer from this guide: what decides the order in which VMs autostart ([topic 12149](https://xcp-ng.org/forum/topic/12149)), and why did a VM stop autostarting until `start-delay` was cleared ([topic 12388](https://xcp-ng.org/forum/topic/12388)).

The answer to the first turns out to be "nothing does", which the guide should say.

## What the tests showed

All on XCP-ng 8.3.0, xapi 26.1.

**Autostart has no ordering.** `/opt/xensource/bin/xapi-autostart-vms` is twenty lines of shell whose operative part is one call:

```sh
xe vm-start other-config:auto_poweron=true power-state=halted is-a-template=false is-a-snapshot=false --multiple
```

Every flagged VM goes in one batch. Nothing reads `order`. That matches the CLI reference, which scopes `order` to "vApp startup/shutdown and for startup after HA failover" rather than to autostart.

**The parameter is `order`.** The two spellings people reach for behave differently, and the wrong one is the quiet one:

```
# xe vm-param-set uuid=<uuid> start-order=1
Error: Unknown field 'start-order'
# xe vm-param-set uuid=<uuid> other-config:start_order=1
# echo $?
0
```

`other-config` accepts arbitrary keys, so `other-config:start_order` writes an inert entry and reports success. Someone following that would set it, see no error, and get no ordering.

**`start-delay` blocks the start call for the VM it is set on.** Timed on a halted VM: `start-delay=30` makes `xe vm-start` return after 30 seconds; cleared, 0. So of the two official descriptions, the CLI reference's ("the delay to wait before a call to start up the VM returns") is the literal one. The XenAPI wording describes the consequence in a vApp, where starts are sequential and the delay therefore postpones the next VM.

**What I could not establish** is why a `start-delay` would stop a VM autostarting altogether, which is what topic 12388 reports. Holding the start call open is measurable; that it prevents the start is a different claim and I have no evidence for it. The page says so rather than offering a mechanism.

## Changes

One new section in `docs/guides/autostart-vm.md`: autostart has no order, ordering and delays belong to [vApps](https://docs.xcp-ng.org/vms/vm-lifecycle/#vapps) and are linked there rather than re-documented, the correct parameter name with a note on the two wrong ones, and the `start-delay` report as a lead with its forum link.

`npm run build` passes, anchor and cross-link resolve.

## Superseded

This replaces the original version of the PR, which documented `other-config:start_order` and claimed the delay landed on the next VM. Both were wrong, and @stormi was right to push back on the sentence that carried them. The branch is squashed to a single commit, since almost nothing of the first draft survived.

## Separate, and worth someone's opinion

* `docs/vms/vm-lifecycle.md` line 105 publishes `xe vm-param-set uuid=<vm-uuid> appliance=<appliance-uuid> start-order=1 start-delay=30`. `start-order` is rejected as an unknown field, so that command fails as written. It should be `order=1`. Happy to send it as a one-line PR, kept out of this one.
* `xapi-autostart-vms` logs `auto_poweron is enabled on the pool -- this is an unsupported configuration`, and this guide is what instructs people to set that pool flag. I did not find the line in the current logs of the host I tested on, so I am only reporting what the script contains, not that it fires. It seems worth a decision rather than a documentation edit.
