### PR TITLE
Note that a toolstack restart fixes VM_HOST_INCOMPATIBLE_VERSION

### DIFF
--- a/docs/troubleshooting/after-upgrade.md
+++ b/docs/troubleshooting/after-upgrade.md
@@ -39,6 +39,25 @@ To access the backup (with all your tools and modifications) just mount the back
 
 ***
 
+## 🚫 Cross-version VM moves fail with VM_HOST_INCOMPATIBLE_VERSION after upgrading the master
+
+### Cause
+
+Right after upgrading and patching the pool master, moving VMs between hosts of different
+versions can keep failing with `VM_HOST_INCOMPATIBLE_VERSION`, even though the master has
+already been rebooted and any mounted ISOs ejected. The toolstack can be left holding stale
+version state from before the upgrade.
+
+### Solution
+
+Restart the toolstack on the master:
+
+```
+# xe-toolstack-restart
+```
+
+***
+
 ## 🐛 After upgrading my XCP-ng host is unstable, network card freezes, kernel errors, etc.
 
 ### Causes and Solutions


### PR DESCRIPTION
After upgrading and patching the pool master, cross-version VM moves can keep failing with `VM_HOST_INCOMPATIBLE_VERSION` even though the master was rebooted and ISOs ejected. A toolstack restart on the master clears the stale state. Adds this as a new entry on the After Upgrade troubleshooting page.

Surfaced via [forum thread](https://xcp-ng.org/forum/topic/11981), self-solved by the reporter.

* [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
* [x] "My contribution complies with the Developer Certificate of Origin [2]."

[1] https://creativecommons.org/licenses/by-sa/2.0/
[2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco