### PR TITLE
Documentation expansion: day-2 operations, unified visual system, console components

### DIFF
--- a/docs/appendix/cli_reference.md
+++ b/docs/appendix/cli_reference.md
@@ -225,7 +225,7 @@ Cluster doesn't work with XCP-ng, but only with Citrix Hypervisor Please do NOT 
 
 Commands for working with consoles.
 
-The console objects can be listed with the standard object listing command (`xe console-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#-low-level-parameter-commands).
+The console objects can be listed with the standard object listing command (`xe console-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#low-level-parameter-commands).
 
 ## Console parameters
 
@@ -491,7 +491,7 @@ The class name can be any of the [event classes](#event-classes) listed at the b
 
 Commands for working with physical GPUs, GPU groups, and virtual GPUs.
 
-The GPU objects can be listed with the standard object listing commands: `xe pgpu-list`, `xe gpu-group-list`, and `xe vgpu-list`. The parameters can be manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#-low-level-parameter-commands).
+The GPU objects can be listed with the standard object listing commands: `xe pgpu-list`, `xe gpu-group-list`, and `xe vgpu-list`. The parameters can be manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#low-level-parameter-commands).
 
 ### Physical GPU parameters
 
@@ -656,7 +656,7 @@ Commands for interacting with XCP-ng server.
 
 XCP-ng servers are the physical servers running XCP-ng software. They have VMs running on them under the control of a special privileged Virtual Machine, known as the control domain or domain 0.
 
-The XCP-ng server objects can be listed with the standard object listing commands: `xe host-list`, `xe host-cpu-list`, and `xe host-crashdump-list`). The parameters can be manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#-low-level-parameter-commands).
+The XCP-ng server objects can be listed with the standard object listing commands: `xe host-list`, `xe host-cpu-list`, and `xe host-crashdump-list`). The parameters can be manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#low-level-parameter-commands).
 
 ### Host selectors
 
@@ -1161,7 +1161,7 @@ host-set-power-on-mode host=host_uuid power-on-mode={"" | "wake-on-lan" | "iLO" 
 
 Use to enable the *Host Power On* function on XCP-ng hosts that are compatible with remote power solutions. When using the `host-set-power-on` command, you must specify the type of power management solution on the host (that is, the power-on-mode). Then specify configuration options using the power-on-config argument and its associated key-value pairs.
 
-To use the secrets feature to store your password, specify the key `"power_on_password_secret"`. For more information, see [Secrets](../../management/manage-locally/cli#-secrets).
+To use the secrets feature to store your password, specify the key `"power_on_password_secret"`. For more information, see [Secrets](../../management/manage-locally/cli#secrets).
 
 ### `host-shutdown`
 
@@ -1300,7 +1300,7 @@ Set all loggers to the specified output (nil, stderr, string, file:*file name*, 
 
 Commands for working with messages. Messages are created to notify users of significant events, and are displayed in XenCenter as alerts.
 
-The message objects can be listed with the standard object listing command (`xe message-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#-low-level-parameter-commands)
+The message objects can be listed with the standard object listing command (`xe message-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#low-level-parameter-commands)
 
 ### Message parameters
 
@@ -1341,7 +1341,7 @@ Destroys an existing message. You can build a script to destroy all messages. Fo
 
 Commands for working with networks.
 
-The network objects can be listed with the standard object listing command (`xe network-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#-low-level-parameter-commands)
+The network objects can be listed with the standard object listing command (`xe network-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#low-level-parameter-commands)
 
 ### Network parameters
 
@@ -1387,7 +1387,7 @@ Destroys an existing network.
 
 Commands for working with SR-IOV.
 
-The network-sriov objects can be listed with the standard object listing command (`xe network-sriov-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#-low-level-parameter-commands)
+The network-sriov objects can be listed with the standard object listing command (`xe network-sriov-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#low-level-parameter-commands)
 
 ### SR-IOV parameters
 
@@ -1533,7 +1533,7 @@ Upload a patch file to the server.
 
 Commands for working with PBDs (Physical Block Devices). PBDs are the software objects through which the XCP-ng server accesses storage repositories (SRs).
 
-The PBD objects can be listed with the standard object listing command (`xe pbd-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#-low-level-parameter-commands)
+The PBD objects can be listed with the standard object listing command (`xe pbd-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#low-level-parameter-commands)
 
 ### PBD parameters
 
@@ -1589,7 +1589,7 @@ Attempt to unplug the PBD from the XCP-ng server.
 
 Commands for working with PIFs (objects representing the physical network interfaces).
 
-The PIF objects can be listed with the standard object listing command (`xe pif-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#-low-level-parameter-commands)
+The PIF objects can be listed with the standard object listing command (`xe pif-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#low-level-parameter-commands)
 
 ### PIF parameters
 
@@ -1719,7 +1719,7 @@ Attempt to bring down the specified physical interface.
 
 Commands for working with pools. A *pool* is an aggregate of one or more XCP-ng servers. A pool uses one or more shared storage repositories so that the VMs running on one host in the pool can be migrated in near-real time to another host in the pool. This migration happens while the VM is still running, without it needing to be shut down and brought back up. Each XCP-ng server is really a pool consisting of a single member by default. When your XCP-ng server is joined to a pool, it is designated as a member, and the pool it has joined becomes the master for the pool.
 
-The singleton pool object can be listed with the standard object listing command (`xe pool-list`). Its parameters can be manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#-low-level-parameter-commands)
+The singleton pool object can be listed with the standard object listing command (`xe pool-list`). Its parameters can be manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#low-level-parameter-commands)
 
 ### Pool parameters
 
@@ -2139,7 +2139,7 @@ Introduce new PVS site.
 
 Commands for controlling Storage Manager plug-ins.
 
-The storage manager objects can be listed with the standard object listing command (`xe sm-list`). The parameters can be manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#-low-level-parameter-commands)
+The storage manager objects can be listed with the standard object listing command (`xe sm-list`). The parameters can be manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#low-level-parameter-commands)
 
 ## SM parameters
 
@@ -2230,7 +2230,7 @@ Uninstall a snapshot. This operation will destroy those VDIs that are marked RW 
 
 Commands for controlling SRs (storage repositories).
 
-The SR objects can be listed with the standard object listing command (`xe sr-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#-low-level-parameter-commands)
+The SR objects can be listed with the standard object listing command (`xe sr-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#low-level-parameter-commands)
 
 ## SR parameters
 
@@ -2469,7 +2469,7 @@ Destroy a secret.
 
 Commands for working with long-running asynchronous tasks. These commands are tasks such as starting, stopping, and suspending a virtual machine. The tasks are typically made up of a set of other atomic subtasks that together accomplish the requested operation.
 
-The task objects can be listed with the standard object listing command (`xe task-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#-low-level-parameter-commands)
+The task objects can be listed with the standard object listing command (`xe task-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#low-level-parameter-commands)
 
 ### Task parameters
 
@@ -2506,7 +2506,7 @@ Commands for working with VM templates.
 
 Templates are essentially VMs with the `is-a-template` parameter set to `true`. A template is a "gold image" that contains all the various configuration settings to instantiate a specific VM. XCP-ng ships with a base set of templates, which are generic "raw" VMs that can boot an OS vendor installation CD (for example: RHEL, CentOS, SLES, Windows). You can create VMs, configure them in standard forms for your particular needs, and save a copy of them as templates for future use in VM deployment.
 
-The template objects can be listed with the standard object listing command (`xe template-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#-low-level-parameter-commands)
+The template objects can be listed with the standard object listing command (`xe template-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#low-level-parameter-commands)
 
 :::tip
 Templates cannot be directly converted into VMs by setting the `is-a-template` parameter to `false`. Setting `is-a-template` parameter to `false` is not supported and results in a VM that cannot be started.
@@ -2640,7 +2640,7 @@ Uninstall a custom template. This operation will destroy those VDIs that are mar
 Update mechanism in XCP-ng is using `yum`, not this CLI. Please do NOT use it and check the [updates section](../../management/updates).
 :::
 
-The update objects can be listed with the standard object listing command (`xe update-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#-low-level-parameter-commands)
+The update objects can be listed with the standard object listing command (`xe update-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#low-level-parameter-commands)
 
 ## Update parameters
 
@@ -2730,7 +2730,7 @@ Commands for working with VBDs (Virtual Block Devices).
 
 A VBD is a software object that connects a VM to the VDI, which represents the contents of the virtual disk. The VBD has the attributes which tie the VDI to the VM (is it bootable, its read/write metrics, and so on). The VDI has the information on the physical attributes of the virtual disk (which type of SR, whether the disk is sharable, whether the media is read/write or read only, and so on).
 
-The VBD objects can be listed with the standard object listing command (`xe vbd-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#-low-level-parameter-commands)
+The VBD objects can be listed with the standard object listing command (`xe vbd-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#low-level-parameter-commands)
 
 ### VBD parameters
 
@@ -2826,7 +2826,7 @@ Commands for working with VDIs (Virtual Disk Images).
 
 A VDI is a software object that represents the contents of the virtual disk seen by a VM. This is different to the VBD, which is an object that ties a VM to the VDI. The VDI has the information on the physical attributes of the virtual disk (which type of SR, whether the disk is sharable, whether the media is read/write or read only, and so on). The VBD has the attributes that tie the VDI to the VM (is it bootable, its read/write metrics, and so on).
 
-The VDI objects can be listed with the standard object listing command (`xe vdi-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#-low-level-parameter-commands)
+The VDI objects can be listed with the standard object listing command (`xe vdi-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#low-level-parameter-commands)
 
 ### VDI parameters
 
@@ -3040,7 +3040,7 @@ Refresh the fields of the VDI object in the database.
 
 Commands for working with VIFs (Virtual network interfaces).
 
-The VIF objects can be listed with the standard object listing command (`xe vif-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#-low-level-parameter-commands)
+The VIF objects can be listed with the standard object listing command (`xe vif-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#low-level-parameter-commands)
 
 ## VIF parameters
 
@@ -3207,7 +3207,7 @@ Commands for controlling VMs and their attributes.
 
 Several of the commands listed here have a common mechanism for selecting one or more VMs on which to perform the operation. The simplest way is by supplying the argument `vm=name_or_uuid`. An easy way to get the uuid of an actual VM is to, for example, execute `xe vm-list power-state=running`. (Get the full list of fields that can be matched by using the command `xe vm-list params=all`. ) For example, specifying `power-state=halted` selects VMs whose `power-state` parameter is equal to `halted`. Where multiple VMs are matching, specify the option `--multiple` to perform the operation. The full list of parameters that can be matched is described at the beginning of this section.
 
-The VM objects can be listed with the standard object listing command (`xe vm-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#-low-level-parameter-commands)
+The VM objects can be listed with the standard object listing command (`xe vm-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#low-level-parameter-commands)
 
 ### VM parameters
 
@@ -3796,7 +3796,7 @@ The VM or VMs on which this operation is performed are selected using the standa
 
 Use the `force` argument to cause an ungraceful shutdown, similar to pulling the plug on a physical server.
 
-An HVM mode VM requires `force=true` to be shutdown, unless [Guest Tools](../../vms#%EF%B8%8F-guest-tools) have been installed.
+An HVM mode VM requires `force=true` to be shutdown, unless [Guest Tools](../../vms#guest-tools) have been installed.
 
 ### `vm-snapshot`
 
@@ -3878,7 +3878,7 @@ We advise to use Xen Orchestra instead of this method. See [Xen Orchestra rollin
 
 Commands for controlling VM scheduled snapshots and their attributes.
 
-The vmss objects can be listed with the standard object listing command (`xe vmss-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#-low-level-parameter-commands)
+The vmss objects can be listed with the standard object listing command (`xe vmss-list`), and the parameters manipulated with the standard parameter commands. For more information, see [Low-level parameter commands](../../management/manage-locally/cli#low-level-parameter-commands)
 
 ### `vmss-create`
 

--- a/docs/appendix/glossary.md
+++ b/docs/appendix/glossary.md
@@ -1,15 +1,48 @@
 # Glossary
 
-All terms and acrocyms.
+All terms and acronyms used throughout this documentation, with links to the pages covering them.
 
-* dom0 - "Domain 0", or "control domain" - The initial domain in Xen and XCP-ng, which has direct access to hardware and manages other virtual machines.
-* HVM - Hardware Virtual Machine
-* PV - ParaVirtualization
-* PBD - Physical Block Device
-* PIF - Physical Interface
-* SR - Storage Repository
-* VBD - Virtual Block Device
-* VDI - Virtual Disk Image
-* VM - Virtual Machine
-* XCP - Xen Cloud Platform
-* XCP-ng - XCP New Generation
+* **Bond**: aggregation of several physical NICs into one logical interface, for redundancy and bandwidth. See [bonds](../networking/networking.md#bonds).
+* **Coalesce**: background process merging a disk chain after snapshot deletion, reclaiming space. See [coalesce](../storage/storage.md#coalesce).
+* **DMC** (Dynamic Memory Control): lets a VM's memory vary between a min and a max while it runs. See [dynamic memory](../vms/vms.md#dynamic-memory).
+* **dom0** ("Domain 0", or "control domain"): the privileged Linux system started by Xen at boot. It has direct access to hardware, runs the toolstack and the storage/network backends for all VMs. See [architecture](../project/architecture.md).
+* **domU**: any unprivileged Xen domain, i.e. a regular VM (by opposition to dom0).
+* **DRBD**: replicated block device technology used by XOSTOR/LINSTOR. See [XOSTOR](../xostor/xostor.md).
+* **Guest tools**: PV drivers plus a management agent installed inside the guest OS, required for good performance and features like clean shutdown or IP reporting. See [guest tools](../vms/vms.md#guest-tools).
+* **HA** (High Availability): pool feature restarting protected VMs automatically when a host fails. See [high availability](../management/ha.md).
+* **HVM** (Hardware Virtual Machine): VM mode using CPU virtualization extensions; the standard mode for all guests on XCP-ng (usually with PV drivers on top, aka "PVHVM").
+* **IQN** (iSCSI Qualified Name): the identifier of an iSCSI initiator or target, e.g. `iqn.2024-01.com.example:storage1`.
+* **LINSTOR**: the software-defined storage orchestrator behind XOSTOR. See [XOSTOR](../xostor/xostor.md).
+* **LUN** (Logical Unit Number): a block device exported by a SAN over iSCSI, Fibre Channel or SAS.
+* **MTU** (Maximum Transmission Unit): the largest packet size on a network; 1500 by default, up to 9000+ for jumbo frames. See [MTUs](../networking/networking.md#mtus).
+* **NBD** (Network Block Device): protocol exposing a disk over the network; used by Xen Orchestra for faster backups (see [NBD backup network](../networking/networking.md#nbd-backup-network)).
+* **OVA / OVF** (Open Virtualization Archive/Format): vendor-neutral VM interchange format, used to exchange VMs with non-XCP-ng platforms. See [import and export](../vms/import-export.md).
+* **OVS** (Open vSwitch): the virtual switch used by XCP-ng to connect VIFs, PIFs, VLANs and tunnels. See [network architecture](../project/architecture.md#network).
+* **PBD** (Physical Block Device): the XAPI object connecting one host to one SR. See [SR management](../storage/manage-srs.md).
+* **PIF** (Physical InterFace): the XAPI object representing a host network interface (a NIC, a bond or a VLAN on them).
+* **Pool** (resource pool): a group of hosts managed as one entity, sharing configuration and (usually) storage. See [hosts and pools](../management/hosts-pools.md).
+* **Pool coordinator** (formerly "pool master"): the pool member exposing the XAPI endpoint for the whole pool and holding the reference database.
+* **PV** (ParaVirtualization): historical VM mode without hardware virtualization extensions; removed on modern XCP-ng. "PV drivers" survived: they're the efficient drivers guests use to talk to dom0.
+* **QCOW2**: virtual disk format available from XCP-ng 8.3, enabling disks larger than 2 TiB. See the [QCOW2 FAQ](../storage/qcow2_faq.md).
+* **RPU** (Rolling Pool Update): updating a whole pool without VM downtime, orchestrated by Xen Orchestra. See [updates](../management/updates.md).
+* **RRD** (Round-Robin Database): fixed-size database in which hosts record their performance metrics. See [monitoring](../management/monitoring.md).
+* **SMAPI**: the Storage Manager API, the layer of drivers implementing each [SR type](../storage/storage.md).
+* **Snapshot**: point-in-time capture of a VM's disks (optionally with its RAM). See [snapshots](../vms/snapshots.md).
+* **SR** (Storage Repository): a storage target holding virtual disks (or ISOs). See [storage](../storage/storage.md).
+* **Template**: blueprint used to create VMs, with or without disk content. See [templates](../vms/templates.md).
+* **vApp** (VM appliance): a group of VMs started and recovered together, with a defined boot order.
+* **VBD** (Virtual Block Device): the XAPI object connecting a VDI to a VM.
+* **VDI** (Virtual Disk Image): one virtual disk, stored in an SR.
+* **VHD**: the historical copy-on-write virtual disk format of XCP-ng (2 TiB limit per disk).
+* **VIF** (Virtual InterFace): a VM's virtual network card, connected to a network.
+* **VLAN**: layer-2 network segmentation (802.1Q tags); XCP-ng networks can sit on any VLAN. See [VLANs](../networking/networking.md#vlans).
+* **VM** (Virtual Machine): you probably know this one.
+* **vTPM**: virtual TPM 2.0 device, available from XCP-ng 8.3 (needed for Windows 11). See [advanced VM settings](../vms/advanced.md#vtpm).
+* **XAPI**: the toolstack (API and daemon) managing XCP-ng hosts and pools. See [XCP-ng API](../management/manage-locally/api.md).
+* **XCP** (Xen Cloud Platform): the historical open source distribution of XenServer, ancestor of XCP-ng ("XCP new generation").
+* **`xe`**: the command-line client for XAPI, available on every host. See the [xe CLI page](../management/manage-locally/cli.md) and the [full command reference](cli_reference.md).
+* **Xen**: the type-1 hypervisor XCP-ng is built on.
+* **XO / XOA** (Xen Orchestra / XO Appliance): the web-based management, backup and orchestration platform for XCP-ng; XOA is its turnkey virtual appliance form. See [manage at scale](../management/manage-at-scale/xo-web-ui.md).
+* **XOSTOR**: XCP-ng's hyperconverged storage (replicated storage built from the hosts' local disks). See [XOSTOR](../xostor/xostor.md).
+* **xsconsole**: the text-mode configuration console displayed on a host's physical/serial screen.
+* **XVA**: the native file format for exported VMs and templates. See [import and export](../vms/import-export.md).

--- a/docs/compute.md
+++ b/docs/compute.md
@@ -6,7 +6,7 @@ sidebar_position: 8
 
 This section is dedicated to compute related things, like GPU/vGPU or PCI passthrough, nested virtualization or advanced Xen features.
 
-## 🔗 PCI Passthrough
+## 🔗 PCI Passthrough {#pci-passthrough}
 
 ### 0. Prerequisites
 
@@ -51,21 +51,21 @@ On XCP-ng 8.3, this limitation is lifted for most hardware.
 
 _This method is the easiest way to find devices._
 
-```
-[root@xen ~]# lspci
+<Terminal title="root@xcp-ng-host — 1. Find your devices ID (B/D/F)…">{`
+lspci
 ...
 04:01.0 Ethernet controller: Intel Corporation 82541PI Gigabit Ethernet Controller (rev 05)
-```
+`}</Terminal>
 
 **Method 2: List System Device Classes with `find`**
 
 _This method works best for finding the device ID by class. The example below the class is `net` and shows how to find the device ID of a specific network interface._
 
-```
-[root@xen ~]# find /sys/class/net -exec readlink {} +
+<Terminal title="1. Find your devices ID (B/D/F) on the PCI bus…">{`
+find /sys/class/net -exec readlink {} +
 ../../devices/virtual/net/lo
 ../../devices/pci0000:00/0000:04:01.0/net/eth1
-```
+`}</Terminal>
 
 **Method 3: List PCI devices using XAPI**
 
@@ -83,9 +83,9 @@ To hide the device from dom0:
 
 Run the following XAPI command:
 
-```
+<Terminal shell title="root@xcp-ng-host — XCP-ng 8.3">{`
 xe pci-disable-dom0-access uuid=<pci uuid>
-```
+`}</Terminal>
 
 ##### XCP-ng 8.2
 
@@ -94,9 +94,11 @@ XCP-ng 8.2 is EOL. This 8.2-specific information is retained solely to assist wi
 :::
 
 Add the **`xen-pciback.hide`** parameter to the kernel boot parameters:
-```bash
+
+<Terminal shell title="root@xcp-ng-host — XCP-ng 8.2">{`
 /opt/xensource/libexec/xen-cmdline --set-dom0 "xen-pciback.hide=(0000:04:01.0)"
-```
+`}</Terminal>
+
 > You can hide multiple devices. If you wanted to add another device at `00:19.0` just append it to the parameter.
 >
 > `/opt/xensource/libexec/xen-cmdline --set-dom0 "xen-pciback.hide=(0000:04:01.0)(0000:00:19.0)"`
@@ -109,10 +111,12 @@ To unhide the device from dom0:
 
 Run the following XAPI command:
 
-`xe pci-enable-dom0-access uuid=<pci uuid>`
+<Terminal shell title="root@xcp-ng-host — XCP-ng 8.3">{`
+xe pci-enable-dom0-access uuid=<pci uuid>
+`}</Terminal>
 
 :::warning
-This kernel parameter is not retained when you upgrade an XCP-ng host [using the installation ISO](../installation/upgrade#-upgrade-via-installation-iso-recommended). Remember to re-do this step after the upgrade.
+This kernel parameter is not retained when you upgrade an XCP-ng host [using the installation ISO](../installation/upgrade#upgrade-via-installation-iso-recommended). Remember to re-do this step after the upgrade.
 :::
 
 ##### XCP-ng 8.2
@@ -121,7 +125,9 @@ This kernel parameter is not retained when you upgrade an XCP-ng host [using the
 XCP-ng 8.2 is EOL. This 8.2-specific information is retained solely to assist with the transition from 8.2 to a supported release.
 :::
 
-`/opt/xensource/libexec/xen-cmdline --delete-dom0 xen-pciback.hide`
+<Terminal shell title="root@xcp-ng-host — XCP-ng 8.2">{`
+/opt/xensource/libexec/xen-cmdline --delete-dom0 xen-pciback.hide
+`}</Terminal>
 
 
 :::tip
@@ -130,40 +136,51 @@ For NVMe storage devices, the Linux driver will try to allocate too many PCI MSI
 
 The default number of extra guest IRQs (which is 64) needs to be increased with Xen's `extra_guest_irqs` boot parameter:
 
-```bash
+<Terminal shell title="root@xcp-ng-host — NVMe storage devices on Linux">{`
 /opt/xensource/libexec/xen-cmdline --set-xen "extra_guest_irqs=128"
-```
+`}</Terminal>
 
 To remove the parameter from Xen command line:
 
-```bash
+<Terminal shell title="root@xcp-ng-host — NVMe storage devices on Linux">{`
 /opt/xensource/libexec/xen-cmdline --delete-xen extra_guest_irqs
-```
+`}</Terminal>
+
 :::
 
 ### 3. Reboot the XCP-ng host
 
-`[root@xen ~]# reboot`
+<Terminal shell title="root@xcp-ng-host — 3. Reboot the XCP-ng host">{`
+reboot
+`}</Terminal>
 
 ### 4. Check with `xl pci-assignable-list` on CLI
 
-```
-[root@xen ~]# xl pci-assignable-list
+<Terminal title="root@xcp-ng-host — 4. Check with xl…">{`
+xl pci-assignable-list
 0000:04:01.0
-```
+`}</Terminal>
 
 ### 5. Put this PCI device 'into' your VM
 
-`[root@xen ~]# xe vm-param-set other-config:pci=0/0000:04:01.0 uuid=<vm uuid>`
+<Terminal shell title="root@xcp-ng-host — 5. Put this PCI device 'into' your VM">{`
+xe vm-param-set other-config:pci=0/0000:04:01.0 uuid=<vm uuid>
+`}</Terminal>
 
 :::tip
 You can also pass through multiple devices. If you wanted to pass through another device at `00:19.0` just append it to the parameter:
-`[root@xen ~]# xe vm-param-set other-config:pci=0/0000:04:01.0,0/0000:00:19.0 uuid=<vm uuid>`
+
+<Terminal shell title="root@xcp-ng-host — 5. Put this PCI device 'into' your VM">{`
+xe vm-param-set other-config:pci=0/0000:04:01.0,0/0000:00:19.0 uuid=<vm uuid>
+`}</Terminal>
+
 :::
 
 ### 6. Start your VM and be happy :-)
 
-`[root@xen ~]# xe vm-start uuid=<vm uuid>`
+<Terminal shell title="root@xcp-ng-host — 6. Start your VM and be happy :-)">{`
+xe vm-start uuid=<vm uuid>
+`}</Terminal>
 
 ### Detaching a PCI device
 
@@ -171,28 +188,28 @@ If you don't want to use your PCI device anymore, you can always remove it later
 
 First, you need to remove it from the VM:
 
-```bash
+<Terminal shell title="root@xcp-ng-host — Detaching a PCI device">{`
 xe vm-param-remove param-name=other-config param-key=pci uuid=<vm uuid>
-```
+`}</Terminal>
 
 Then, when booting the VM, it won't be attached anymore.
 
 If you want to get the PCI device accessible again in the Dom0, you also need to removing it from the command line:
 
-```bash
+<Terminal shell title="root@xcp-ng-host — Detaching a PCI device">{`
 /opt/xensource/libexec/xen-cmdline --delete-dom0 xen-pciback.hide
-```
+`}</Terminal>
 
 It will be back in the Dom0 after a reboot.
 
-## 🎮 GPU Passthrough
+## 🎮 GPU Passthrough {#gpu-passthrough}
 To passthrough a complete graphics card to a VM (not virtualize it into multiple virtual vGPUs, which is different, see the vGPU section below), just follow the regular PCI passthrough instructions, no special steps are needed. Most Nvidia and AMD video cards should work without issue.  
 
 :::tip
 Previously, Nvidia would block the use of gaming/consumer video cards for passthrough (the Nvidia installer would throw an **Error 43** when installing the driver inside your VM). They lifted this restriction in 2021 with driver R465 and above, so be sure to use the latest driver. [Details from Nvidia here.](https://nvidia.custhelp.com/app/answers/detail/a_id/5173/)
 :::
 
-## 🖥️ vGPU
+## 🖥️ vGPU {#vgpu}
 
 ### NVIDIA vGPU
 
@@ -213,7 +230,9 @@ Version 2.0 of the mxgpu iso should work on any 8.X version of XCP-ng
 
 `cd /tmp`
 
-`xe-install-supplemental-pack mxgpu-2.0.0.amd.iso`
+<Terminal shell title="root@xcp-ng-host — MxGPU (AMD vGPU)">{`
+xe-install-supplemental-pack mxgpu-2.0.0.amd.iso
+`}</Terminal>
 
 6. Reboot the XCP-ng
 7. Assign an MxGPU to the VM from the VM properties page.  Go to the GPU section.  From the Drop down choose how big of a slice of the GPU you want on the VM and click OK
@@ -223,7 +242,7 @@ Start the VM and log into the guest OS and load the appropriate guest driver fro
 > Known working cards:
 * S7150x2
 
-## 🖱️ USB Passthrough
+## 🖱️ USB Passthrough {#usb-passthrough}
 
 :::tip
 There's no need to alter any files manually as some older guides suggest
@@ -231,8 +250,8 @@ There's no need to alter any files manually as some older guides suggest
 
 It's fairly easy using the `xe` CLI. First use `xe pusb-list` to list all the physical USB devices on your host available for passthrough:
 
-```
-[root@xenserver ~]# xe pusb-list
+<Terminal title="root@xcp-ng-host — USB Passthrough">{`
+xe pusb-list
 uuid ( RO)            : 10fbec89-4472-c215-5d55-17969b473ee6
             path ( RO): 2-1.1
        vendor-id ( RO): 0781
@@ -242,55 +261,71 @@ uuid ( RO)            : 10fbec89-4472-c215-5d55-17969b473ee6
           serial ( RO): 4C530001151223117134
          version ( RO): 2.10
      description ( RO): SanDisk Corp._4C530001151223117134
-```
+`}</Terminal>
 
 Find your USB device there, and note the `uuid`. Then use that uuid to enable passthrough for it:
-```
-[root@xenserver ~]# xe pusb-param-set uuid=10fbec89-4472-c215-5d55-17969b473ee6 passthrough-enabled=true
-```
+
+<Terminal shell title="root@xcp-ng-host — USB Passthrough">{`
+xe pusb-param-set uuid=10fbec89-4472-c215-5d55-17969b473ee6 passthrough-enabled=true
+`}</Terminal>
+
 This will create a `usb-group` containing this USB device. We need to find the uuid of that group, so we use the `usb-group-list` command, specifying the physical USB uuid we got in step one: 
-```
-[root@xenserver ~]# xe usb-group-list PUSB-uuids=10fbec89-4472-c215-5d55-17969b473ee6
+
+<Terminal title="root@xcp-ng-host — USB Passthrough">{`
+xe usb-group-list PUSB-uuids=10fbec89-4472-c215-5d55-17969b473ee6
 uuid ( RO)                : 1f731f6a-6025-8858-904d-c98548f8bb23
 name-label ( RW): Group of 0781 5591 USBs
 name-description ( RW):
-```
+`}</Terminal>
+
 Note the uuid of this usb-group, then use it in the following command to attach this USB device to your desired VM. Remember to first shut down the target VM as hot-plug for USB passthrough is not supported:
-```
+
+<Terminal shell title="root@xcp-ng-host — USB Passthrough">{`
 xe vusb-create usb-group-uuid=<usb_group_uuid> vm-uuid=<vm_uuid>
-```
+`}</Terminal>
+
 So using the examples above, it would look like:
-```
+
+<Terminal shell title="root@xcp-ng-host — USB Passthrough">{`
 xe vusb-create usb-group-uuid=1f731f6a-6025-8858-904d-c98548f8bb23 vm-uuid=4feeb9b2-2176-b69d-b8a8-cf7289780a3f
-```
+`}</Terminal>
+
 Finally, start the target guest VM:
-```
-[root@xenserver ~]# xe vm-start uuid=<vm_uuid>
-```
+
+<Terminal shell title="root@xcp-ng-host — USB Passthrough">{`
+xe vm-start uuid=<vm_uuid>
+`}</Terminal>
 
 **Note:** If you get a message containing `internal error` when trying to start the VM after assigning it a USB device, try the following command to ensure its `platform:usb` parameter is set correctly:
-```
+
+<Terminal shell title="root@xcp-ng-host — USB Passthrough">{`
 xe vm-param-set uuid=<vm_uuid> platform:usb=True
-```
+`}</Terminal>
+
 In the future if you ever need to unplug the virtual USB device from your VM, or remove and unassign it completely, find the uuid of the virtual USB device by running `xe vusb-list`. Then use the uuid of the virtual USB device in one or both of the following commands:
-```
+
+<Terminal shell title="root@xcp-ng-host — USB Passthrough">{`
 xe vusb-unplug uuid=<vusb_uuid>
 xe vusb-destroy uuid=<vusb_uuid>
-```
+`}</Terminal>
+
 ### Passing through Keyboards and Mice
 xcp-ng host uses usb-policy.conf at `/etc/xensource/usb-policy.conf` with ALLOW and DENY rules for different classes of usb devices.
 The default file contains Mice and Keyboards with DENY rules. You can edit this file to allow these devices (and any other ones similarly).
 
 Once edited, run the following command to refresh:
-```
-/opt/xensource/libexec/usb_scan.py -d
-```
-Then run
-```
-xe pusb-scan host-uuid=<host_uuid>
-```
 
-## 📦 Nested Virtualization
+<Terminal shell title="root@xcp-ng-host — Passing through Keyboards and…">{`
+/opt/xensource/libexec/usb_scan.py -d
+`}</Terminal>
+
+Then run
+
+<Terminal shell title="root@xcp-ng-host — Passing through Keyboards and…">{`
+xe pusb-scan host-uuid=<host_uuid>
+`}</Terminal>
+
+## 📦 Nested Virtualization {#nested-virtualization}
 
 Nested virtualization is the ability to run a hypervisor within another hypervisor. For example, running XCP-ng inside a VM that itself runs on XCP-ng.
 
@@ -306,13 +341,13 @@ XCP-ng allows to enable this partial nested virtualization support. It can be us
 
 We understand the use cases that necessitate nested virtualization and are committed to making this feature available in a supported form in the future. Until it is implemented, there is unfortunately no supported way to enable it.
 
-## 🌡 CPU Temperature on Intel
+## 🌡 CPU Temperature on Intel {#cpu-temperature-on-intel}
 
 As coretemp is not supported in XCP-ng, you can't rely on `sensors` to get the CPU temperatures on Intel platforms.
 
 Starting with XCP-ng 8.3 (`xen-4.17.6-9.3.xcpng8.3`), the `xenpm get-core-temp` command was introduced as an alternative.
 
-## 🐼 Advanced Xen
+## 🐼 Advanced Xen {#advanced-xen}
 
 This section is dedicated to advanced Xen use cases. Use it with caution!
 
@@ -331,39 +366,45 @@ node1: 8-15
 
 If we run `xl list --numa`, it'll return `all` as the node affinity. This indicates that the VM can run on any available nodes and cores. Now, change the VM affinity to node1 (VM reboot required):
 
-```
-xe vm-param-set uuid=[VM-UUID] VCPUs-params:mask=8,9,10,11,12,13,14,15`
-```
+<Terminal shell title="root@xcp-ng-host — NUMA affinity">{`
+xe vm-param-set uuid=[VM-UUID] VCPUs-params:mask=8,9,10,11,12,13,14,15
+`}</Terminal>
 
 Check the new affinity. It'll now display `1` instead of `all`, indicating that the VM will only be allowed to run on `node1` cores:
-```
+
+<Terminal shell title="root@xcp-ng-host — NUMA affinity">{`
 xl list --numa
-```
+`}</Terminal>
 
 In order to reset the config, just remove the attribute (VM reboot required):
-```
-xe vm-param-remove uuid=[VM-UUID] param-name=VCPUs-params param-key=mask`
-```
+
+<Terminal shell title="root@xcp-ng-host — NUMA affinity">{`
+xe vm-param-remove uuid=[VM-UUID] param-name=VCPUs-params param-key=mask
+`}</Terminal>
 
 Other useful commands for listing the VM core affinity and cores per NUMA node(s):
-```
+
+<Terminal shell title="root@xcp-ng-host — NUMA affinity">{`
 xl vcpu-list
 xenpm get-cpu-topology
 xl info --numa
-```
+`}</Terminal>
 
 Other ways control the vCPUs placement, using the `xl` CLI:
-```
+
+<Terminal shell title="root@xcp-ng-host — NUMA affinity">{`
 xl vcpu-pin <Domain> <vcpu id> <cpu id>
 xl vcpu-pin "Domain 0" all 2-5
-```
+`}</Terminal>
+
 You can use the domain name or the domain ID you can obtain from the `xl list` command.
 
 Or using the CPUPool functionality:
-```
+
+<Terminal shell title="root@xcp-ng-host — NUMA affinity">{`
 xl cpupool-numa-split # Will create a cpupool by NUMA node
 xl cpupool-migrate <VM> <Pool> # Will migrate a VM to the given pool
-```
+`}</Terminal>
 
 :::warning
 Be careful, the changes done using `xl` only affect vCPU at the moment, the memory of the VM will not be moved between node nor the pinning stay after a reboot. You need to use `xe` for it to be taken into account at the VM startup.

--- a/docs/guides/TLS-certificates-xcpng.md
+++ b/docs/guides/TLS-certificates-xcpng.md
@@ -8,21 +8,21 @@ If you would like to replace this certificate by a valid one, either from an int
 
 Note that if you use an non-public certificate authority and XenOrchestra, you have [additional configuration to specify on Xen Orchestra side](https://xen-orchestra.com/docs/configuration.html#custom-certificate-authority).
 
-## Generate certificate signing request
+## 📝 Generate certificate signing request {#generate-certificate-signing-request}
 
 You can use the auto-generated key to create a certificate signing request:
 
-```
+<Terminal shell title="Generate certificate signing request">{`
 openssl req -new -key /etc/xensource/xapi-ssl.pem -subj '/CN=XCP-ng hypervisor/' -out xcp-ng.csr
-```
+`}</Terminal>
 
-## Install the certificate chain (for XCP-ng v8.2+)
+## 🔗 Install the certificate chain (for XCP-ng v8.2+) {#install-the-certificate-chain-for-xcp-ng-v82}
 
 Once you have your certificates, upload the certificates to your XCP-ng host, then use the following command to install the certificates:
 
-```
+<Terminal shell title="root@xcp-ng-host — Install the certificate chain…">{`
 xe host-server-certificate-install certificate=<path to certificate> private-key=<path to key> certificate-chain=<path to chain>
-```
+`}</Terminal>
 
 :::tip
 The `certificate-chain` parameter is optional. The private key can be deleted after certificate is installed for additional security. For additional details check Citrix [documentation](https://docs.citrix.com/en-us/citrix-hypervisor/hosts-pools.html#install-a-tls-certificate-on-your-server).
@@ -31,7 +31,7 @@ The `certificate-chain` parameter is optional. The private key can be deleted af
 Done! Visit your XCP-ng host ip using a browser and validate the certificate is correct.
 
 
-## Install the certificate chain (for XCP-ng up to v8.1)
+## 🧓 Install the certificate chain (for XCP-ng up to v8.1) {#install-the-certificate-chain-for-xcp-ng-up-to-v81}
 
 :::note
 This information about deprecated releases is retained solely to assist with the transition to a supported release.
@@ -40,6 +40,24 @@ This information about deprecated releases is retained solely to assist with the
 The certificate, intermediate certificates (if needed), certificate authority and private key are stored in `/etc/xensource/xapi-ssl.pem`, in that order. You have to replace all lines before `-----BEGIN RSA PRIVATE KEY----` with the certificate and the chain you got from your provider, using your favorite editor (`nano` is present on XCP-ng by default).
 
 Then, you have to restart xapi :
-```
+
+<Terminal shell title="Install the certificate chain (for XCP-ng up to…">{`
 systemctl restart xapi
-```
+`}</Terminal>
+
+## 🛡️ Pool certificate verification (XCP-ng 8.3) {#pool-certificate-verification}
+
+Since XCP-ng 8.3, hosts of a pool can verify each other's TLS certificates. New pools have it enabled; on upgraded pools, enable it once every member runs 8.3:
+
+<Terminal shell title="root@xcp-ng-host — Pool certificate verification…">{`
+xe pool-enable-tls-verification
+`}</Terminal>
+
+Useful related commands:
+
+<Terminal shell title="root@xcp-ng-host — Pool certificate verification…">{`
+xe host-refresh-server-certificate host=<host>   # refresh the pool-internal identity certificates
+xe host-reset-server-certificate host=<host>     # regenerate the host's self-signed server certificate
+`}</Terminal>
+
+Resetting or replacing a certificate (including with the procedure at the top of this page) is compatible with verification: XAPI redistributes the new certificate to the pool. XAPI raises alerts when certificates approach expiry, visible in Xen Orchestra.

--- a/docs/guides/VLAN-trunking-vm.md
+++ b/docs/guides/VLAN-trunking-vm.md
@@ -26,7 +26,7 @@ For this scenario, we are assuming a configuration of 3 physical interfaces:
 - `eth1`: WAN side - ethernet
 - `eth2`: LAN side - VLAN trunk
 
-## MTU configuration
+## 📏 MTU configuration {#mtu-configuration}
 
 The [MTU](https://en.wikipedia.org/wiki/Maximum_transmission_unit) needs to be the same on all the switch's ports carrying 802.1Q packets.
 As the VLAN header adds 4-byte overhead, a standard 1500 ethernet MTU should be configured with MTU 1504.
@@ -54,8 +54,8 @@ As an alternative to using XO,
 you can see the network list using `xe network-list`,
 directly on the master host:
 
-```
-# xe network-list params=uuid,name-label,MTU
+<Terminal title="root@xcp-ng-host — MTU configuration">{`
+xe network-list params=uuid,name-label,MTU
 uuid ( RO)          : e1012298-fdd6-595a-c81f-dae5c3a6d4f6
     name-label ( RW): Host internal management network
            MTU ( RW): 1500
@@ -71,7 +71,7 @@ uuid ( RO)          : ea1a8810-43ba-0f8c-499a-22442ad5ea11
 uuid ( RO)          : 015bda3e-830b-d33d-ab91-098632ef61a3
     name-label ( RW): Pool-wide network associated with eth2
            MTU ( RW): 1500
-```
+`}</Terminal>
 
 choose the LAN network that will have the VLAN trunk,
 and modify it:
@@ -110,7 +110,7 @@ or more simply, just reboot the host.
 
 ```
 
-## VM interfaces
+## 🔌 VM interfaces {#vm-interfaces}
 
 Once the MTU is properly configured, create a new VM for OPNsense with several VIFs:
 - `VIF #0` - the management interface (MTU 1500)
@@ -121,7 +121,7 @@ The MTU isn't configurable here and the value is taken from the underlying netwo
 If the MTU isn't 1504 for your trunk network,
 please go back and review the configuration.
 
-## OPNsense installation
+## 🛡️ OPNsense installation {#opnsense-installation}
 
 Once you've booted OPNsense, start the manual interface assignment and configure VLANs.
 

--- a/docs/guides/_category_.json
+++ b/docs/guides/_category_.json
@@ -1,6 +1,6 @@
 {
     "label": "Guides",
-    "position": 8,
+    "position": 9,
     "link": {
       "type": "generated-index",
       "description": "List of guides for XCP-ng."

--- a/docs/guides/amd-performance-improvements.md
+++ b/docs/guides/amd-performance-improvements.md
@@ -2,7 +2,7 @@
 
 This page details performance improvements on AMD processors and how to deploy the fixes on your pool.
 
-## What's the "AMD EPYC performance" story?
+## 📖 What's the "AMD EPYC performance" story? {#whats-the-amd-epyc-performance-story}
 
 This issue was first identified on EPYC processors in 2024, which is why it was first called the "AMD EPYC performance issue". However, it affects all AMD processors, not just the EPYC product line.
 
@@ -11,7 +11,7 @@ Network traffic is efficient for many workloads, but not the most demanding ones
 
 As with most performance issues, this case is complicated. The issue can stem from multiple causes, but at least one bottleneck has been eliminated.
 
-## Fix 1 (significant): uncached grant-tables
+## 🩹 Fix 1 (significant): uncached grant-tables {#fix-1-significant-uncached-grant-tables}
 
 ### Technical description of the issue and its fix
 
@@ -53,12 +53,12 @@ There's more work to be done to improve performance on AMD EPYC servers, but it 
 
 Use the [`check_grant_table_cacheability.py`](https://github.com/xcp-ng/xcp/blob/master/scripts/amd_perf/check_grant_table_cacheability.py) script:
 
-```
-$ wget https://raw.githubusercontent.com/xcp-ng/xcp/refs/heads/master/scripts/amd_perf/check_grant_table_cacheability.py
+<Terminal title="How to validate the fix on Linux guests">{`
+wget https://raw.githubusercontent.com/xcp-ng/xcp/refs/heads/master/scripts/amd_perf/check_grant_table_cacheability.py
 $ sudo python3 ./check_grant_table_cacheability.py
 'xen-platform-pci' PCI IO mem address is 0xFB000000
 Grant table cacheability fix is ACTIVE.
-```
+`}</Terminal>
 
 ### OS support
 
@@ -105,7 +105,7 @@ Guest kernel version determines whether the performance fix is supported or not.
 * _SOON_: Distro needs to update its kernel
 
 
-## Fix 2: spurious interrupts
+## ⚡ Fix 2: spurious interrupts {#fix-2-spurious-interrupts}
 
 ### Technical description of the issue and its fix
 
@@ -138,7 +138,7 @@ Here are the LTS kernels that have been fixed:
 * v6.15.11
 * v6.16.2
 
-## Future improvements and leads
+## 🔮 Future improvements and leads {#future-improvements-and-leads}
 
 The last improvement does not work on every platform, so the story may not be over yet. At least one bottleneck remains.
 

--- a/docs/guides/autostart-vm.md
+++ b/docs/guides/autostart-vm.md
@@ -4,21 +4,21 @@ How to start VM on host boot?
 
 A VM can be started at XCP-ng boot itself, it's called **Auto power on**. We have two ways to configure it: using Xen Orchestra or via the CLI.
 
-## With Xen Orchestra
+## 🛰️ With Xen Orchestra {#with-xen-orchestra}
 
 In Xen Orchestra we can just enable a toggle in VM "Advanced" view, called **Auto power on**. Everything will be set accordingly.
 
 ![XO's VM advanced tab showing the Auto power on option.](../../assets/img/autopoweron1.png)
 
 
-## With the CLI
+## 🧑‍💻 With the CLI {#with-the-cli}
 
 1. Determine the UUID of the pool for which we want to enable Auto Start. To do this, run the console command on the server:
 
-```
-# xe pool-list
+<Terminal title="root@xcp-ng-host — With the CLI">{`
+xe pool-list
 uuid ( RO) : <VM_UUID>
-```
+`}</Terminal>
 
 2. Allow autostart of virtual machines at the pool level with the found UUID command:
 `# xe pool-param-set uuid=<VM_UUID> other-config:auto_poweron=true`
@@ -26,12 +26,12 @@ uuid ( RO) : <VM_UUID>
 Now we enable autostart at the virtual machine level.
 3. Execute the command to get the UUID of the virtual machine:
 
-```
-# xe vm-list
+<Terminal title="root@xcp-ng-host — xe pool-list">{`
+xe vm-list
     uuid ( RO)           : <VM_UUID>
     name-label ( RW)     : VM
     power-state ( RO)    : running
-```
+`}</Terminal>
 
 4. Enable autostart for each virtual machine with the UUID found:
 `# xe vm-param-set uuid=<VM_UUID> other-config:auto_poweron=true`

--- a/docs/guides/create-use-custom-xcpng-ubuntu-templates.md
+++ b/docs/guides/create-use-custom-xcpng-ubuntu-templates.md
@@ -17,7 +17,7 @@ This post explains in detail the steps to create templates based on Ubuntu. The 
 
 All experiments will be conducted using the graphical virtual machine manager [Xen Orchestra](https://xen-orchestra.com), except for the last part where we will use XO-CLI (Xen Orchestra CLI) to bypass the graphical interface.
 
-## Prerequisites
+## ℹ️ Prerequisites {#prerequisites}
 
 * [XCP-NG](https://xcp-ng.org/)
 * [Xen Orchestra](https://xen-orchestra.com) from the sources or Xen Orchestra virtual Appliance (XOA)
@@ -25,7 +25,7 @@ All experiments will be conducted using the graphical virtual machine manager [X
 * [JQ](https://jqlang.github.io/jq/) (for the last part of this post)
 * Ubuntu 22.04.04 Server LTS under ISO and OVA formats
 
-## Create a new Virtual Machine
+## 🏗️ Create a new Virtual Machine {#create-a-new-virtual-machine}
 
 Two approaches for creating a virtual machine will be presented in this post:
 
@@ -81,7 +81,7 @@ The creation of the virtual image from a cloud image in OVA format is complete. 
     $ sudo apt dist-upgrade
     ```
 
-10. Install the package *xe-guest-utilities-latest* to improve communication between the XCP-NG hypervisor and the virtual machine ([Guest tools](https://docs.xcp-ng.org/vms/#%EF%B8%8F-guest-tools)):
+10. Install the package *xe-guest-utilities-latest* to improve communication between the XCP-NG hypervisor and the virtual machine ([Guest tools](https://docs.xcp-ng.org/vms/#guest-tools)):
 
     ```
     $ sudo apt install xe-guest-utilities
@@ -225,7 +225,7 @@ The creation of the virtual image *custom-ubuntu22.04* from an ISO file is compl
 * If a problem occurs when creating or using your template, go to `/var/log` and look for `cloud-init.log` to troubleshoot the issue.
 :::
 
-## Template creation
+## 📸 Template creation {#template-creation}
 
 The template creation step involves converting an existing virtual machine into the format used for templates. This step is irreversible in the sense that the virtual machine will no longer appear in the list of virtual machines in [Xen Orchestra](https://xen-orchestra.com).
 
@@ -235,7 +235,7 @@ The template creation step involves converting an existing virtual machine into 
 
 The template has been created and added to the list of existing templates. The created template is named after the virtual machine *custom-ubuntu22.04*.
 
-## Using the template
+## 🚀 Using the template {#using-the-template}
 
 Using the previously created template will allow you to rely on an existing virtual machine on which it will be possible to add configurations supported by Cloud-init. The [documentation](https://cloudinit.readthedocs.io/en/latest/index.html) for [Cloud-init](https://cloud-init.io/) regarding configurations is not user friendly. This [GitHub repository](https://github.com/number5/cloud-init/tree/main/doc/examples) associated with the official documentation makes it easier to understand the complexity of [Cloud-init](https://cloud-init.io/).
 
@@ -356,7 +356,7 @@ ssh_authorized_keys:
 
 Note that it is possible to use a programming language to call the JSON-RPC API over WebSocket. This [post](https://mickael-baron.fr/blog/2021/05/28/xo-server-websocket-jsonrcp) provides more details on how to use either Python or Java.
 
-## Conclusion
+## 🏁 Conclusion {#conclusion}
 
 This post has detailed the creation of templates based on the Ubuntu distribution. These described steps can also be applied to other Linux distributions, such as Debian. Regarding the creation of Linux virtual machines from a template using [Cloud-init](https://cloud-init.io/), there are still many configurations to explore. The [Cloud-init](https://cloud-init.io/) documentation, despite its complexity, allows you to express all the constraints to initialize virtual machines tailored to your needs.
 

--- a/docs/guides/dom0-memory.md
+++ b/docs/guides/dom0-memory.md
@@ -12,7 +12,7 @@ In any case:
 * monitor RAM usage in the control domain
 * if issues arise (failed live migration for example), [look at the logs](../../troubleshooting/log-files) for messages related to lack of memory
 
-## Recommended values
+## 📏 Recommended values {#recommended-values}
 
 * we advise to give at least 2GiB of RAM for Dom0. Below that your XCP-ng may experience performance issues or other weird errors.
 * up to 64GiB RAM on your machine, at least 4GiB RAM for Dom0
@@ -22,15 +22,17 @@ In any case:
 Note: If you use ZFS, assign at least 16GB RAM to avoid swapping. ZFS (in standard configuration) uses half the Dom0 RAM as cache!
 :::
 
-## Current RAM usage
+## 📊 Current RAM usage {#current-ram-usage}
 
 You can use `htop` to see how much RAM is currently used in the dom0. Alternatively, you can have Netdata to show you past values.
 
-## Change dom0 memory
+## 🔧 Change dom0 memory {#change-dom0-memory}
 
 Example with 4 GiB:
 
-`/opt/xensource/libexec/xen-cmdline --set-xen dom0_mem=4096M,max:4096M`
+<Terminal shell title="root@xcp-ng-host — Change dom0 memory">{`
+/opt/xensource/libexec/xen-cmdline --set-xen dom0_mem=4096M,max:4096M
+`}</Terminal>
 
 Do not mess the units and make sure to set the same value as base value and as max value.
 

--- a/docs/guides/guest-UEFI-Secure-Boot.md
+++ b/docs/guides/guest-UEFI-Secure-Boot.md
@@ -4,7 +4,7 @@ How to configure UEFI Secure boot?
 
 Enabling UEFI Secure Boot for guests ensures that XCP-ng VMs will only execute trusted binaries at boot. In practice, these are the binaries released by the operating system (OS) vendor for the OS running in the VM (Microsoft Windows, Debian, RHEL, Alpine, etc.).
 
-## Recent changes in guest Secure Boot configuration
+## 🆕 Recent changes in guest Secure Boot configuration {#recent-changes-in-guest-secure-boot-configuration}
 
 The default guest Secure Boot keys in XCP-ng are changing.
 
@@ -44,7 +44,7 @@ This step is also required for Secure Boot support on previously V2V-migrated VM
 **Risk of data loss:** Propagating certificates to an existing VM will change its Secure Boot vTPM measurements. If you depend on these measurements (e.g. BitLocker with TPM protector), you must carefully read the [Preparing for Secure Boot Variable Changes](#preparing-for-secure-boot-variable-changes) procedure.
 :::
 
-## Requirements
+## ℹ️ Requirements {#requirements}
 
 * XCP-ng >= 8.2.1.
 * UEFI Secure Boot Certificates installed on the pool (this is detailed below).
@@ -52,13 +52,13 @@ This step is also required for Secure Boot support on previously V2V-migrated VM
 
 Note: it's not necessary that the XCP-ng host boots in UEFI mode for Secure Boot to be enabled on VMs.
 
-## 8.3 with varstored >= 1.2.0-3.4
+## 🆙 8.3 with varstored >= 1.2.0-3.4 {#83-with-varstored--120-34}
 
 Secure Boot is ready to use on new VMs without extra configuration. Simply activate Secure Boot on your VMs, and they will be provided with an appropriate set of default Secure Boot variables.
 
 We will keep updating the default Secure Boot variables with future updates from Microsoft. If you don't want this behavior, you can lock in these variables by using the [Manually Install the Default UEFI Certificates](#manually-install-the-default-uefi-certificates) procedure.
 
-## 8.2.1 and 8.3 with varstored < 1.2.0-3.4
+## 🧓 8.2.1 and 8.3 with varstored < 1.2.0-3.4 {#821-and-83-with-varstored--120-34}
 
 These versions of XCP-ng require manual configuration to enable Secure Boot.
 
@@ -89,7 +89,7 @@ Starting with XCP-ng 8.3, Xen Orchestra was made to help you in the setup of Sec
 More about this in [Troubleshoot Guest Secure Boot Issues](#troubleshoot-guest-secure-boot-issues)
 :::
 
-## How XCP-ng Manages the Certificates
+## 🎓 How XCP-ng Manages the Certificates {#how-xcp-ng-manages-the-certificates}
 
 Let's embark on our journey towards understanding how all this works.
 
@@ -125,7 +125,7 @@ At the VM level:
 * The VM's Operating System may update some of the VM's certificates by itself (Windows updates the revocation list, `dbx`, when needed).
 * We provide administrators with tools to [manage a VM's UEFI certificates](#certificate-management) if needed.
 
-## Configure the Pool
+## 🎱 Configure the Pool {#configure-the-pool}
 
 For pools with varstored version >= 1.2.0-3.4, no action is required.
 
@@ -171,7 +171,7 @@ Certificate and revocation lists provided by [microsoft/secureboot_objects](http
 
 To install these variables from the command line interface:
 
-```
+<Terminal shell title="root@xcp-ng-host — Manually Install the Default…">{`
 # Download and install PK/KEK/db/dbx certificates (varstored < 1.2.0-3.4)
 secureboot-certs install default default default latest
 # or simply: secureboot-certs install
@@ -181,13 +181,13 @@ secureboot-certs install
 
 # Go back to XCP-ng-managed defaults (varstored >= 1.2.0-3.4)
 secureboot-certs clear
-```
+`}</Terminal>
 
 If `secureboot-certs` fails to download the certificates from Microsoft due to microsoft.com deciding to forbid downloads from the user agent declared by the script, you may try to download with a different user agent (for example your current browser's user agent):
 
-```
+<Terminal shell title="root@xcp-ng-host — Go back to XCP-ng-managed…">{`
 secureboot-certs install --user-agent="Mozilla/5.0 My custom user agent"
-```
+`}</Terminal>
 
 If this still fails, check the next section which explains how to install them manually.
 
@@ -228,10 +228,10 @@ Advanced use, not needed by most users.
 
 For example, to install a custom PK you may do the following:
 
-```
+<Terminal shell title="root@xcp-ng-host — Install Custom UEFI Certificates">{`
 # Enroll a custom PK along with the default KEK/db/dbx
 secureboot-certs install PK.cer
-```
+`}</Terminal>
 
 The same procedure may be used to install custom KEK, db, or dbx variables.
 
@@ -244,10 +244,10 @@ This is the most compatible option for old installation media that may not inclu
 Once installed, the guest can still update the dbx variable on its own to revoke vulnerable bootloaders as long as the default KEK is included.
 Omitting the dbx variable can be done using the following command:
 
-```
+<Terminal shell title="root@xcp-ng-host — Enroll a custom PK along with…">{`
 # Install default PK/KEK/db variables, omit the dbx
 secureboot-certs install default default default none
-```
+`}</Terminal>
 
 For help with the tool's install functionality, call `secureboot-certs install -h`.
 
@@ -255,13 +255,13 @@ For help with the tool's install functionality, call `secureboot-certs install -
 
 If you want to revert to the XCP-ng pool Secure Boot defaults, simply issue the following command:
 
-```
+<Terminal shell title="root@xcp-ng-host — Resetting Pool UEFI Certificates…">{`
 secureboot-certs clear
-```
+`}</Terminal>
 
 Existing VMs will not be affected.
 
-## Enable Secure Boot for a Guest VM
+## ✅ Enable Secure Boot for a Guest VM {#enable-secure-boot-for-a-guest-vm}
 
 ### Enable Secure Boot at VM creation
 
@@ -291,10 +291,10 @@ to enable Secure Boot.
 
 2. In the XCP-ng CLI, set the platform Secure Boot mode to `true`:
 
-```
+<Terminal shell title="root@xcp-ng-host — Enable Secure Boot for an…">{`
 # Enable Secure Boot for the VM
 xe vm-param-set uuid=<vm-uuid> platform:secureboot=true
-```
+`}</Terminal>
 
 #### Check Secure Boot Is Actually Enforced
 Boot the VM, and [check Secure Boot is really enforced](#check-uefi-secure-boot-status-from-inside-the-vm). There are cases where you may think it is enforced but it isn't. See also [Troubleshoot Guest Secure Boot Issues](#troubleshoot-guest-secure-boot-issues).
@@ -331,7 +331,7 @@ Consequences:
 Also see [VMs that won't boot due to a revoked certificate](#vms-that-wont-boot-due-to-a-revoked-certificate).
 :::
 
-## Disable Secure Boot for a Guest VM
+## 🚫 Disable Secure Boot for a Guest VM {#disable-secure-boot-for-a-guest-vm}
 
 ### Disable Secure Boot for a Guest VM using XO
 
@@ -341,14 +341,14 @@ Navigate to the *Advanced* tab and use the **Secure boot** toggle to disable Sec
 
 In the XCP-ng CLI:
 
-```
+<Terminal shell title="root@xcp-ng-host — Disable Secure Boot for a Guest…">{`
 # Disable Secure Boot for the VM
 xe vm-param-set uuid=<vm-uuid> platform:secureboot=false
-```
+`}</Terminal>
 
 Reboot the VM and Secure Boot will be disabled.
 
-## Troubleshoot Guest Secure Boot Issues
+## 🧑‍⚕️ Troubleshoot Guest Secure Boot Issues {#troubleshoot-guest-secure-boot-issues}
 You may encounter the following issues with your VMs when enabling Secure Boot:
 * The VM won't boot.
 * The VM does boot, but SecureBoot is actually disabled.
@@ -365,7 +365,7 @@ Starting with XCP-ng 8.3, you can get a "secureboot readiness" status of a VM: f
 | certs_incomplete | ⚠️ SecureBoot wanted, but some EFI certificates are missing | Unbootable VM because Secure Boot can't be enforced, due to missing certificates. Only some certs are present. This will often mean that your VM was booted before your pool was setup for Secure Boot, so it only has the `PK` key, and is missing the rest of the necessary certificates. | [Check your pool was setup](#view-certificates-already-installed-on-the-pool) for Secure Boot, [set it up](#configure-the-pool) if needed, then [propagate the pool certificates to the VM](#propagate-pool-certificates-to-a-vm).|
 
 
-## Secure Boot and revoked certificates
+## ⛔ Secure Boot and revoked certificates {#secure-boot-and-revoked-certificates}
 
 ### Revocation database updates
 
@@ -404,15 +404,15 @@ Despite this, we still recommend that you always install the latest revocation d
   * either disable Secure Boot for the VM, as its binaries are not secure anymore anyway. This can be temporary until an update brings properly signed binaries.
   * or [install](#change-the-certificates-already-installed-on-a-vm) an older `dbx` to the VM, [downloaded from the archive of prior versions of `dbx` files](https://uefi.org/revocationlistfile/archive). Let us stress again that this exposes the VM to risk, and therefore, we recommend that before choosing an archived `dbx` users evaluate the vulnerabilities that their guest system will be exposed to by omitting the most recent revocations. Above all, downgrading the `dbx` must not give you a dangerous false sense of security.
 
-## Certificate Management
+## 🗂️ Certificate Management {#certificate-management}
 
 ### View Certificates Already Installed on the Pool
 
 To view the default certificates that are available pool-wide:
 
-```
+<Terminal shell title="root@xcp-ng-host — View Certificates Already…">{`
 secureboot-certs report
-```
+`}</Terminal>
 
 If it lists `PK`, `KEK`, `db` and `dbx`, then your pool was already setup for Secure Boot.
 
@@ -426,9 +426,9 @@ The new certificates will be used for new VMs, but will *not* be automatically p
 
 To remove the installed certs in the pool:
 
-```
+<Terminal shell title="root@xcp-ng-host — Remove Certificates from the Pool">{`
 secureboot-certs clear
-```
+`}</Terminal>
 
 :::tip
 Note that this does not remove the certs from the VMs. On XCP-ng 8.2.x it doesn't remove them from host disk either.
@@ -440,15 +440,15 @@ Note that this does not remove the certs from the VMs. On XCP-ng 8.2.x it doesn'
 
 List UEFI variables:
 
-```
+<Terminal shell title="root@xcp-ng-host — View Certificates Already…">{`
 varstore-ls <vm-uuid>
-```
+`}</Terminal>
 
 And then to see the full cert:
 
-```
+<Terminal shell title="View Certificates Already Installed in a VM">{`
 varstore-get <vm-uuid> <guid> <name> | hexdump -Cv
-```
+`}</Terminal>
 
 The GUID and name for varstore-get are the values returned by `varstore-ls`.
 
@@ -456,9 +456,9 @@ The GUID and name for varstore-get are the values returned by `varstore-ls`.
 
 A VM will usually have its own copy of the UEFI certificates (unless it never booted on a host that has certificates installed). To verify this, execute:
 
-```
+<Terminal shell title="root@xcp-ng-host — Change the Certificates Already…">{`
 varstore-ls <vm-uuid>
-```
+`}</Terminal>
 
 If the relevant certs are installed, their names will be in the output (i.e., `PK`, `KEK`, `db`, or `dbx`).
 
@@ -539,7 +539,7 @@ To update an individual certificate in the VM's NVRAM store:
    d719b2cb-3d3a-4596-a3bc-dad00e67656f dbx
    ```
 
-## Misc
+## ⛑️ Misc {#misc}
 
 ### Secure Boot and the UEFI Firmware Menu in the Guest
 
@@ -553,9 +553,9 @@ If disabling Secure Boot by removing keys via Custom Mode is attempted in the UE
 
 ### Check whether a VM runs on UEFI firmware from command line
 
-```
+<Terminal shell title="root@xcp-ng-host — Check whether a VM runs on UEFI…">{`
 xe vm-param-get uuid=<vm-uuid> param-name=HVM-boot-params param-key=firmware
-```
+`}</Terminal>
 
 ### Check UEFI Secure Boot status from inside the VM
 
@@ -586,21 +586,23 @@ Advanced use, not needed by most users.
 To create a Secure Boot variable (PK, KEK, db, or dbx) with multiple certificates, it is required to use the `create-auth` tool to bundle the certificates into a single .auth file.
 
 From command line, to create a KEK with certificates `cert1.crt` and `cert2.crt`:
-```
+
+<Terminal shell title="root@xcp-ng-host — Use two or more certificates for…">{`
 /opt/xensource/libexec/create-auth KEK KEK.auth cert1.crt cert2.crt
-```
+`}</Terminal>
 
 To create the same auth as above, but also sign it with a custom key:
-```
+
+<Terminal shell title="root@xcp-ng-host — Use two or more certificates for…">{`
 /opt/xensource/libexec/create-auth -c signer.crt -k signer.key KEK KEK.auth cert1.crt cert2.crt
-```
+`}</Terminal>
 
 After creating the auth file, use secureboot-certs to install it with the rest of your certs:
 
-```
+<Terminal shell title="root@xcp-ng-host — Use two or more certificates for…">{`
 # Install custom KEK, download and install public PK/db/dbx certificates
 secureboot-certs install default KEK.auth default latest
-```
+`}</Terminal>
 
 This may be done with any PK, KEK, db, or dbx.
 
@@ -614,9 +616,9 @@ Advanced use, not needed by most users.
 
 For example, to remove the `dbx` from a VM.
 
-```
+<Terminal shell title="Remove Certificates from a VM">{`
 varstore-rm <vm-uuid> d719b2cb-3d3a-4596-a3bc-dad00e67656f dbx
-```
+`}</Terminal>
 
 Note that the GUID may be found by using `varstore-ls <vm-uuid>`.
 
@@ -635,6 +637,6 @@ A VM without a `PK` is in UEFI Setup Mode. In this mode, defined in the UEFI spe
 
 We don't know why someone would want to use Setup Mode in their VMs, but if for any reason you need it, you can switch a VM to Setup Mode with:
 
-```
+<Terminal shell title="UEFI Setup Mode">{`
 varstore-sb-state
-```
+`}</Terminal>

--- a/docs/guides/host-reboot.md
+++ b/docs/guides/host-reboot.md
@@ -2,7 +2,7 @@
 
 How to properly handle host power cycle?
 
-## General case
+## 🔄 General case {#general-case}
 
 The proper way to reboot or shutdown a host is:
 
@@ -22,7 +22,7 @@ The proper way to reboot or shutdown a host is:
 Step 1 is especially important if [High Availability](../../management/ha) is enforced on your pool. You don't want the other hosts to believe that a host crashed or self-fenced - and take consecutive action - when it's actually planned maintenance. Alternatively, you can also disable HA on the pool for the duration of the maintenance operations to avoid issues caused by HA.
 :::
 
-## With "agile" VMs
+## 🤸 With "agile" VMs {#with-agile-vms}
 
 If all your VMs are "agile", that is, they're not tied to local storage or local devices (device pass-through), and if there are enough resources on other hosts in the pool, the above can be simplified as:
 

--- a/docs/guides/lacp-install-upgrade.md
+++ b/docs/guides/lacp-install-upgrade.md
@@ -1,6 +1,6 @@
 # Using LACP to Net Install or Upgrade XCP-ng
 
-## Foreword
+## 📖 Foreword {#foreword}
 
 :::warning
 - This guide is specifically for environments using LACP-only networks, without LACP fallback. It assumes you do not want to reconfigure your switches.
@@ -13,7 +13,7 @@ Our installer does not support LACP. This guide explains how to bypass this limi
 When using LACP, your switch needs to be configured for it. If you cannot or prefer not to reconfigure your switch, you won’t be able to use the single-interface option provided by the installer.
 For other bonding methods (active-backup, balance-lsb), the switch does not need to be aware of the bond, and you can simply use one of the interfaces that will be part of the bond.
 
-## When does the installer need network?
+## 🌐 When does the installer need network? {#when-does-the-installer-need-network}
 
 A working network configuration is only necessary in the following scenarios:
 
@@ -26,7 +26,7 @@ Network access is not required for:
 - A new installation from the full ISO.
 - Upgrading the master host from the full ISO.
 
-## Installation or Upgrade steps
+## 🪜 Installation or Upgrade steps {#installation-or-upgrade-steps}
 
 :::info
 During an upgrade, the installer will not detect your existing bond configuration. In XCP-ng, network settings are managed by XAPI and applied to Open vSwitch, but the installation process operates independently of these components.
@@ -45,31 +45,31 @@ Do not attempt to configure the bond yet. Doing so would mislead the installer i
 4. Use `ip link` to make sure that the interfaces are named `ethX`. If that's the case, you can move on to the next steps.
 5. Now we can configure a bond using standard linux tools.
 
-```bash
+<Terminal shell title="Installation or Upgrade steps">{`
 modprobe bonding mode=802.3ad miimon=100 # automatically creates bond0 in 8.3 installer
 ip link set eth0 down
 ip link set eth1 down
 ip link set eth0 master bond0
 ip link set eth1 master bond0
-```
+`}</Terminal>
 
 6. Configure an IP address. There are two ways to do this:
 
 - Via DHCP:
 
-```bash
+<Terminal shell title="Installation or Upgrade steps">{`
 dhclient bond0
-```
+`}</Terminal>
 
 - Manually assigning a static IP:
 
-```bash
+<Terminal shell title="Installation or Upgrade steps">{`
 ip addr add aaa.bbb.ccc.ddd/NN dev bond0
 ip route add default via aaa.bbb.ccc.1
 ip link set bond0 up
 # if doing a netinstall, set DNS too
 echo "nameserver aaa.bbb.ccc.1" > /etc/resolv.conf
-```
+`}</Terminal>
 
 For example:\
 ![Terminal capture showing the output of previous commands.](../assets/img/installer-creating-lacp-bond.png)
@@ -117,25 +117,25 @@ At this point, you’ll need to create your bond and set it as the management in
 
 1. Create a new network named `bond0`. For example:
 
-```bash
+<Terminal shell title="root@xcp-ng-host — New net install">{`
 xe network-create name-label="bond0"
-```
+`}</Terminal>
 
 2. Create the bond using the `network-uuid` that command just returned:
 
-```bash
+<Terminal shell title="root@xcp-ng-host — New net install">{`
 xe bond-create mode=lacp network-uuid=<network_uuid> pif-uuids=<pif_uuid#1>,<pif-uuid#2>
-```
+`}</Terminal>
 
 3. Set the previously created bond as your management interface:
 
-```bash
+<Terminal shell title="root@xcp-ng-host — New net install">{`
 # for example, to set a static IP:
 xe pif-reconfigure-ip uuid=<bond_pif_uuid> netmask=255.255.255.0 gateway=192.168.1.1 IP=192.168.1.5 DNS=192.168.1.1 mode=static
 # or, for DHCP:
 xe pif-reconfigure-ip uuid=<bond_pif_uuid> mode=dhcp
 # then set it as management interface:
 xe host-management-reconfigure pif-uuid=<bond_pif_uuid>
-```
+`}</Terminal>
 
 You're all set!

--- a/docs/guides/logs.md
+++ b/docs/guides/logs.md
@@ -6,7 +6,7 @@ How to get further with XCP-ng logs?
 Any manual modification to the configuration files described below may prevent future XCP-ng updates to update the contents of those files. Avoid modifying them and ask for advice if you have a use case that appears to require such modifications.
 :::
 
-## logrotate
+## ♻️ logrotate {#logrotate}
 
 `logrotate` is the tool to administrate the rotation, compression, removal, ... of log files.
 The configuration is located in `/etc/logrotate.conf`; the `/etc/logrotate.d` directory is included by this file for additional rules (for example for specific packages after RPM installation like `xha`, `blktap`, `SMlog`...).
@@ -18,13 +18,24 @@ By default a file is rotated if:
 
 Also a file is compressed after two rotations, the first time it is just renamed.
 
-## rsyslog
+## 📡 rsyslog {#rsyslog}
 
 Because a file must be rotated if a log exceeds 100 MiB, the `rsyslog` daemon is used to trigger automatically the `/etc/cron.daily/logrotate` script without waiting for the logrotate cron job to run. (Conf location: `/etc/rsyslog.d/xenserver.conf`)
 
-## Specific config: `xensource.log`
+## 📜 Specific config: `xensource.log` {#specific-config-xensourcelog}
 
 `xensource.log` has many particular and different configuration parameters, so another `logrotate` config is used: `/etc/xensource/xapi-logrotate.conf` in a shell script `/opt/xensource/libexec/xapi-logrotate.sh` that executes `logrotate` with this specific config.
 
 There is normally no need to run it manually, a cron task `/etc/cron.d/xapi-logrotate.cron` is present to schedule it each hour.
 The goal of this special config is to keep the `xensource.log` files for one month, and to limit the number of log files to 100.
+
+## 📤 Remote syslog {#remote-syslog}
+
+Sending logs to a central syslog server keeps them available even when a host dies, and offloads the (very verbose) log writing from the host's disk:
+
+<Terminal shell title="root@xcp-ng-host — Remote syslog">{`
+xe host-param-set uuid=<host-uuid> logging:syslog_destination=<syslog-server-ip-or-fqdn>
+xe host-syslog-reconfigure host-uuid=<host-uuid>
+`}</Terminal>
+
+To revert, remove the key with `xe host-param-remove uuid=<host-uuid> param-name=logging param-key=syslog_destination` and run `host-syslog-reconfigure` again.

--- a/docs/guides/pfsense.md
+++ b/docs/guides/pfsense.md
@@ -4,25 +4,25 @@ A guide to run pfSense in a VM.
 
 Despite pfSense and OPNsense do work great in a VM, there are a few extra steps that need to be taken first.
 
-## 1. Create VM as normal.
+## 🏗️ 1. Create VM as normal. {#1-create-vm-as-normal}
 
 * When creating the VM, choose the `other install media` VM template
 * Prefer `UEFI` boot mode for pfSense versions > 2.4 (`BIOS` mode works but will be slower to boot)
 * Continue through the installer like normal
 
-## 2. Install Guest Utilities
+## 🛠️ 2. Install Guest Utilities {#2-install-guest-utilities}
 
 There are 2 ways of doing that, either using the CLI (pfSense or OPNsense) or the Web UI (OPNsense).
 
 Option 1 via console/ssh:
 Now that you have the VM running, we need to install guest utilities and tell them to run on boot. SSH (or other CLI method) to the VM and perform the following:
 
-```
+<Terminal shell title="2. Install Guest Utilities">{`
 pkg install xe-guest-utilities
 echo 'xenguest_enable="YES"' >> /etc/rc.conf.local
 ln -s /usr/local/etc/rc.d/xenguest /usr/local/etc/rc.d/xenguest.sh
 service xenguest start
-```
+`}</Terminal>
 
 Option 2 is via the Web GUI (only available on OPNsense):
 Open the web UI on `http(s)://your-configured-ip` and go to:
@@ -33,41 +33,42 @@ Next: Reboot the system to have the guest tools started (installer doesn't do th
 
 Guest Tools are now installed and running, and will automatically run on every boot of the VM.
 
-## 3. Disable TX Checksum Offload
+## 🚫 3. Disable TX Checksum Offload {#3-disable-tx-checksum-offload}
 
 Now is the most important step: we must disable TX checksum offload on the virtual xen interfaces of the VM. This is because network traffic between VMs in a hypervisor is not populated with a typical Ethernet checksum, since they only traverse server memory and never leave over a physical cable. The majority of operating systems know to expect this when virtualized and handle Ethernet frames with empty checksums without issue. However `pf` in FreeBSD does not handle them correctly and will drop them, leading to broken performance.
 
 The solution is to simply turn off checksum-offload on the virtual xen interfaces for pfSense in the TX direction only (TX towards the VM itself). Then the packets will be checksummed like normal and `pf` will no longer complain.
 
 :::tip
-Disabling checksum offloading is only necessary for virtual interfaces. When using [PCI Passthrough](../compute.md#-pci-passthrough) to provide a VM with direct access to physical or virtual (using [SR-IOV](https://en.wikipedia.org/wiki/Single-root_input/output_virtualization)) devices it is unnecessary to disable TX checksum offloading on any interfaces on those devices.
+Disabling checksum offloading is only necessary for virtual interfaces. When using [PCI Passthrough](../compute.md#pci-passthrough) to provide a VM with direct access to physical or virtual (using [SR-IOV](https://en.wikipedia.org/wiki/Single-root_input/output_virtualization)) devices it is unnecessary to disable TX checksum offloading on any interfaces on those devices.
 :::
 
 :::warning
 Many guides on the internet for pfSense in Xen VMs will tell you to uncheck checksum options in the pfSense web UI, or to also disable RX offload on the Xen side. These are not only unnecessary, but some of them will make performance worse.
 :::
 
-## Using Xen Orchestra
+## 🛰️ Using Xen Orchestra {#using-xen-orchestra}
 
 - Head to the "Network" tab of your VM : in the advanced settings (click the blue gear icon) for each adapter, disable TX checksumming.
 - Restart the VM.
 
 That's it !
 
-## Using CLI
+## 🧑‍💻 Using CLI {#using-cli}
 
 SSH to dom0 on your XCP-NG hypervisor and run the following:
 
 First get the UUID of the VM to modify:
 
-```
+<Terminal shell title="root@xcp-ng-host — Using CLI">{`
 xe vm-list
-```
+`}</Terminal>
+
 Find your pfSense / OPNsense VM in the list, and copy the UUID. Now stick the UUID in the following command:
 
-```
+<Terminal shell title="root@xcp-ng-host — Using CLI">{`
 xe vif-list vm-uuid=57a27650-6dab-268e-1200-83ee17ee3a55
-```
+`}</Terminal>
 
 This will list all the virtual interfaces assigned to the VM:
 
@@ -86,10 +87,10 @@ uuid ( RO)            : a9380705-8da2-4bf7-bbb0-f167d8f0d645
 
 For each interface, you need to take the UUID (the one at the top labeled `uuid ( RO)`) and insert it in the `xe vif-param-set uuid=xxx other-config:ethtool-tx="off"` command. So for our two virtual interfaces the commands to run would look like this:
 
-```
+<Terminal shell title="root@xcp-ng-host — Using CLI">{`
 xe vif-param-set uuid=789358b4-54c8-87d3-bfb3-0b7721e4661b other-config:ethtool-tx="off"
 xe vif-param-set uuid=a9380705-8da2-4bf7-bbb0-f167d8f0d645 other-config:ethtool-tx="off"
-```
+`}</Terminal>
 
 That's it! For this to take effect you need to fully shut down the VM then power it back on. Then you are good to go!
 
@@ -111,15 +112,15 @@ SSH to dom0 on your XCP-NG hypervisor and find your pfSense / OPNsense VM UUID (
 
 Configure the VM `parallel` port to `none` using the following command:
 
-```
+<Terminal shell title="root@xcp-ng-host — Remove Parallel / Serial Ports…">{`
 xe vm-param-set platform:parallel=none uuid=57a27650-6dab-268e-1200-83ee17ee3a55
-```
+`}</Terminal>
 
 Configure the VM `serial` port to `none` using the following command:
 
-```
+<Terminal shell title="root@xcp-ng-host — Remove Parallel / Serial Ports…">{`
 xe vm-param-set platform:hvm_serial=none uuid=57a27650-6dab-268e-1200-83ee17ee3a55
-```
+`}</Terminal>
 
 :::tip
 If your pfSense VM is experiencing long delays during the boot process, it may be due to the [VM communicating with the disks using the emulated IDE controller instead of the SCSI controller](https://blog.3mdeb.com/2019/2019-12-13-pfsense-boot-under-xen/#debug-xen). If this is the case, the pre-boot process can take a few minutes before the pfSense "Starting Device Manager (devd)" step which normally takes ~1 minute or less, then the boot process continues at the "normal" speed. This issue has been observed when the VM is using the `BIOS` boot mode (default for `Other install media` in XCP-ng Center) with recent pfSense > 2.4 versions. This problem only delays the boot process (booted VM performance is "normal") and is not observed when using the `UEFI` boot mode (as recommended in step 1).

--- a/docs/guides/shrink_virtual_drive.md
+++ b/docs/guides/shrink_virtual_drive.md
@@ -2,7 +2,7 @@
 
 XCP-ng doesn't support VDI (Virtual Disk Image) shrinking, only growing. However, there are solutions to achieve the same result, albeit with some manual steps.
 
-## Windows VMs
+## 🪟 Windows VMs {#windows-vms}
 
 There are two options to do this. The most reliable is the Clonezilla method, but the XenConvert route might also work.
 
@@ -58,6 +58,6 @@ When it's done:
 1. Detach the bigger disk (keep it as a backup in case something goes wrong).
 1. Boot the VM.
 
-## Linux VMs
+## 🐧 Linux VMs {#linux-vms}
 
 You can use the same Clonezilla method. However, since "everything is a file" in Linux/BSDs, you can also use `rsync` to migrate the files from the original system to the new one.

--- a/docs/guides/software-RAID-SR.md
+++ b/docs/guides/software-RAID-SR.md
@@ -18,7 +18,7 @@ In addition, the example presented below is a fresh installation and not being i
 
 These instructions assume you are starting with a server already installed with software RAID and have no other storage repositories defined except what may be on the existing RAID.
 
-## Example System
+## 🖥️ Example System {#example-system}
 
 The example system we're demonstrating here is a small server using 5 identical 1TB hard drives. XCP-ng has already been installed in a software RAID configuration using 2 of the 5 drives. There is already a default "Local storage" repository configured as part of the XCP-ng setup on the existing RAID 1 drive pair.
 
@@ -55,7 +55,7 @@ unused devices: <none>
 
 The 5 drives are in place as `sda` through `sde` and as can be seen from the list are exactly the same size. The RAID 1 drive pair is set up as the XCP-ng default of a partitioned RAID 1 array `md127` using drives `sda` and `sdb` and is in a healthy state.
 
-## Building the Second RAID
+## 🧱 Building the Second RAID {#building-the-second-raid}
 
 We have 3 remaining identical drives,  `sdc`, `sdd`, and `sde` and we're going to create a RAID 5 array using them in order to maximize the amount of space. We'll create this using the mdadm command like this:
 
@@ -103,7 +103,7 @@ unused devices: <none>
 
 Here we can see that the new RAID 5 array is in place as array `md0`, is using drives `sdc`, `sdd`, and `sde` and is healthy. As expected for a 3 drive RAID 5 array, it is providing about twice as much available space as a single drive.
 
-## Building the Storage Repository
+## 💽 Building the Storage Repository {#building-the-storage-repository}
 
 Now we create a new storage repository on the new RAID array like this:
 
@@ -118,7 +118,7 @@ At this point, we'd expect that the system could just be used as is, virtual mac
 
 Unfortunately, we'd be wrong.
 
-## Unstable RAID Arrays When Booting
+## 🫨 Unstable RAID Arrays When Booting {#unstable-raid-arrays-when-booting}
 
 What really happens when XCP-ng boots with a software RAID is that code in the Linux kernel and in the initrd file will attempt to find and automatically assemble any RAID arrays in the system. When there is just the single `md127` RAID 1 array, the process works pretty well. Unfortunately, the system seems to occasionally break down where there are more drives, more arrays, and more complex arrays.
 
@@ -132,7 +132,7 @@ This can also happen to the `md127` boot array where it will show with only one 
 
 So what can we do about this?  Fortunately, we can give the system more information about what RAID arrays are in the system and specify that they should be started up at boot.
 
-## Stabilizing the RAID Boot Configuration: The mdadm.conf File
+## 📌 Stabilizing the RAID Boot Configuration: The mdadm.conf File {#stabilizing-the-raid-boot-configuration-the-mdadmconf-file}
 
 The first thing we need to do is give the system more information on what RAID arrays exist and how they're put together. The way to do this is by creating a raid configuration file `/etc/mdadm.conf`.
 
@@ -159,19 +159,20 @@ Notice that this is output in almost exactly the same format as shown in the `md
 
 If we don't want to type in the entire file, we can create the file like this.
 
-```
+<Terminal shell title="Stabilizing the RAID Boot Configuration: The…">{`
 echo 'AUTO +all' > /etc/mdadm.conf
 echo 'MAILADDR root' >> /etc/mdadm.conf
 echo 'DEVICE /dev/sda /dev/sdb /dev/sdc /dev/sdd /dev/sde' >> /etc/mdadm.conf
 mdadm --examine --scan >> /etc/mdadm.conf
-```
+`}</Terminal>
+
 And then edit the file to change the format of the array names from `/dev/md/0` to `/dev/md0` and remove the `name=` parameters from each line. This isn't strictly necessary but keeps the array names in the file consistent with what is reported in `/proc/mdstat` and `/proc/partitions` and avoids giving each array another name (in our case those names would be `localhost:127` and `XCP-ng:0`).
 
 So what do these lines do? The first line instructs the system to allow or attempt automatic assembly for all arrays defined in the file. The second specifies to report errors in the system by email to the root user. The third is a list of all drives in the system participating in RAID arrays. Not all drives need to be specified on a single DEVICE line. Drives can be split among multiple lines and we could even have one DEVICE line for each drive. The last two are descriptions of each array in the system.
 
 This file gives the system a description of what arrays are configured in the system and what drives are used to create them but doesn't specify what to do with them. The system should be able to use this information at boot for automatic assembly of the arrays. Booting with the `mdadm.conf` file in place is more reliable but still runs into same problems as before.
 
-## Stabilizing the RAID Boot Configuration: The initrd Configuration
+## 🧬 Stabilizing the RAID Boot Configuration: The initrd Configuration {#stabilizing-the-raid-boot-configuration-the-initrd-configuration}
 
 The other thing we need to do is give the system some idea of what to do with the RAID arrays at boot time. The way to do this is by adding instructions for the `dracut` program creating the initrd file to enable all RAID support, use the `mdadm.conf` file we created, and to start the arrays at boot time.
 
@@ -206,13 +207,13 @@ The second set instructs the booting Linux kernel to support automatic RAID asse
 
 Something to note when creating the file is to allow extra space between command line parameters. That is why most of the lines have extra space before and after parameters within the quotes.
 
-## Building and Testing the New initrd File
+## 🧪 Building and Testing the New initrd File {#building-and-testing-the-new-initrd-file}
 
 Now that we have all of this extra configuration, we need to get the system to include it for use at boot. To do that we use the `dracut` command to create a new initrd file like this:
 
-```
+<Terminal shell title="Building and Testing the New initrd File">{`
 dracut --force -M /boot/initrd-$(uname -r).img $(uname -r)
-```
+`}</Terminal>
 
 This creates a new initrd file with the correct name matching the name of the Linux kernel and prints a list of modules included in the initrd file. Printing the list isn't necessary but is handy to see that `dracut` is making progress as it runs.
 
@@ -234,7 +235,7 @@ unused devices: <none>
 
 We can see that both arrays are active and healthy with all drives accounted for. Examining the storage repositories using Xen Orchestra, XCP-ng, or `xe` commands shows that both the Local storage and RAID storage repositories are available.
 
-## Troubleshooting
+## 🧑‍⚕️ Troubleshooting {#troubleshooting}
 
 The most common problems in this process stem from one of a few things.
 
@@ -244,16 +245,17 @@ The second is that the drives were not empty before including them into the syst
 
 The way to avoid this problem is to make sure the drives are thoroughly wiped before starting the process. This can be done from the command line with the `dd` command like this:
 
-```
+<Terminal shell title="Troubleshooting">{`
 dd if=/dev/zero of=/dev/sde bs=1M
-```
+`}</Terminal>
+
 This writes zeroes to every block on the drive and will wipe any traces of previous filesystems or RAID configurations.
 
 Sometimes only one drive has a problem when assembling the RAID and we'll see a working RAID with one drive missing. We'll assume that our md0 RAID was assembled correctly except that it is missing drive `/dev/sde`. In that case, it should be possible to add the missing drive into the array like this:
 
-```
+<Terminal shell title="Troubleshooting">{`
 mdadm --add /dev/md0 /dev/sde
-```
+`}</Terminal>
 
 If the drive is added to the RAID array correctly, we should start to see a lot of disk activity and we should be able to monitor the progress of it by looking at the `/proc/mdstat` file.
 
@@ -261,9 +263,9 @@ If the drive will not add to the array due to something left over on the drive, 
 
 The other possibility is that the RAID array is created correctly but XCP-ng will not create a storage repository on it because some previous content of the drives is causing a problem. It should be possible to recover from this by writing zeroes to the entire array without needing to rebuild it like this:
 
-```
+<Terminal shell title="Troubleshooting">{`
 dd if=/dev/zero of=/dev/md0 bs=1M
-```
+`}</Terminal>
 
 After the probably very lengthy process of zeroing out the array, it should be possible to try again to create a storage repository on the RAID array.
 
@@ -277,13 +279,13 @@ Another possible but rare problem is caused by drives that shift their identific
 
 This type of problem is very difficult to diagnose and correct. It may be possible to resolve it using different BIOS or setup configurations in the host system or by updating BIOS or controller firmware.
 
-## Updates and Upgrades
+## ♻️ Updates and Upgrades {#updates-and-upgrades}
 
 We will eventually need to update or patch the system to fix problems or close security holes as they are discovered.
 
 [Updates](../../management/updates) are patches that are applied to isolated parts of the system and replace or correct just the affected programs or data files. The patches are applied using the `yum` command from the host system's command line or via the Xen Orchestra patches tab for a host or pool. The individual update patches should not affect either the added `mdadm.conf` or `dracut_mdraid.conf` files and any rebuild of the initrd file as part of a Linux kernel update should use the configuration from those files. In general, updates should be safe to apply without risk of affecting software RAID operation.
 
-[Upgrades made by booting from CD](../../installation/upgrade#-upgrade-via-installation-iso-recommended) or the equivalent via network booting are different from updates. The upgrade process replaces the entire running system by creating a backup copy of the current system into a separate disk partition then performing a full installation from the CD and makes copies of the configuration data and files from the previous system, upgrading them as needed. As part of a full upgrade, it is likely that one or both of the added RAID configuration files will not be copied from the original system to the upgraded system.
+[Upgrades made by booting from CD](../../installation/upgrade#upgrade-via-installation-iso-recommended) or the equivalent via network booting are different from updates. The upgrade process replaces the entire running system by creating a backup copy of the current system into a separate disk partition then performing a full installation from the CD and makes copies of the configuration data and files from the previous system, upgrading them as needed. As part of a full upgrade, it is likely that one or both of the added RAID configuration files will not be copied from the original system to the upgraded system.
 
 Before installing an upgrade via CD, check the running RAID arrays and look for any problems with drives as follows:
 
@@ -335,9 +337,9 @@ If the `mdadm.conf` or `dracut_mdraid.conf` files are damaged or cannot be copie
 
 After the rebuilding of the initrd file has finished, it should be safe to reboot the host system. At this point, the system should start and run normally.
 
-In some cases it is also possible to perform [an upgrade using `yum`](../../installation/upgrade#-from-command-line) instead of booting from CD. This type of upgrade does not completely replace the running system and does not create a backup copy. It is really a long series of updates instead of a full replacement. When upgrading a system using `yum`, the `mdadm.conf` and `dracut_mdraid.conf` files should remain in place just as with updates but copies of the files should be saved before the upgrade just in case.
+In some cases it is also possible to perform [an upgrade using `yum`](../../installation/upgrade#from-command-line) instead of booting from CD. This type of upgrade does not completely replace the running system and does not create a backup copy. It is really a long series of updates instead of a full replacement. When upgrading a system using `yum`, the `mdadm.conf` and `dracut_mdraid.conf` files should remain in place just as with updates but copies of the files should be saved before the upgrade just in case.
 
-## More and Different
+## 🎨 More and Different {#more-and-different}
 
 So what if we don't have or don't want a system that's identical to the example we just built in these instructions? Here are some of the possible and normal variations of software RAID under XCP-ng.
 

--- a/docs/guides/vm-encryption.md
+++ b/docs/guides/vm-encryption.md
@@ -11,7 +11,7 @@ This guide covers two common methods: encrypting data inside the VM and using en
 
 :::
 
-## Encrypting inside the VM
+## 🔒 Encrypting inside the VM {#encrypting-inside-the-vm}
 
 The easiest and most flexible way to secure your VM's data is by enabling encryption directly within the operating system.
 
@@ -52,13 +52,13 @@ For Linux VMs, here are two popular tools:
     sudo mount /dev/mapper/encrypted_volume /mnt
     ```
 
-## Encrypting a shared storage repository
+## 🗄️ Encrypting a shared storage repository {#encrypting-a-shared-storage-repository}
 
 If you want to protect data across multiple hosts, consider using an encrypted storage repository (SR) for your VM disks. A popular option for this is TrueNAS, which can manage and encrypt SRs.
 
 For detailed instructions, refer to the TrueNAS guide on [storage encryption](https://www.truenas.com/docs/core/13.0/coretutorials/storage/pools/storageencryption/).
 
-## Things to keep in mind
+## 🧠 Things to keep in mind {#things-to-keep-in-mind}
 
 - **Encryption inside the VM** is the easiest and most flexible option. It works regardless of your storage setup and lets you choose the encryption method you prefer. However, this only protects data inside the VM. Your hypervisor and storage layer stay unencrypted.
 - **Encrypted storage repositories** secure data at the storage level, protecting all virtual disks in the SR. This is useful if you want to safeguard data across multiple VMs or hosts. Just be aware that it may affect performance and requires compatible storage hardware.

--- a/docs/guides/winpv-update.md
+++ b/docs/guides/winpv-update.md
@@ -14,7 +14,7 @@ To contextualize the update process, we will test it on a VM vulnerable to XSA-4
 
 ![A banner indicating that some of the VMs are vulnerable with a link to check them.](../assets/img/winpv-update/vuln1.png)
 
-## Setting up automatic installation
+## ⚙️ Setting up automatic installation {#setting-up-automatic-installation}
 
 Create a new GPO in your desired OU and edit it:
 
@@ -39,7 +39,7 @@ In **Select deployment method**, select **Assigned**. You can change this later.
 
 The targeted VMs will now pick up and install the driver package you selected.
 
-## Setting up automatic reboot
+## 🔄 Setting up automatic reboot {#setting-up-automatic-reboot}
 
 The Windows PV drivers require multiple reboots to be installed or updated.
 In this section, we will set up the Autoreboot feature of Windows PV drivers.
@@ -69,7 +69,7 @@ Specify the following settings:
 
 Click **OK** to save the changes.
 
-## Observing the installation process
+## 👀 Observing the installation process {#observing-the-installation-process}
 
 You'll need to reboot your VMs to apply the updates.
 After reboot, the VMs will pick up on your new GPO and install the linked driver package.
@@ -84,12 +84,12 @@ Once the update finishes, you should no longer see the vulnerability warning in 
 
 ![Hosts list showing no banner and no warning icon now that everything is installed.](../assets/img/winpv-update/vuln2.png)
 
-## Useful links
+## 🔗 Useful links {#useful-links}
 
 - If you want to remove existing Xen drivers, refer to the [XenClean guide](/vms/#fully-removing-xen-pv-drivers-with-xenclean).
 - Refer to the [XenBootFix guide](/troubleshooting/windows-pv-tools/#windows-fails-to-boot-hangs-inaccessible_boot_device) if you encounter VM boot issues after the update.
 
-## Appendix: Blocking vulnerable Xen drivers with Application Control for Windows
+## 🛡️ Appendix: Blocking vulnerable Xen drivers with Application Control for Windows {#appendix-blocking-vulnerable-xen-drivers-with-application-control-for-windows}
 
 :::warning
 **Risk of BSOD**: Incorrect application of App Control rules can prevent the system from booting.

--- a/docs/guides/xcpng-in-a-vm.md
+++ b/docs/guides/xcpng-in-a-vm.md
@@ -16,7 +16,7 @@ Here is the list of hypervisors on which you can try XCP-ng :
 * [QEMU/KVM](#nested-xcp-ng-using-qemukvm)
 * [Virtualbox](https://www.virtualbox.org) (Nested Virtualisation implemented only in v6.1.x and above - [https://www.virtualbox.org/ticket/4032](https://www.virtualbox.org/ticket/4032))
 
-## Nested XCP-ng using XCP-ng
+## 📦 Nested XCP-ng using XCP-ng {#nested-xcp-ng-using-xcp-ng}
 
 * create a new VM from CentOS 7 template with minimum 2 vCPU and 4GB RAM
 * change disk size to 100GB
@@ -24,7 +24,7 @@ Here is the list of hypervisors on which you can try XCP-ng :
 * default NIC type of Realtek may create stability issue for nested XCP-NG, change it to Intel e1000 : `xe vm-param-set uuid=<UUID> platform:nic_type="e1000"`
 * install/use it like normal :-)
 
-## Nested XCP-ng using Xen
+## 🐼 Nested XCP-ng using Xen {#nested-xcp-ng-using-xen}
 
 It's a pretty standard HVM, but you need to use a `vif` of `ioemu` type. Check this configuration example:
 
@@ -58,7 +58,7 @@ on_reboot   = 'destroy'
 on_crash    = 'destroy'
 ```
 
-## Nested XCP-ng using VMware (ESXi and Workstation)
+## 🇻 Nested XCP-ng using VMware (ESXi and Workstation) {#nested-xcp-ng-using-vmware-esxi-and-workstation}
 
 _The following steps can be performed under VMware Workstation Pro, the settings will remain the same but the configuration will be slightly different. We will discuss this point at the end of this section about VMware._
 
@@ -122,7 +122,7 @@ Once your host's network is set up, we'll look at configuring the XCP-ng virtual
    * Check if the virtual machine correctly works by trying to connect using XCP-ng Center and by creating a virtual machine on your nested XCP-ng.
 
 
-## Nested XCP-ng using Microsoft Hyper-V (Windows 10 - Windows Server 2016)
+## 🇭 Nested XCP-ng using Microsoft Hyper-V (Windows 10 - Windows Server 2016) {#nested-xcp-ng-using-microsoft-hyper-v-windows-10---windows-server-2016}
 
 
 _The following steps can be performed with Hyper-V on Windows 10 (version 1607 minimum) and Windows Server 2016 (Hyper-V Server also). The settings will remain the same for both OS._
@@ -158,7 +158,7 @@ The VM settings :
 
 ![Windows Server on XCP-ng under Hyper-V](http://image.noelshack.com/fichiers/2018/39/5/1538145459-2.png)
 
-## Nested XCP-ng using QEMU/KVM
+## 🇰 Nested XCP-ng using QEMU/KVM {#nested-xcp-ng-using-qemukvm}
 
 _The following steps can be performed using QEMU/KVM on a Linux host, Proxmox or oVirt._
 

--- a/docs/installation/hardware.md
+++ b/docs/installation/hardware.md
@@ -11,16 +11,16 @@ XCP-ng comes with a large range of hardware support.
 
 A given device may be supported at one of two levels:
 
-1. Presence on the [Hardware Compatibility List](#-hardware-compatibility-list-hcl) guarantees support by XCP-ng. With some exceptions described in the next section.
-2. Many devices outside the HCL are also supported, but are not tested routinely. See [Supported hardware outside the HCL](#-supported-hardware-outside-the-hcl).
+1. Presence on the [Hardware Compatibility List](#hardware-compatibility-list-hcl) guarantees support by XCP-ng. With some exceptions described in the next section.
+2. Many devices outside the HCL are also supported, but are not tested routinely. See [Supported hardware outside the HCL](#supported-hardware-outside-the-hcl).
 
-## 📖 Hardware Compatibility List (HCL)
+## 📖 Hardware Compatibility List (HCL) {#hardware-compatibility-list-hcl}
 
 XCP-ng 8.3 shares a compatibility list with XenServer 8.4. Thus, devices listed on [XenServer's Hardware Compatibility List](http://hcl.xenserver.com/) are supported, with rare exceptions.
 
 Exceptions include devices which require *proprietary* software components to operate (closed source drivers, for example). Such devices do not impede the use of XCP-ng, but their features cannot be exploited.
 
-## ♻ Supported hardware outside the HCL
+## ♻ Supported hardware outside the HCL {#supported-hardware-outside-the-hcl}
 
 Many devices outside the HCL actually work perfectly with XCP-ng. Contrarily to some hypervisors, XCP-ng does not demand the use of servers from a curated short list. Most of the hardware support depends on the Linux kernel drivers plus vendor drivers covering a very large range of devices.
 
@@ -30,7 +30,7 @@ Concretely, if your hardware is not on the HCL, there's still a very high chance
 
 Let's mention one particular kind of exceptions to support, though. **Security on older hardware having hardware vulnerabilities.** Older hardware, while usually still running very well - and we're all for using existing hardware while it lasts rather than buying new machines - may not receive hardware-related security updates from their very vendor. In particular those related to side-channel attacks (Spectre, Meltdown, and everything that ensued). In this case, you can use XCP-ng, but without expecting protection against this kind of vulnerablity, because it simply doesn't depend on XCP-ng (or any other hypervisor): it depends on the hardware vendor.
 
-## 🧰 Alternate drivers
+## 🧰 Alternate drivers {#alternate-drivers}
 
 XCP-ng occasionally provides alternate drivers for users who have issues with the main drivers installed with XCP-ng.
 
@@ -43,26 +43,29 @@ In this section we provide instructions that are common to all the provided driv
 Just replace `package-name` with the actual package name.
 
 ### Installation
-```
+
+<Terminal shell title="root@xcp-ng-host — Installation">{`
 yum install package-name
-```
+`}</Terminal>
 
 ### Activation
 
 The simplest way is to `reboot`.
 
 Else, if you know the module name, you can unload it from the kernel and reload it.
-```
+
+<Terminal shell title="Activation">{`
 modprobe -r module-name
 modprobe -v module-name
-```
+`}</Terminal>
 
 ### Uninstallation
 
 If the driver does not work as intended, just remove the package from the system and follow the "Activation" steps above.
-```
+
+<Terminal shell title="root@xcp-ng-host — Uninstallation">{`
 yum remove package-name
-```
+`}</Terminal>
 
 ### Updates
 
@@ -81,14 +84,14 @@ A list is maintained at [https://github.com/xcp-ng/xcp/wiki/Drivers](https://git
 Check the "XCP-ng X.Y alternate driver" column, which provides packages names and versions for every available alternate driver.
 
 
-## 🎁 Additional kernel modules
+## 🎁 Additional kernel modules {#additional-kernel-modules}
 
-Additional kernel modules are a lot like [alternate drivers](#-alternate-drivers) (most of the above section applies to them) except that they don't replace an existing driver from the system. They add a new one that didn't exist at all.
+Additional kernel modules are a lot like [alternate drivers](#alternate-drivers) (most of the above section applies to them) except that they don't replace an existing driver from the system. They add a new one that didn't exist at all.
 
 Their list is maintained at [https://github.com/xcp-ng/xcp/wiki/Drivers](https://github.com/xcp-ng/xcp/wiki/Drivers), in a table named "Other kernel modules available in XCP-ng X.Y".
 
 
-## 🚒 Alternate kernel
+## 🚒 Alternate kernel {#alternate-kernel}
 
 We provide an "alternate Linux kernel" on XCP-ng 8.0 and above, named `kernel-alt`. It is kernel 4.19, as the main kernel, but with all updates from the Linux 4.19 branch applied. By construction, it should thus be stable. However it **receives less testing** so we cannot fully guarantee against regressions (any detected regression we'd work on a fix quickly, of course). We also backport security fixes from the main kernel to the alternate kernel when needed.
 
@@ -107,27 +110,28 @@ This will boot the installer with the alternate kernel and also install the alte
 ### Installation on an existing system
 You can install it using
 
-```
+<Terminal shell title="root@xcp-ng-host — Installation on an existing…">{`
 yum install kernel-alt
-```
+`}</Terminal>
 
 This will install the kernel and add a grub boot menu entry to boot from it. It will **not** default to it unless you change the default in `grub.cfg` (`/boot/grub/grub.cfg` or `/boot/efi/EFI/xenserver/grub.cfg` depending on whether you are in BIOS mode or UEFI mode).
 
 There may also be a newer release of kernel-alt in testing repositories:
 
-```
+<Terminal shell title="root@xcp-ng-host — Installation on an existing…">{`
 yum install kernel-alt --enablerepo=xcp-ng-testing
-```
+`}</Terminal>
 
 ### Uninstall
 Boot the main kernel, then:
-```
+
+<Terminal shell title="root@xcp-ng-host — Uninstall">{`
 yum remove kernel-alt
-```
+`}</Terminal>
 
 This will remove the added grub entry automatically too and set default boot to main kernel if needed.
 
-## 🛠️ Tips related to specific hardware
+## 🛠️ Tips related to specific hardware {#tips-related-to-specific-hardware}
 
 Below is a non-exhaustive list of server models or devices for which the XCP-ng community provided extra tips.
 
@@ -190,7 +194,7 @@ There are several USB 5Gbps NICs based on this chipset available on the market. 
 
 The kernel module is just a repackage for XCP-ng of [the AQC111U drivers available for Linux Kernel 3.10 on the Marvell website](https://www.marvell.com/support/downloads.html).
 
-To install the driver follow the instructions provided in the [**Alternate drivers** section below](#-alternate-drivers) and use `aqc111u-module` as `package-name` _(`module-name` would be `aqc111u`)_.
+To install the driver follow the instructions provided in the [**Alternate drivers** section below](#alternate-drivers) and use `aqc111u-module` as `package-name` _(`module-name` would be `aqc111u`)_.
 
 Known compatible NICs are [^1]:
 

--- a/docs/installation/install-xcp-ng.md
+++ b/docs/installation/install-xcp-ng.md
@@ -6,9 +6,9 @@ sidebar_position: 2
 
 How to install XCP-ng.
 
-## 💿 ISO installation
+## 💿 ISO installation {#iso-installation}
 
-If you want to use the netinstall ISO, see the [Netinstall section](#-netinstall).
+If you want to use the netinstall ISO, see the [Netinstall section](#netinstall).
 
 ### Download and create media
 
@@ -18,10 +18,10 @@ SHA256 checksums, GPG signatures and net-install ISOs are available [here](https
 
 Then, create the install media (e.g. a USB key 1GB or larger should work):
 
-```
+<Terminal shell title="Download and create media">{`
 # example with XCP-ng 8.3
 dd if=xcp-ng-8.3.0-20250606.2.iso of=/dev/sdX bs=8M oflag=direct
-```
+`}</Terminal>
 
 Finally, boot on that media and go to the next section.
 
@@ -166,7 +166,7 @@ After a reboot, you should see the GRUB menu:
 
 It means the system is correctly installed! Enjoy XCP-ng 🚀
 
-## 🌐 Netinstall
+## 🌐 Netinstall {#netinstall}
 
 The netinstall image is a lightweight ISO (around 150MiB) that will only contain the installer, but no actual RPM packages. Sometimes, it's more convenient/faster when your ISO is on a slow connection (e.g. a virtual media using a server IPMI).
 
@@ -174,13 +174,13 @@ You can download it on this URL: [https://mirrors.xcp-ng.org/isos/8.3/xcp-ng-8.3
 
 As with the regular installation ISO, write it on a USB media:
 
-```
+<Terminal shell title="Netinstall">{`
 dd if=xcp-ng-8.3.0-20250606-netinstall.iso of=/dev/sdX bs=8M oflag=direct
-```
+`}</Terminal>
 
 Everything else is like the [regular install](#start-the-host), except that it will not offer to install from local media, only from distant ones.
 
-## 🎬 PXE boot install
+## 🎬 PXE boot install {#pxe-boot-install}
 
 ### Requirements
 
@@ -204,7 +204,7 @@ PXE boot doesn't support tagged VLAN networks! Be sure to boot on a untagged net
 4. In the TFTP root directory, create a folder called `pxelinux.cfg`
 5. In the pxelinux.cfg directory, create your configuration file called `default`.
 
-The file itself will contain the way to install XCP-ng: manually (with answer to provide on the host console/screen) or fully automated (see [Automated install](/installation/install-xcp-ng/#-automated-install) below).
+The file itself will contain the way to install XCP-ng: manually (with answer to provide on the host console/screen) or fully automated (see [Automated install](/installation/install-xcp-ng/#automated-install) below).
 
 Here is an example of a manual installation:
 
@@ -216,7 +216,8 @@ label xcp-ng
 ```
 
 How TFTP folder looks like when configured
-```
+
+<Terminal title="TFTP server configuration - BIOS boot">{`
 tree -L 1 /srv/tftp/
 srv/tftp
 ├── mboot.c32
@@ -227,7 +228,7 @@ srv/tftp
     ├── install.img
     ├── vmlinuz
     └── xen.gz
-```
+`}</Terminal>
 
 #### TFTP server configuration - UEFI boot
 
@@ -248,7 +249,8 @@ If you want to make an installation in UEFI mode, you need to have a slightly di
 5. Copy the following files from the XCP-ng ISO: `grubx64.efi`, `install.img` (from the root directory), `vmlinuz`, and `xen.gz` (from the /boot directory) to the new `EFI/xcp-ng` directory on the TFTP server.
 
 How TFTP folder looks like when configured
-```
+
+<Terminal title="TFTP server configuration - UEFI boot">{`
 tree -L 1 /srv/tftp/
 srv/tftp
 └── EFI
@@ -259,7 +261,7 @@ srv/tftp
     │   └── xen.gz
     └── xenserver
         └── grub.cfg
-```
+`}</Terminal>
 
 On the FTP, NFS or HTTP server, get all the installation media content in there.
 
@@ -276,7 +278,7 @@ When you do copy the installation files, **DO NOT FORGET** the `.treeinfo` file.
 3. Select boot from the Ethernet card
 4. You should see the PXE menu you created before!
 
-## ✨ iPXE over HTTP install
+## ✨ iPXE over HTTP install {#ipxe-over-http-install}
 
 This guide is for UEFI boot, using iPXE over an HTTP server to serve files needed for installation.
 
@@ -291,7 +293,7 @@ To get XCP-ng installed from iPXE over HTTP, you need:
 
 The top-level should look like this:
 
-```
+<Terminal title="Requirements">{`
 tree -L 1 /path/to/http-directory/
 .
 ├── EFI
@@ -302,7 +304,7 @@ tree -L 1 /path/to/http-directory/
 ├── RPM-GPG-KEY-Platform-V1
 ├── boot
 └── install.img
-```
+`}</Terminal>
 
 2. Boot the target machine.
 3. Press Ctrl-B to catch the iPXE menu.  Use the chainload command to load grub.
@@ -336,7 +338,7 @@ configfile /EFI/xenserver/grub.cfg
 7. Continue with installation as normal.
 
 
-## 🤖 Automated install
+## 🤖 Automated install {#automated-install}
 <a name="-automatedinstall"></a>
 XCP-ng's installation can be automated by using network boot (PXE) or a custom installation image.
 
@@ -371,7 +373,7 @@ Check [the full answerfile reference](../../appendix/answerfile).
 
 ### Via PXE
 
-Follow the [previous section on Network boot (PXE)](#-pxe-boot-install) and add options to that will fetch and use an answer file.
+Follow the [previous section on Network boot (PXE)](#pxe-boot-install) and add options to that will fetch and use an answer file.
 
 #### PXE unattended install - BIOS boot
 
@@ -524,15 +526,31 @@ As an improvement and to delay the `md` resync (increasing install speed by abou
 
 The `noresync.sh` script would do something like this:
 
-```
+<Terminal shell title="Software RAID in answerfile">{`
 #!/bin/sh
 echo 0 > /proc/sys/dev/raid/speed_limit_max
 echo 0 > /proc/sys/dev/raid/speed_limit_min
-```
+`}</Terminal>
 
 Upon server reboot, normal `md` resync will take place.
 
-## Advanced installation options (installer command-line parameters)
+## 🧭 Boot from SAN {#boot-from-san}
+
+Instead of local disks, a host can be installed on (and boot from) a SAN LUN. Facts verified against the XCP-ng installer:
+
+* **Hardware HBA (Fibre Channel, FCoE HBA, SAS, hardware iSCSI)**: the HBA presents the LUN like a local disk, so the installer simply shows it in the disk selection step. Configure the HBA's boot BIOS so the server firmware boots from it.
+* **Software iSCSI boot (iBFT)**: on NICs whose firmware supports iSCSI boot (iBFT), boot the installer with the `use_ibft` parameter: it reads the iSCSI target configuration from the firmware, connects to the LUN and offers it as an installation target. The NIC used for iSCSI is then reserved for storage traffic.
+* **Multipath**: if the LUN is reachable over several paths, also boot the installer with `device_mapper_multipath=enabled` so the installation lands on the multipath device and the host boots with multipathing active from the start. Without it, installing on one bare path makes the "redundant" boot disk a single point of failure.
+
+To pass these parameters, edit the boot entry at the installer's boot menu (or add them to your [PXE](#pxe-boot-install) configuration, next to the other installer parameters), for example:
+
+```
+device_mapper_multipath=enabled use_ibft
+```
+
+The same applies to [automated installs](#automated-install): these are installer *boot* parameters, they go on the kernel command line, not in the answer file.
+
+## 🎛️ Advanced installation options (installer command-line parameters) {#advanced-installation-options-installer-command-line-parameters}
 
 The XCP-ng installer can be further parameterized to support advanced installation environments. The command line options are passed as parameters to the ```vmlinuz``` kernel of the installer.
 
@@ -562,6 +580,14 @@ A script is either XML (for ```answerfile=``` or ```rt_answerfile=```) or an exe
 Start an ssh server during installation allowing root to log-on interactively with the given password.
 
 ### Behaviour
+
+#### device_mapper_multipath=disabled|enabled
+
+Run the installation on top of multipath devices, for [boot from SAN](#boot-from-san) setups. Default: `disabled`.
+
+#### use_ibft
+
+Read the NIC firmware's iBFT to determine the iSCSI boot configuration, for software [boot from SAN](#boot-from-san).
 
 #### atexit=reboot|poweroff|shell
 
@@ -635,11 +661,11 @@ Read the scriptlocation execute it and use its standard output as an answerfile 
 
 See ```network_device=```.
 
-## 🧑‍⚕️ Troubleshooting
+## 🧑‍⚕️ Troubleshooting {#troubleshooting}
 
 See [the Troubleshooting page](../../troubleshooting/after-upgrade).
 
-## ⛑️ Misc
+## ⛑️ Misc {#misc}
 
 ### Installation on USB drives
 

--- a/docs/installation/migrate-to-xcp-ng.md
+++ b/docs/installation/migrate-to-xcp-ng.md
@@ -12,25 +12,25 @@ This documentation will help you to make a migration to XCP-ng, from any most co
 OVA import method will miss the information if the VM is running BIOS or UEFI mode. Double check your settings on your original system, and then enable (or not) UEFI on XCP-ng side for the destination VM. You can do so in VM advanced tab in Xen Orchestra.
 :::
 
-## 🇽 From XenServer
+## 🇽 From XenServer {#from-xenserver}
 
-We got a dedicated section on [how to migrate from XenServer to XCP-ng](../../installation/upgrade#-upgrade-from-xenserver).
+We got a dedicated section on [how to migrate from XenServer to XCP-ng](../../installation/upgrade#upgrade-from-xenserver).
 
-## 🍋 From Citrix Hypervisor
+## 🍋 From Citrix Hypervisor {#from-citrix-hypervisor}
 
-We got a dedicated section on [how to migrate from Citrix Hypervisor to XCP-ng](../../installation/upgrade#-upgrade-from-xenserver).
+We got a dedicated section on [how to migrate from Citrix Hypervisor to XCP-ng](../../installation/upgrade#upgrade-from-xenserver).
 
-## 🐼 From Xen on Linux
+## 🐼 From Xen on Linux {#from-xen-on-linux}
 
 If you are running Xen on your usual distro (Debian, Ubuntu…), you are using `xl` to manage your VMs, and also plain text configuration files. You can migrate to an existing XCP-ng host thanks to [the `xen2xcp` script](https://github.com/xcp-ng/xen2xcp).
 
 Check [the README](https://github.com/xcp-ng/xen2xcp/blob/master/README.md) for usage instructions.
 
-## 📦 From Virtualbox
+## 📦 From Virtualbox {#from-virtualbox}
 
-Export your VM in OVA format, and use Xen Orchestra to import it. If you have an issue on VM boot, check the [VMware](#-from-vmware) section.
+Export your VM in OVA format, and use Xen Orchestra to import it. If you have an issue on VM boot, check the [VMware](#from-vmware) section.
 
-## 🇻 From VMware
+## 🇻 From VMware {#from-vmware}
 
 :::warning
 
@@ -314,30 +314,30 @@ This method use external packages to install in XCP-ng directly (the Dom0), and 
 
 #### Install Qemu-img and vmfs tools
 
-```
+<Terminal shell title="root@xcp-ng-host — Install Qemu-img and vmfs tools">{`
 yum install qemu-img --enablerepo=base,updates
 yum install vmfs6-tools --enablerepo=xcp-ng-lab
-```
+`}</Terminal>
 
 #### Mount the VMware storage repository
 
-```
+<Terminal shell title="Mount the VMware storage repository">{`
 vmfs6-fuse /path/to/vmware/disk /mnt
-```
+`}</Terminal>
 
 #### Convert a VMDK file to a VHD
 
 For example, on a file-based SR (local ext or NFS):
 
-```
-qemu-img convert -f vmdk -O vpc myVMwaredisk.vmdk /run/sr-mount/<SR UUID>/`uuidgen`.vhd
-```
+<Terminal shell title="Convert a VMDK file to a VHD">{`
+qemu-img convert -f vmdk -O vpc myVMwaredisk.vmdk /run/sr-mount/<SR UUID>/\`uuidgen\`.vhd
+`}</Terminal>
 
 #### Rescan the SR
 
 You need to rescan the SR where you new VHD file is, so it can be detected. It will appear in the disk list, without a name or description though. Attach it to any VM you created before (eg without booting it first), and boot.
 
-## 🇭 From Hyper-V
+## 🇭 From Hyper-V {#from-hyper-v}
 
 There's two options, both requiring to export your Hyper-V VM disk in VHD format.
 
@@ -417,7 +417,7 @@ As soon you did scan the SR, the new disk is visible in the SR/disk view. Don't 
 If you lost ability to extend migrated volume (opening journal failed: -2) You need to move disk to another storage, VM should be ON during moving process. This issue can occur when vhd files was directly copied to storage folder.
 :::
 
-## 🇰 From KVM (Libvirt)
+## 🇰 From KVM (Libvirt) {#from-kvm-libvirt}
 
 Related forum thread: [https://xcp-ng.org/forum/topic/1465/migrating-from-kvm-to-xcp-ng](https://xcp-ng.org/forum/topic/1465/migrating-from-kvm-to-xcp-ng)
 

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -12,7 +12,7 @@ An XCP-ng server is dedicated entirely to running XCP-ng and hosting VMs. It is 
 Installing third-party software directly in the XCP-ng control domain is not supported, except for software supplied in the official repositories. If you wish to add extra packages to XCP-ng, please [submit your request here](https://github.com/xcp-ng/xcp/issues/56).
 :::
 
-## 📋 XCP-ng System Requirements
+## 📋 XCP-ng System Requirements {#xcp-ng-system-requirements}
 
 XCP-ng is generally deployed on server-class hardware, but it also supports many workstation and laptop models. For more information, refer to the [Hardware Compatibility List (HCL)](../../installation/hardware).
 
@@ -62,7 +62,7 @@ Similarly, installing XCP-ng on SD cards is highly discouraged. A basic SSD offe
 ### Network
 
 - Minimum 100 Mbit/s NIC. Recommended: one or more Gb or 10 Gb NICs for faster data transfers, including P2V, import/export, and VM live migrations.
-- Use multiple NICs for redundancy. Network configuration depends on your storage type—refer to vendor documentation for guidance.
+- Use multiple NICs for redundancy. Network configuration depends on your storage type: refer to vendor documentation for guidance.
 
 XCP-ng 8.2 requires an IPv4 network for management and storage traffic. Starting from XCP-ng 8.3, the management network supports IPv6.
 
@@ -71,10 +71,10 @@ XCP-ng 8.2 is EOL. This 8.2-specific information is retained solely to assist wi
 :::
 
 :::info
-Set the server's BIOS clock to the current UTC time. For debugging support cases, serial console access may be required. Consider configuring serial console access for XCP-ng. For systems without physical serial ports, explore embedded management devices like Dell DRAC or HP iLO. See [CTX228930 - How to Configure Serial Console Access on XenServer 7.0 and later](https://support.citrix.com/article/CTX228930).
+Set the server's BIOS clock to the current UTC time. For debugging support cases, serial console access may be required: see [how to configure it](../troubleshooting/advanced.md#serial-console-access). For systems without physical serial ports, embedded management devices (Dell iDRAC, HP iLO...) provide Serial-over-LAN.
 :::
 
-## 📋 XCP-ng Configuration Limits
+## 📋 XCP-ng Configuration Limits {#xcp-ng-configuration-limits}
 
 XCP-ng supports the following per host:
 
@@ -116,7 +116,7 @@ The theoretical, untested limit is 2,048 logical processors.
 
 - Up to 800 VLANs.
 
-## Virtual Machine Configuration Limits
+## 📋 Virtual Machine Configuration Limits {#virtual-machine-configuration-limits}
 
 Below are the supported limits for virtual machines on XCP-ng.
 
@@ -189,13 +189,13 @@ XCP-ng 8.2 is EOL. This 8.2-specific information is retained solely to assist wi
 
 - **Passed-through USB devices**: Up to **6**.
 
-## 🎱 Pool Requirements
+## 🎱 Pool Requirements {#pool-requirements}
 
 A resource pool is a collection of one or more servers (up to 64), which can be homogeneous or heterogeneous. Before creating or joining a pool, ensure the following:
 
 ### Hardware Requirements
 
-- All servers must have compatible CPUs (same vendor — Intel or AMD).
+- All servers must have compatible CPUs (same vendor: Intel or AMD).
 
 ### Additional Pool Requirements
 
@@ -209,7 +209,7 @@ In addition to the hardware prerequisites identified previously, there are some 
 * It cannot have a bonded management interface. Reconfigure the management interface and move it to a physical NIC before adding the server to the pool. Once the server has joined the pool, you can reconfigure the management interface again.
 * It must be running the same version of XCP-ng, at the same update level, as servers already in the pool.
 
-Resource pools can have hosts with varying physical network interfaces and local storage capacities. In practice, it is often difficult to obtain multiple servers with the exact same CPUs, and so minor variations are permitted. If you want your environment to have hosts with varying CPUs in the same resource pool, you can force join a pool together using the CLI. To know more on forced joining operation, see Hosts and Resource Pools.
+Resource pools can have hosts with varying physical network interfaces and local storage capacities. In practice, it is often difficult to obtain multiple servers with the exact same CPUs, and so minor variations are permitted. If you want your environment to have hosts with varying CPUs in the same resource pool, you can force join a pool together using the CLI. To know more on forced joining operation, see [Hosts and pools operations](../management/hosts-pools.md#heterogeneous-pools).
 
 > **Note**: Servers providing shared NFS or iSCSI storage must have static or DNS-addressable IPs.
 
@@ -221,4 +221,33 @@ A homogeneous resource pool is an aggregate of servers with identical CPUs. Serv
 
 Technologies such as Intel FlexMigration or AMD Extended Migration allow you to create heterogeneous pools. These technologies provide CPU masking or leveling, which means you can configure a CPU to appear to provide a different make, model, or feature set than it actually does. These capabilities allow you to create pools of hosts with different CPUs and still support secure, live migrations.
 
-For detailed information, see the Hosts and Resource Pools.
+For detailed information, see [Hosts and pools operations](../management/hosts-pools.md).
+
+## 🔌 Network ports and connectivity {#network-ports-and-connectivity}
+
+What needs to be reachable, if you have firewalls between your management network, your hosts and your storage.
+
+### Inbound, to the hosts
+
+| Port | Protocol | Used for |
+|---|---|---|
+| 443 | TCP | XAPI (HTTPS): all management clients (Xen Orchestra, XO Lite, `xe`), VM consoles, migrations |
+| 80 | TCP | Legacy HTTP access to XAPI. Restricted by default on XCP-ng 8.3 |
+| 22 | TCP | SSH access to dom0 |
+| 10809 | TCP | NBD, used by Xen Orchestra's NBD-enabled backups |
+
+VM consoles (VNC) are proxied through XAPI over port 443: no direct VNC port needs to be opened.
+
+### Between the hosts of a pool
+
+* **443/TCP**: pool coordination (XAPI to XAPI) and live migrations.
+* **694/UDP**: [HA](../management/ha.md) heartbeat, when high availability is enabled.
+* **[XOSTOR](../xostor/xostor.md)** pools additionally need the LINSTOR and DRBD replication ports between hosts: see the XOSTOR documentation.
+
+### Outbound, from the hosts
+
+* **53/UDP-TCP** (DNS) and **123/UDP** (NTP): name resolution and time sync.
+* **80/443 TCP** to the [update repositories](../management/updates.md) (directly or through a proxy).
+* Storage protocols towards your SRs: **2049/TCP** for NFS (plus 111 and the mountd port for NFSv3), **3260/TCP** for iSCSI, **445/TCP** for SMB.
+
+Keep the management network private: XAPI, SSH and consoles are administrative interfaces, they have no business being exposed to the internet.

--- a/docs/installation/upgrade.md
+++ b/docs/installation/upgrade.md
@@ -12,16 +12,16 @@ For updates that don't change the version numbers (bugfixes, security fixes), se
 
 :::info
 There are 3 upgrade methods, detailed below:
-* [Using the installation ISO (recommended)](#-upgrade-via-installation-iso-recommended).
+* [Using the installation ISO (recommended)](#upgrade-via-installation-iso-recommended).
 * [Using the installation ISO when you can't boot from it: remote upgrade](#using-the-installation-iso-when-you-cant-boot-from-it-remote-upgrade).
-* [From command line a.k.a. yum-style upgrade](#-from-command-line). ⚠️ Only for some point version upgrades.
+* [From command line a.k.a. yum-style upgrade](#from-command-line). ⚠️ Only for some point version upgrades.
 :::
 
 :::warning
 For upgrading XCP-ng machines with an XOSTOR SR, please refer to this [additional information](../../xostor#upgrade) before taking any action.
 :::
 
-## ☢️ Release Notes & Known Issues
+## ☢️ Release Notes & Known Issues {#release-notes--known-issues}
 
 Read the [Release Notes and Known Issues](../../releases#xcp-ng-release-history) for every release that is higher than your current release. They may provide additional instructions for specific situations. Also **please read the following warnings**:
 
@@ -30,7 +30,7 @@ Read the [Release Notes and Known Issues](../../releases#xcp-ng-release-history)
 * DON'T use the `Maintenance Mode` in XCP-ng Center. It moves the pool master to another host, which has to be avoided in the upgrade procedure.
 * If HA (High Availability) is enabled, disable it before upgrading.
 * Eject CDs from your VMs before upgrading [to avoid issues](https://xcp-ng.org/forum/topic/174/upgrade-from-xenserver-7-1-did-not-work): `xe vm-cd-eject --multiple`.
-* Read [Handling alternate drivers or kernel](#-handling-alternate-drivers-or-kernel) if your host depends on them.
+* Read [Handling alternate drivers or kernel](#handling-alternate-drivers-or-kernel) if your host depends on them.
 * [Update your pool with the latest updates](../../management/updates) **before** upgrading, and reboot or restart the toolstack, depending on the nature of the installed updates.
 * [Install the latest updates](../../management/updates) **after** upgrading.
 :::
@@ -39,7 +39,7 @@ Read the [Release Notes and Known Issues](../../releases#xcp-ng-release-history)
 * When upgrading from *XCP-ng 7.5 or lower* or from *XenServer* or *Citrix Hypervisor*, **it is very important to make sure clustering is not enabled on your pool**. It's a functionality that relies on proprietary software and that is not available in XCP-ng, and having it enabled before the upgrade will lead to XAPI being unable to start due to unexpected data in the database. If it is enabled or you already upgraded, see [this comment](https://github.com/xcp-ng/xcp/issues/94#issuecomment-437838544).
 :::
 
-## 💿 Upgrade via installation ISO (recommended)
+## 💿 Upgrade via installation ISO (recommended) {#upgrade-via-installation-iso-recommended}
 
 This is the standard XCP-ng way. With this method, note that you can often skip intermediate release (e.g. from 7.5 to 8.2 directly) without needing intermediate upgrade, but there are exceptions, so check the [release notes](../../releases#xcp-ng-release-history)! For example, we strongly advise to upgrade to XCP-ng 8.2.1 first before jumping to XCP-ng 8.3.
 
@@ -77,7 +77,7 @@ See [the Troubleshooting page](../../troubleshooting/after-upgrade).
 
 This is an alternate method if you can't boot from the installation ISO.
 
-If you do not have access to your server or remote KVM in order to upgrade using the interactive ISO installer, you can initiate an automatic reboot and upgrade process using the following procedure, which replaces steps 4 to 6 in the above [upgrade procedure](#-upgrade-via-installation-iso-recommended).
+If you do not have access to your server or remote KVM in order to upgrade using the interactive ISO installer, you can initiate an automatic reboot and upgrade process using the following procedure, which replaces steps 4 to 6 in the above [upgrade procedure](#upgrade-via-installation-iso-recommended).
 
 * Unpack/extract the XCP-ng ISO to a folder on an HTTP server. Make sure not to miss the hidden .treeinfo file (common mistake if you `cp` the files with `*`).
 * Get the UUID of your host by running the below command:
@@ -100,7 +100,7 @@ Note: it has been brought to our attention that [a DHCP server may be necessary 
 
 Once upgraded, **keep the system regularly updated** (see [Updates Howto](../../management/updates)).
 
-## 🧑‍💻 From command line
+## 🧑‍💻 From command line {#from-command-line}
 
 A.k.a. yum-style upgrade.
 
@@ -144,7 +144,7 @@ More at [Additional packages](../../management/additional-packages).
 
 #### Precautions
 
-The [precautions that apply to regular updates](../../management/updates#-precautions) also apply to the upgrade process.
+The [precautions that apply to regular updates](../../management/updates#precautions) also apply to the upgrade process.
 
 Check them carefully.
 
@@ -191,9 +191,9 @@ In the commands below your shell will automatically replace `$VER` with the valu
 
 #### 2. Upgrade the system's packages
 
-```
+<Terminal shell title="root@xcp-ng-host — 2. Upgrade the system's packages">{`
 yum update
-```
+`}</Terminal>
 
 #### 3. Check the configuration files
 
@@ -207,14 +207,14 @@ If you haven't modified configuration files that `rpm` wants to update, there wi
 
 /!\ There is an exception: always ignore the `/etc/cron.d/logrotate.cron.rpmsave` file. Citrix team named that file this way so that it is ignored by cron. It is used only with legacy partitioning, where no `/var/log` partition exists, and triggers a very aggressive log rotation. Leave it alone.
 
-```
+<Terminal shell title="3. Check the configuration files">{`
 # Find conflicting configuration files, excluding logrotate.cron.rpmsave
 find /etc \( -name "*.rpmnew" -or -name "*.rpmsave" ! -name "logrotate.cron.rpmsave" \)
-```
+`}</Terminal>
 
 #### 4. Reboot the host
 
-## 🇽 Upgrade from XenServer
+## 🇽 Upgrade from XenServer {#upgrade-from-xenserver}
 
 This article describes how to proceed in order to convert your Citrix XenServer infrastructure into a XCP-ng infrastructure.
 
@@ -326,23 +326,29 @@ If you do not have access to your server or remote KVM in order to upgrade using
 
 Unpack/extract the XCP-NG ISO to a folder on a webserver. Then get the UUID of your host by running the below command:
 
-`xe host-list`
+<Terminal shell title="root@xcp-ng-host — Alternate method: remote upgrade">{`
+xe host-list
+`}</Terminal>
 
 Using that host UUID, as well as the URL to the folder hosting the unpacked XCP-NG ISO, run the following command to test access:
 
-`xe host-call-plugin plugin=prepare_host_upgrade.py host-uuid=750d9176-6468-4a08-8647-77a64c09093e fn=testUrl args:url=http://<ip-address>/xcp-ng/unpackedexample/`
+<Terminal shell title="root@xcp-ng-host — Alternate method: remote upgrade">{`
+xe host-call-plugin plugin=prepare_host_upgrade.py host-uuid=750d9176-6468-4a08-8647-77a64c09093e fn=testUrl args:url=http://<ip-address>/xcp-ng/unpackedexample/
+`}</Terminal>
 
 The returned output must be true to continue.
 
 Now tell the host to automatically boot to the ISO and upgrade itself on next reboot (using the UUID and URL from before):
 
-`xe host-call-plugin plugin=prepare_host_upgrade.py host-uuid=750d9176-6468-4a08-8647-77a64c09093e fn=main args:url=http://<ip-address>/xcp-ng/unpackedexample/`
+<Terminal shell title="root@xcp-ng-host — Alternate method: remote upgrade">{`
+xe host-call-plugin plugin=prepare_host_upgrade.py host-uuid=750d9176-6468-4a08-8647-77a64c09093e fn=main args:url=http://<ip-address>/xcp-ng/unpackedexample/
+`}</Terminal>
 
 The output should also be true. It has created a temporary entry in the grub bootloader which will automatically load the upgrade ISO on the next boot. It then automatically runs the XCP-NG upgrade with no user intervention required. It will also backup your existing XenServer dom0 install to the secondary backup partition, just like the normal upgrade.
 
 To start the process, just tell the host to reboot. It is best to watch the progress by using KVM if it's available, but if not, it should proceed fine and boot into upgraded XCP-NG in 10 to 20 minutes.
 
-## 👴 Migrate VMs from older XenServer/XCP-ng
+## 👴 Migrate VMs from older XenServer/XCP-ng {#migrate-vms-from-older-xenserverxcp-ng}
 
 ### Live migration
 
@@ -352,13 +358,13 @@ Live migration **should work** from any older XenServer/XCP-ng toward the latest
 
 If a live migration doesn't work, Xen Orchestra is able to do a warm migration for you. It's safer and still have a reasonable downtime. [Read this dedicated article](https://xen-orchestra.com/blog/warm-migration-with-xen-orchestra/) to learn more about it.
 
-## ☣ Handling alternate drivers or kernel
+## ☣ Handling alternate drivers or kernel {#handling-alternate-drivers-or-kernel}
 
-If - before the upgrade - your host depends on [alternate drivers](../../installation/hardware#-alternate-drivers) or on the [alternate kernel](../../installation/hardware#-alternate-kernel) to function, then it is possible that the upgraded system doesn't need such alternatives anymore. It is also possible that it still needs them.
+If - before the upgrade - your host depends on [alternate drivers](../../installation/hardware#alternate-drivers) or on the [alternate kernel](../../installation/hardware#alternate-kernel) to function, then it is possible that the upgraded system doesn't need such alternatives anymore. It is also possible that it still needs them.
 
 When upgrading using the upgrade ISO:
 * Alternate drivers will not be installed automatically: install them from the repositories after the first reboot.
-* The alternate kernel will not be installed automatically, unless you tell the installer to do so (see [Alternate kernel](../../installation/hardware#-alternate-kernel)).
+* The alternate kernel will not be installed automatically, unless you tell the installer to do so (see [Alternate kernel](../../installation/hardware#alternate-kernel)).
 
 When upgrading using `yum`:
 * Alternate drivers will usually be kept and upgraded if a newer version is provided, but that is not a general rule: we handle it on a case by case basis. Sometimes a newer "default" driver will obsolete an older alternate driver.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -11,31 +11,118 @@ sidebar_position: 1
 
 XCP-ng is a high performance enterprise level virtualization platform with a rich ecosystem, that can be integrated in an entire stack to do management and backup for it (see [Xen Orchestra](management/manage-at-scale/xo-web-ui) section for that). XCP-ng stands for *Xen Cloud Platform - next generation*: it is the modern successor to XCP, initially created as an Open Source version of Citrix XenServer back in 2010.
 
-XCP-ng is -by default- a [secure platform](project/security) to run any kind of virtualization workload, while being managed by a [central administration console](management/manage-at-scale/xo-web-ui), integrated with an API and CLI but also compatible with Packer, Terraform and Ansible.
+XCP-ng is, by default, a [secure platform](project/security) to run any kind of virtualization workload, while being managed by a [central administration console](management/manage-at-scale/xo-web-ui), integrated with an API and CLI but also compatible with Packer, Terraform and Ansible.
 
 Visit the [main website](https://xcp-ng.org) to learn more. Latest updates are published on [our blog](https://xcp-ng.org/blog), don't miss any announcement there!
 
 :::tip
-Discover the growing network around XCP-ng and Xen Orchestra, collectively known as the [Vates Stack](https://vates.tech). Visit the [ecosystem page](https://docs.vates.tech/ecosystems/xcp-ng-ecosystem) at the Vates VMS documentation to explore our current partnerships and certification opportunities. Interested in joining? We’d love to [hear from you](https://vates.tech/contact)!
+Discover the growing network around XCP-ng and Xen Orchestra, collectively known as the [Vates Stack](https://vates.tech). Visit the [ecosystem page](https://docs.vates.tech/compatible-solutions/xcp-ng-ecosystem) at the Vates VMS documentation to explore our current partnerships and certification opportunities. Interested in joining? We’d love to [hear from you](https://vates.tech/contact)!
 :::
 
-## ⚙️ General design
+## 🚀 Where to start {#where-to-start}
+
+<CardGrid>
+<LinkCard title="Install XCP-ng" href="/installation/install-xcp-ng/">Download the ISO and install your first host.</LinkCard>
+<LinkCard title="Getting started journey" href="https://docs.vates.tech/getting-started/dl-install-xcpng">The guided path on the Vates docs: install, deploy Xen Orchestra, first VMs.</LinkCard>
+<LinkCard title="Migrate from VMware" href="/installation/migrate-to-xcp-ng/">V2V from VMware, and imports from Hyper-V, KVM, VirtualBox...</LinkCard>
+<LinkCard title="Create and manage VMs" href="/vms/vm-lifecycle/">Templates, clones, snapshots, migration, import/export.</LinkCard>
+<LinkCard title="Hosts and pools operations" href="/management/hosts-pools/">Pools, maintenance mode, passwords, NTP, pool-wide settings.</LinkCard>
+<LinkCard title="Updates" href="/management/updates/">Keep your hosts patched, with Rolling Pool Updates at scale.</LinkCard>
+<LinkCard title="Backup" href="/management/backup/">VM backup with Xen Orchestra, DR, pool metadata.</LinkCard>
+<LinkCard title="Troubleshooting" href="/troubleshooting/">The 3-step guide, common problems, log files.</LinkCard>
+</CardGrid>
+
+## 🧭 Which documentation for what? {#which-documentation}
+
+Three documentation sets work together. Knowing which one to open saves time:
+
+<CardGrid>
+<LinkCard title="XCP-ng documentation (you are here)" href="/">The platform itself: installation, hosts and pools, storage, networking, VMs, troubleshooting, and the project internals.</LinkCard>
+<LinkCard title="Xen Orchestra documentation" href="https://docs.xen-orchestra.com/">The management plane: XO installation, backup jobs, users and ACLs, load balancing, REST API.</LinkCard>
+<LinkCard title="Vates VMS documentation" href="https://docs.vates.tech/">The product level: getting started journeys, editions and pricing, hardware compatibility list, support, security advisories.</LinkCard>
+</CardGrid>
+
+As a rule of thumb: if it happens **on a host or pool**, it's documented here; if you do it **from Xen Orchestra**, it's in the XO docs; if it's about **the offer around the software** (trial, licenses, support, certified hardware), it's on the Vates docs.
+
+## ⚙️ General design {#general-design}
 
 XCP-ng contains multiple components, built around the Xen Hypervisor. It's meant to run on top of bare-metal machines.
 
-<div style={{textAlign: 'center'}}>
-![XCP-ng architecture overview.](../assets/img/archoverview.png)
-</div>
+<Schema label="XCP-ng · what runs where" legend={[["#8e83fe", "XCP-ng / Xen"], ["#56c288", "your workloads"]]} maxWidth="840px">
+<svg viewBox="0 0 640 330" role="img" aria-label="XCP-ng layers: hardware at the bottom, the Xen hypervisor above it, and on top the dom0 control domain running the XAPI toolstack next to the guest VMs, which run your apps on their own OS with the XCP-ng VM tools">
+  <g fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.28)">
+    <rect x="20" y="20" width="280" height="170" rx="8"/>
+    <rect x="330" y="20" width="140" height="170" rx="8"/>
+    <rect x="480" y="20" width="140" height="170" rx="8"/>
+    <rect x="20" y="274" width="600" height="44" rx="8"/>
+  </g>
+  <rect x="20" y="216" width="600" height="44" rx="8" fill="rgba(142,131,254,0.14)" stroke="#8e83fe" strokeOpacity="0.85"/>
+  <text x="36" y="46" fontSize="14.5" fill="#c6d2e1">dom0 <tspan fontSize="11" fill="#7a8699">· control domain</tspan></text>
+  <rect x="36" y="60" width="248" height="34" rx="5" fill="rgba(142,131,254,0.14)" stroke="#8e83fe" strokeOpacity="0.85"/>
+  <text x="160" y="82" fontSize="13" fill="#8e83fe" textAnchor="middle">XAPI toolstack</text>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)">
+    <rect x="36" y="106" width="118" height="34" rx="5"/>
+    <rect x="166" y="106" width="118" height="34" rx="5"/>
+    <rect x="36" y="150" width="248" height="28" rx="5"/>
+  </g>
+  <text x="95" y="127" fontSize="11.5" fill="#7a8699" textAnchor="middle">device drivers</text>
+  <text x="225" y="127" fontSize="11.5" fill="#7a8699" textAnchor="middle">QEMU</text>
+  <text x="160" y="168" fontSize="11" fill="#7a8699" textAnchor="middle">I/O backends for the guests</text>
+  <text x="400" y="46" fontSize="14.5" fill="#c6d2e1" textAnchor="middle">guest VM</text>
+  <text x="550" y="46" fontSize="14.5" fill="#c6d2e1" textAnchor="middle">guest VM</text>
+  <g fill="rgba(86,194,136,0.14)" stroke="#56c288" strokeOpacity="0.8">
+    <rect x="346" y="60" width="108" height="50" rx="5"/>
+    <rect x="496" y="60" width="108" height="50" rx="5"/>
+  </g>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)">
+    <rect x="346" y="122" width="108" height="56" rx="5"/>
+    <rect x="496" y="122" width="108" height="56" rx="5"/>
+  </g>
+  <g fontSize="12" fill="#56c288" textAnchor="middle">
+    <text x="400" y="90">your apps</text>
+    <text x="550" y="90">your apps</text>
+  </g>
+  <g fontSize="12" fill="#7a8699" textAnchor="middle">
+    <text x="400" y="146">guest OS</text>
+    <text x="550" y="146">guest OS</text>
+    <text x="400" y="164" fontSize="10">+ XCP-ng VM tools</text>
+    <text x="550" y="164" fontSize="10">+ XCP-ng VM tools</text>
+  </g>
+  <g stroke="#7a8699" strokeWidth="1.5">
+    <line x1="160" y1="190" x2="160" y2="216"/>
+    <line x1="400" y1="190" x2="400" y2="216"/>
+    <line x1="550" y1="190" x2="550" y2="216"/>
+    <line x1="320" y1="260" x2="320" y2="274"/>
+  </g>
+  <text x="36" y="243" fontSize="15" fill="#8e83fe">Xen hypervisor</text>
+  <text x="604" y="243" fontSize="11" fill="#7a8699" textAnchor="end">type-1 · boots directly on the metal</text>
+  <text x="36" y="301" fontSize="15" fill="#c6d2e1">Hardware</text>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)">
+    <rect x="360" y="285" width="44" height="22" rx="4"/>
+    <rect x="412" y="285" width="44" height="22" rx="4"/>
+    <rect x="464" y="285" width="44" height="22" rx="4"/>
+    <rect x="516" y="285" width="44" height="22" rx="4"/>
+    <rect x="568" y="285" width="44" height="22" rx="4"/>
+  </g>
+  <g fontSize="11" fill="#7a8699" textAnchor="middle">
+    <text x="382" y="299">CPU</text>
+    <text x="434" y="299">RAM</text>
+    <text x="486" y="299">disks</text>
+    <text x="538" y="299">NICs</text>
+    <text x="590" y="299">GPU</text>
+  </g>
+</svg>
+</Schema>
 
-## 📚 Stack overview
+## 📚 Stack overview {#stack-overview}
 
-The main goal of XCP-ng is to be a fully integrated and dedicated virtualization platform, without requiring any deep Linux or system knowledge. It's meant to be managed in a centralized manner via [Xen Orchestra](management/#%EF%B8%8F-manage-at-scale), whether you have only one host or thousands of them. Backup is also included inside Xen Orchestra.
+The main goal of XCP-ng is to be a fully integrated and dedicated virtualization platform, without requiring any deep Linux or system knowledge. It's meant to be managed in a centralized manner via [Xen Orchestra](management/#manage-at-scale), whether you have only one host or thousands of them. Backup is also included inside Xen Orchestra.
 
 <div style={{textAlign: 'center'}}>
 ![Vates VMS stack overview.](../assets/img/vates-vms.png)
 </div>
 
-## 🎓 Concepts
+## 🎓 Concepts {#concepts}
 
 There are a few concepts to grasp in order to get a clear picture about what XCP-ng is.
 
@@ -65,7 +152,7 @@ Some clients are stateless (only running when you open or use them) and others a
 
 Xen Orchestra is a complete and agentless backup solution for your VMs running on XCP-ng. Please read the dedicated [backup section](management/backup) to get more details.
 
-## 📹 Community videos on XCP-ng
+## 📹 Community videos on XCP-ng {#community-videos-on-xcp-ng}
 
 :::note
 Those videos are made by 3rd parties. However, for example, Tom from Lawrence Systems is providing a lot of content on XCP-ng and Xen Orchestra. Check his [YouTube channel](https://www.youtube.com/channel/UCHkYOD-3fZbuGhwsADBd9ZQ).
@@ -83,12 +170,10 @@ A quick intro by Raid Owl:
 <iframe width="560" height="315" src="https://www.youtube.com/embed/kguTbVBqmuw?si=bWze86s07ZDkLzlU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </div>
 
-### The Project
+## 🌍 Project and community {#project-and-community}
 
-About the project itself, please see the [project page](/category/project).
+XCP-ng is a community-driven Open Source project, backed by [Vates](https://vates.tech). Everything about the project itself (roadmap, contributing, development process, security handling) lives in the [project pages](/category/project).
 
-### Follow us
-
-* Our YouTube channel: https://www.youtube.com/@Vates_tech
-* Latest XCP-ng news: https://xcp-ng.org/blog
-* XCP-ng community: https://xcp-ng.org/forum
+* Latest news: [xcp-ng.org/blog](https://xcp-ng.org/blog)
+* Community forum: [xcp-ng.org/forum](https://xcp-ng.org/forum)
+* YouTube channel: [@Vates_tech](https://www.youtube.com/@Vates_tech)

--- a/docs/management/additional-packages.md
+++ b/docs/management/additional-packages.md
@@ -13,7 +13,7 @@ Best effort support is provided for additional packages provided by the XCP-ng p
 * [supported list for XCP-ng 8.3](http://reports.xcp-ng.org/8.3/extra_installable.txt)
 :::
 
-## 📜 Rules
+## 📜 Rules {#rules}
 
 ### 1. Never enable additional repositories
 
@@ -31,7 +31,7 @@ To disable a repository, edit `/etc/yum.repos.d/name_of_repo.repo` and set `enab
 
 ### 2. Prefer additional packages from XCP-ng's own repositories
 
-We offer a number of additional packages ranging from ZFS support, [newer drivers](../../installation/hardware#-alternate-drivers) or [newer kernel](../../installation/hardware#-alternate-kernel), to small utilities such as `vim`, `joe`, `iperf`, `mc`, etc.).
+We offer a number of additional packages ranging from ZFS support, [newer drivers](../../installation/hardware#alternate-drivers) or [newer kernel](../../installation/hardware#alternate-kernel), to small utilities such as `vim`, `joe`, `iperf`, `mc`, etc.).
 
 A regularly updated list of such utilities is available at [http://reports.xcp-ng.org/8.3/extra_installable.txt](http://reports.xcp-ng.org/8.3/extra_installable.txt) for XCP-ng 8.3.
 
@@ -76,7 +76,7 @@ The `wpa_supplicant` package is provided for homelab and testing purposes only. 
 - [CVE-2019-9496](https://www.cvedetails.com/cve/CVE-2019-9496):  An invalid authentication sequence could result in Denial of Service.
 - [CVE-2019-9497](https://www.cvedetails.com/cve/CVE-2019-9497), [CVE-2019-9498](https://www.cvedetails.com/cve/CVE-2019-9498), [CVE-2019-9499](https://www.cvedetails.com/cve/CVE-2019-9499):  These vulnerabilities may allow an attacker to complete EAP-PWD authentication without knowing the password.
 
-#### mc ((Midnight Commander)
+#### mc (Midnight Commander)
 
 - [CVE-2021-36370](https://www.cvedetails.com/cve/CVE-2021-36370): When establishing an SFTP connection, the fingerprint of the server is neither checked nor displayed, therefore a user will not be able to verify its authenticity.
 
@@ -84,7 +84,7 @@ The `wpa_supplicant` package is provided for homelab and testing purposes only. 
 
 If you have [pro support](https://xcp-ng.com), ask there. As part of the support, additional supported packages - such as new drivers - may be provided. Else ask the community on the [forum](https://xcp-ng.org/forum/).
 
-## 🦮 How to install
+## 🦮 How to install {#how-to-install}
 
 Before doing any change, start keeping track somewhere of any change you bring to the system. This will help for:
 * support
@@ -93,14 +93,17 @@ Before doing any change, start keeping track somewhere of any change you bring t
 
 ### From XCP-ng repositories
 
-`yum install name_of_package`
+<Terminal shell title="root@xcp-ng-host — From XCP-ng repositories">{`
+yum install name_of_package
+`}</Terminal>
 
 ### From CentOS repositories
 
 The CentOS repos are already installed but are disabled, on purpose. Install from them with:
-```
+
+<Terminal shell title="root@xcp-ng-host — From CentOS repositories">{`
 yum install name_of_package --enablerepo=base,updates
-```
+`}</Terminal>
 
 Make sure it will not try to overwrite system packages with updates from CentOS. XCP-ng uses fixed or modified versions of some CentOS packages whereas the CentOS repos point at the latest.
 
@@ -111,14 +114,16 @@ CentOS 7 reached its end of life, so installing additional packages from its rep
 ### From EPEL repositories
 
 On XCP-ng, the EPEL repos are already installed but are disabled, on purpose. Install from them with:
-```
+
+<Terminal shell title="root@xcp-ng-host — From EPEL repositories">{`
 yum install name_of_package --enablerepo=epel
-```
+`}</Terminal>
 
 Sometimes you'll need extra dependencies from CentOS. Replace the command with:
-```
+
+<Terminal shell title="root@xcp-ng-host — From EPEL repositories">{`
 yum install name_of_package --enablerepo=epel,base,updates
-```
+`}</Terminal>
 
 And as above make sure no package from the system will get overwritten in the process.
 
@@ -135,16 +140,26 @@ EPEL 7 reached its end of life at the same time as CentOS 7, so installing addit
 
 And as usual make sure it won't overwrite existing packages...
 
-## 📦 Up to date additional packages
+## 📦 Up to date additional packages {#up-to-date-additional-packages}
 
 If you installed from XCP-ng repositories, [they will be updated like the rest of the XCP-ng system](../../management/updates).
 
 If you installed from any other repository, including CentOS and EPEL, you need to update them (and their dependencies) manually
 
-## ♻️ System upgrade
+## ♻️ System upgrade {#system-upgrade}
 
 See [upgrade section](../../installation/upgrade) for a discussion of the differences between "Installer upgrade" and "`yum`-style upgrade".
 
 Installer upgrade will reinstall the system from scratch and just keep your configuration related to XCP-ng (network, VMs, SRs, etc.). Anything else will have to be re-done.
 
 An upgrade using `yum` directly will try to update or keep the packages that you installed. Packages installed from XCP-ng repositories should get updated seamlessly. Packages from other repositories will not get updated: they may be left in place (then you'll have to update them yourselves if needed), removed (due to package conflicts or because they are obsoleted by packages from the updated XCP-ng) or even make the upgrade fail until they are manually removed.
+
+## 📀 Supplemental packs {#supplemental-packs}
+
+Supplemental packs are vendor-provided ISO images adding software or drivers to a host (management agents, GPU drivers...). They can be provided [at installation time](../installation/install-xcp-ng.md), or installed on a running host:
+
+<Terminal shell title="root@xcp-ng-host — Supplemental packs">{`
+xe-install-supplemental-pack /path/to/pack.iso
+`}</Terminal>
+
+The same rules as other additional software apply: only install packs built for your XCP-ng version, and remember they may need reinstalling after an upgrade.

--- a/docs/management/backup.md
+++ b/docs/management/backup.md
@@ -2,7 +2,7 @@
 
 It's really important to backup your VMs. You have multiple options, but only Xen Orchestra is both **advanced, agentless, fully Open Source and officially supported** (tested for all XCP-ng releases).
 
-## 🛰️ Xen Orchestra
+## 🛰️ Xen Orchestra {#xen-orchestra}
 
 Xen Orchestra is the most advanced backup solution and 100% integrated with XCP-ng. There is many different backup options:
 
@@ -25,7 +25,7 @@ And they come with different features:
 * Encryption
 * Compression
 * File level restore
-* NBD-enabled for extra backup speed
+* NBD-enabled for extra backup speed (requires [an NBD-enabled network](../networking/networking.md#nbd-backup-network))
 * Rate limiting
 * XO Proxy (backup remote sites without any VPN requirement)
 
@@ -35,12 +35,63 @@ All options are explained in the [official documentation](https://xen-orchestra.
 
 Alternatively, you can install and build it yourself [from the GitHub repository](https://github.com/vatesfr/xen-orchestra/).
 
-## 🛣️ 3rd party solutions
+## 🛣️ 3rd party solutions {#3rd-party-solutions}
 
-There's 3rd party solutions officially compatible with XCP-ng to make VM backups. Please check our [ecosystem](https://docs.vates.tech/ecosystems/xcp-ng-ecosystem#-vm-backup) page on the backup section.
+There's 3rd party solutions officially compatible with XCP-ng to make VM backups. Please check our [ecosystem](https://docs.vates.tech/compatible-solutions/xcp-ng-ecosystem#vm-backup) page on the backup section.
 
 :::tip
 Some popular backup solutions (like [VEEAM](https://www.veeam.com/)) can be used with agents inside your VMs, while Xen Orchestra deals with VM backup.
 :::
 
 However, you'll lose the tight integration you have between XCP-ng and Xen Orchestra, both bundled of the [Vates Stack](https://vates.tech).
+
+## 🚑 Disaster recovery {#disaster-recovery}
+
+Disaster recovery (replicating VMs to a secondary site/pool and restarting them there when the primary is lost) is handled by Xen Orchestra: **Continuous Replication** keeps standby copies of your VMs on another pool's storage, ready to start; **Disaster Recovery** backup jobs do the same from backup files. See the [XO backup documentation](https://docs.xen-orchestra.com/xo5/backups) for the full picture (RPO, failover, failback).
+
+What a DR plan needs on the XCP-ng side, whatever the tooling:
+
+* **Replicated VMs**: continuous replication of the critical VMs to a pool that doesn't share the primary's failure domain (site, storage, power).
+* **Replicated configuration**: pool metadata backup (below) and the XO config backup, restorable at the secondary site.
+* **Network mapping**: know in advance which networks/VLANs the recovered VMs plug into at the secondary site.
+* **A management plane that survives**: run Xen Orchestra (or be able to redeploy it from its config backup) outside the primary failure domain.
+* **Tests**: a failover you never exercised is a hypothesis, not a plan. XO can start replicated VMs on an isolated network for testing.
+
+## 🧰 Host and pool configuration backup {#host-and-pool-configuration-backup}
+
+Besides VM data, the platform itself has state worth saving: the pool metadata (all your XAPI objects: VM configurations, SRs, networks...).
+
+### With Xen Orchestra (recommended)
+
+Use an **XCP-ng Metadata backup** job in Xen Orchestra: it saves the pool metadata of the pools you select, on a schedule, to your backup repositories, with retention. Restoring it brings a reinstalled pool coordinator back to its full configuration. Details in the [XO metadata backup documentation](https://docs.xen-orchestra.com/xo5/metadata_backup). While you're there, also enable the **XO config backup** so your Xen Orchestra setup itself (users, jobs, settings) is covered.
+
+### Manually
+
+Under the hood this is the pool database, replicated on every pool member. You can dump and restore it yourself, for example before a risky manual operation:
+
+<Terminal shell title="root@xcp-ng-host — Manually">{`
+xe pool-dump-database file-name=pool-backup.db
+`}</Terminal>
+
+To restore it on a freshly reinstalled pool coordinator:
+
+<Terminal shell title="root@xcp-ng-host — Manually">{`
+xe pool-restore-database file-name=pool-backup.db dry-run=true   # check first
+xe pool-restore-database file-name=pool-backup.db                # the coordinator restarts
+`}</Terminal>
+
+Dump it before risky operations (upgrades already do it for you), and keep a copy off the pool.
+
+### Host configuration
+
+`xsconsole` (menu **Backup, Restore and Update**) and the CLI can save a host's dom0 state:
+
+<Terminal shell title="root@xcp-ng-host — Host configuration">{`
+xe host-backup host=<host> file-name=host-backup.xbk
+`}</Terminal>
+
+The result is big (it's a copy of the control domain's filesystem) and mostly useful right before hardware maintenance on the boot disk. In practice, a clean reinstall plus a pool metadata restore is often simpler and safer than a host restore; keep `host-backup` for specific cases.
+
+:::tip
+What actually deserves a scheduled backup: your VMs (XO backup jobs), the pool metadata (XO's XCP-ng metadata backup), and your XO configuration itself (XO config backup). With those three, any host can be reinstalled from the ISO and everything else restored on top.
+:::

--- a/docs/management/cloud.md
+++ b/docs/management/cloud.md
@@ -7,7 +7,7 @@ You have multiple choices:
 1. Using Xen Orchestra Cloud features (ACLs, Self Service)
 2. Using CloudStack or OpenStack (adapted to very large deployments)
 
-## 🛰️ Xen Orchestra
+## 🛰️ Xen Orchestra {#xen-orchestra}
 
 Some interesting "cloud-like" features are available in Xen Orchestra : ACLs and Self-service.
 
@@ -42,7 +42,7 @@ The self-service feature allows users to create new VMs within a **limited amoun
 ![XO dashboard of the available ressources to the devs group, with vCPUs, Memory and Storage, showing their usage and total available ressources.](../../static/img/xoself.png)
 </div>
 
-## ☁️ CloudStack
+## ☁️ CloudStack {#cloudstack}
 
 <div style={{textAlign: 'center'}}>
 ![The CloudStack logo.](../../static/img/cloudstack_logo.png)
@@ -54,7 +54,7 @@ Apache CloudStack is open source software designed to deploy and manage large ne
 
 See the [dedicated documentation](https://docs.cloudstack.apache.org/en/4.17.2.0/installguide/hypervisor/xenserver.html?highlight=xcp-ng) on how to install CloudStack on top of XCP-ng.
 
-## 📚 OpenStack
+## 📚 OpenStack {#openstack}
 
 :::warning
 Unlike Cloudstack, we do not know the level of compatibility with OpenStack. Take time to ask OpenStack community about their support for XAPI-based hosts

--- a/docs/management/ha.md
+++ b/docs/management/ha.md
@@ -2,7 +2,7 @@
 
 In XCP-ng, high availability (or HA) is the ability to detect a failed host and automatically boot all the VMs that were running on this host to the other alive machines.
 
-## 📋 Introduction
+## 📋 Introduction {#introduction}
 
 Implementing VM High availability (HA) is a real challenge.
 
@@ -22,7 +22,7 @@ High availability requires **far more maintenance** and will create some traps i
 Before using it, **please think about it carefully**: do you **REALLY** need it? We've seen people having less uptime using HA than when not using it, because you **must understand** what you are doing every time you reboot or update a host.
 :::
 
-## 🎓 Concepts
+## 🎓 Concepts {#concepts}
 
 The pool concept allows hosts to exchange their data and status:
 
@@ -39,7 +39,7 @@ Here are the possible cases and how they are dealt with:
 * **Lost storage but not network**: if the host can contact a majority of pool members, it can stay alive. Indeed, in this scenario, there is no harm for the data (can't write to the VM disks). If the host is alone (i.e can't contact any other host or less than the majority), it goes for a reboot procedure.
 * **Lost network but not storage (worst case!)**: the host considers itself as problematic and starts a reboot procedure (hard power off and restart). This fencing procedure guarantees the sanity of your data.
 
-## Requirements
+## ✅ Requirements {#requirements}
 
 Enabling HA in XCP-ng requires thorough planning and validation of several prerequisites:
 
@@ -70,7 +70,7 @@ Use the `pif-plug` command in the CLI to activate VLAN and bond PIFs, ensuring t
 Additionally, the `xe diagnostic-vm-status` CLI command can help identify why a VM isn’t agile, allowing you to take corrective action as needed.
 
 
-## ⚙️ Configuration
+## ⚙️ Configuration {#configuration}
 
 ### Prepare the pool
 
@@ -85,9 +85,9 @@ To enable HA, just toggle it on, which gives you a SR selector as Heartbeat SR.
 
 You can also enable it with this xe CLI command:
 
-```
+<Terminal shell title="root@xcp-ng-host — Prepare the pool">{`
 xe pool-ha-enable heartbeat-sr-uuids=<SR_UUID>
-```
+`}</Terminal>
 
 :::tip
 Remember that you need to use a shared storage repository to enable high availability.
@@ -101,18 +101,18 @@ How many host failures you can tolerate before running out of options? For 2 hos
 
 XCP-ng can calculate this value for you. In our sample case, it looks like this:
 
-```
+<Terminal title="root@xcp-ng-host — Maximum host failure number">{`
 xe pool-ha-compute-max-host-failures-to-tolerate
 1
-```
+`}</Terminal>
 
 But it could be also **0**. Because, even if you lose 1 host, is there not enough RAM to boot the HA VM on the last one? If not, you can't ensure their survival. 
 
 If you want to set the number yourself, you can do it with this command:
 
-```
+<Terminal shell title="root@xcp-ng-host — Maximum host failure number">{`
 xe pool-param-set ha-host-failures-to-tolerate=1 uuid=<Pool_UUID>
-```
+`}</Terminal>
 
 If more hosts fail than this number, the system will raise an **over-commitment** alert.
 
@@ -135,9 +135,9 @@ This is pretty straightforward with Xen Orchestra. Go to the **Advanced** panel 
 
 You can also do that configuration with *xe CLI*:
 
-```
+<Terminal shell title="root@xcp-ng-host — Choosing a high availability mode">{`
 xe vm-param-set uuid=<VM_UUID> ha-restart-priority=restart
-```
+`}</Terminal>
 
 #### Start order
 
@@ -155,9 +155,9 @@ The order value is an integer, with the default set to **0**, indicating the **h
 
 You can set the order property value of a VM via the command-line interface:
 
-```
+<Terminal shell title="root@xcp-ng-host — How do I set the start order?">{`
 xe vm-param-set uuid=<VM UUID> order=<number>
-```
+`}</Terminal>
 
 #### Configure HA timeout
 
@@ -171,11 +171,11 @@ If any XCP-ng server cannot regain access to networking or storage within the sp
 
 The **default timeout is 60 seconds**, but you can adjust this value using the following command to suit your needs:
 
-```
+<Terminal shell title="root@xcp-ng-host — How do I configure it?">{`
 xe pool-param-set uuid=<pool UUID> other-config:default_ha_timeout=<timeout in seconds>
-```
+`}</Terminal>
 
-## 🔧 Updates/maintenance
+## 🔧 Updates/maintenance {#updatesmaintenance}
 
 Before any update or host maintenance, planned reboot and so on, **ALWAYS** put your host in maintenance mode. If you don't do that, XAPI will think it's an unplanned failure, and will act accordingly.
 
@@ -186,7 +186,7 @@ If you have enough memory to put one host in maintenance (migrating all its VMs 
 - **Do NOT restart host toolstacks while high availability is enabled!** Attempting to restart the toolstack on an active host will cause the host to be immediately fenced and removed from the active liveset and pool. Always make sure that HA is disabled before restarting toolstacks.
 :::
 
-## ↔️ Behavior
+## ↔️ Behavior {#behavior}
 
 ### Halting the VM
 
@@ -200,9 +200,9 @@ However, if you halt the VM directly in the guest OS (via the console or in SSH)
 
 Starting with XAPI 25.16.0, VM restart behavior can be changed on a pool-wide basis. To do this, run this command:
 
-```
+<Terminal shell title="root@xcp-ng-host — Configure VM shutdown behavior">{`
 xe pool-param-set uuid=... ha-reboot-vm-on-internal-shutdown=false
-```
+`}</Terminal>
 
 The `ha-reboot-vm-on-internal-shutdown` parameter indicates whether VM-initiated shutdowns will trigger a restart for HA-protected VMs, for example, when a user clicks the shutdown in Windows.
 
@@ -260,13 +260,66 @@ Immediatly after fencing, **Minion 1** will be booted on the other host.
 
 Finally, the worst case: keep the storage operational, but "cut" the (management) network interface. Same procedure: unplug the cable physically and wait... Because **lab1** cannot contact any other host in the pool (in this case, **lab2**), it starts the fencing procedure. The result is exactly the same as the previous test. It's gone for the pool master, displayed as **Halted** until we re-plug the cable.
 
-## 🤓 Architecture
+## 🤓 Architecture {#architecture}
 
 ### General
 
 The diagram below shows how HA is managed on a pool.
 
-![Shared SR has an ha-statefile queried by the XHA daemons running on each hosts. These daemons also talk to each other.](../../assets/img/xha-shared-sr.png)
+<Schema label="HA on a shared SR · two heartbeat paths to tell network and storage failures apart" legend={[["#4a90e2", "network heartbeat"], ["#56c288", "storage heartbeat"], ["#e0a94a", "ha-statefile"]]} maxWidth="640px">
+<svg viewBox="0 0 640 400" role="img" aria-label="Three XCP-ng hosts each run an XHA daemon; the daemons exchange a network heartbeat with each other, and each also writes a storage heartbeat into the ha-statefile volume on the shared SR that holds the VM disks">
+  <g fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.28)">
+    <rect x="20" y="20" width="190" height="120" rx="8"/>
+    <rect x="225" y="20" width="190" height="120" rx="8"/>
+    <rect x="430" y="20" width="190" height="120" rx="8"/>
+  </g>
+  <g fontSize="12.5" fill="#c6d2e1" textAnchor="middle">
+    <text x="115" y="42">XCP-ng A</text>
+    <text x="320" y="42">XCP-ng B</text>
+    <text x="525" y="42">XCP-ng C</text>
+  </g>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)">
+    <rect x="66" y="52" width="98" height="24" rx="5"/>
+    <rect x="271" y="52" width="98" height="24" rx="5"/>
+  </g>
+  <g fontSize="10.5" fill="#7a8699" textAnchor="middle">
+    <text x="115" y="68">VM A</text>
+    <text x="320" y="68">VM B</text>
+  </g>
+  <g fill="rgba(74,144,226,0.14)" stroke="#4a90e2" strokeOpacity="0.85">
+    <rect x="46" y="92" width="138" height="28" rx="5"/>
+    <rect x="251" y="92" width="138" height="28" rx="5"/>
+    <rect x="456" y="92" width="138" height="28" rx="5"/>
+  </g>
+  <g fontSize="11" fill="#c6d2e1" textAnchor="middle">
+    <text x="115" y="110">XHA daemon</text>
+    <text x="320" y="110">XHA daemon</text>
+    <text x="525" y="110">XHA daemon</text>
+  </g>
+  <g stroke="#4a90e2" strokeWidth="1.8">
+    <line x1="184" y1="106" x2="251" y2="106"/>
+    <line x1="389" y1="106" x2="456" y2="106"/>
+  </g>
+  <rect x="140" y="210" width="360" height="140" rx="8" fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.28)"/>
+  <text x="488" y="338" fontSize="12" fill="#c6d2e1" textAnchor="end">Shared SR (e.g. NFS)</text>
+  <rect x="160" y="266" width="130" height="32" rx="6" fill="rgba(224,169,74,0.14)" stroke="#e0a94a" strokeOpacity="0.85"/>
+  <text x="225" y="286" fontSize="11" fill="#e0a94a" textAnchor="middle">ha-statefile</text>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)">
+    <rect x="320" y="240" width="92" height="24" rx="5"/>
+    <rect x="320" y="274" width="92" height="24" rx="5"/>
+  </g>
+  <g fontSize="10" fill="#7a8699" textAnchor="middle">
+    <text x="366" y="256">vol_1.vhd</text>
+    <text x="366" y="290">vol_2.vhd</text>
+    <text x="366" y="316">… VM disks</text>
+  </g>
+  <g stroke="#56c288" strokeWidth="1.6" fill="none">
+    <path d="M100 120 C 100 180, 150 230, 180 264"/>
+    <path d="M320 120 C 320 170, 250 220, 222 264"/>
+    <path d="M525 120 C 525 190, 340 230, 292 276"/>
+  </g>
+</svg>
+</Schema>
 
 As you can see, a `XHA daemon` is running on each host and two main paths are used: one for the network, another for storage.
 For HA to operate properly, two communication paths are used: one over the network and another reserved for storage.
@@ -278,7 +331,48 @@ The only difference is that `ha-statefile` is a raw volume in which data is writ
 
 Regarding the structure of this SR heartbeat volume:
 
-![The ha-statefile has info about each alive hosts in the pool.](../../assets/img/xha-statefile-structure.png)
+<Schema label="ha-statefile layout · one reserved slot per host, readable by all" legend={[["#56c288", "host writes its own slot"], ["#e0a94a", "ha-statefile (raw volume)"]]} maxWidth="640px">
+<svg viewBox="0 0 640 250" role="img" aria-label="Three hosts each write a heartbeat into their own slot of the ha-statefile volume; every host reads all the slots to know who is alive">
+  <g fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.28)">
+    <rect x="40" y="20" width="150" height="36" rx="6"/>
+    <rect x="245" y="20" width="150" height="36" rx="6"/>
+    <rect x="450" y="20" width="150" height="36" rx="6"/>
+  </g>
+  <g fontSize="12" fill="#c6d2e1" textAnchor="middle">
+    <text x="115" y="43">XCP-ng A</text>
+    <text x="320" y="43">XCP-ng B</text>
+    <text x="525" y="43">XCP-ng C</text>
+  </g>
+  <g stroke="#56c288" strokeWidth="1.8">
+    <line x1="115" y1="56" x2="115" y2="118"/>
+    <line x1="320" y1="56" x2="320" y2="118"/>
+    <line x1="525" y1="56" x2="525" y2="118"/>
+  </g>
+  <g fontSize="9.5" fill="#56c288">
+    <text x="124" y="92">writes</text>
+    <text x="329" y="92">writes</text>
+    <text x="534" y="92">writes</text>
+  </g>
+  <rect x="30" y="120" width="580" height="70" rx="8" fill="rgba(224,169,74,0.08)" stroke="#e0a94a" strokeOpacity="0.85"/>
+  <g fill="rgba(255,255,255,0.05)" stroke="rgba(255,255,255,0.28)">
+    <rect x="46" y="134" width="170" height="42" rx="5"/>
+    <rect x="251" y="134" width="170" height="42" rx="5"/>
+    <rect x="456" y="134" width="140" height="42" rx="5"/>
+  </g>
+  <g fontSize="10.5" fill="#c6d2e1" textAnchor="middle">
+    <text x="131" y="151">slot A</text>
+    <text x="336" y="151">slot B</text>
+    <text x="526" y="151">slot C</text>
+  </g>
+  <g fontSize="9.5" fill="#7a8699" textAnchor="middle">
+    <text x="131" y="168">"alive at 10:42:03"</text>
+    <text x="336" y="168">"alive at 10:42:03"</text>
+    <text x="526" y="168">"alive at 10:42:02"</text>
+  </g>
+  <text x="36" y="214" fontSize="10.5" fill="#7a8699">no write lock needed: each host only ever writes its own slot…</text>
+  <text x="604" y="238" fontSize="10.5" fill="#7a8699" textAnchor="end">…and reads all the others to know who is alive</text>
+</svg>
+</Schema>
 
 - As the picture shows, this volume contains a single entry for each host, where each host writes to its own dedicated area AND can also read the state of other hosts. In other words, each host writes a “heartbeat” value indicating that it’s alive at a given time, which is verified by the whole pool.
 
@@ -288,9 +382,80 @@ Regarding the structure of this SR heartbeat volume:
 
 For DRBD/LINSTOR experts, and with the general architecture explanation, you can understand what happens when we replace the NFS hearbeat volume by a DRBD device.
 
-We must change our architecture because — basically — a DRBD volume can only be opened in one place at a time. We cannot easily write in each volume at the same time, because we would have to open or close the heartbeat volume several times per second. Or, we would have to set up a mechanism in the xha daemon so that each one writes in turn. Since this is complex to set up, we chose another approach.
+We must change our architecture because, basically, a DRBD volume can only be opened in one place at a time. We cannot easily write in each volume at the same time, because we would have to open or close the heartbeat volume several times per second. Or, we would have to set up a mechanism in the xha daemon so that each one writes in turn. Since this is complex to set up, we chose another approach.
 
-![In XOSTOR case, each hosts have an HTTP DISK server, only one is active. It checks the ha-statefile, talk to each hosts NBD HTTP server which talks to their host XHA daemon.](../../assets/img/xha-xostor-sr.png)
+<Schema label="HA on XOSTOR · the storage heartbeat is proxied to the single DRBD primary" legend={[["#4a90e2", "network heartbeat"], ["#56c288", "storage heartbeat path"], ["#e0a94a", "ha-statefile"]]} maxWidth="640px">
+<svg viewBox="0 0 640 470" role="img" aria-label="Three XCP-ng hosts run the XHA daemon over an NBD HTTP server; only host A runs the active HTTP disk server, which owns the DRBD primary and writes the ha-statefile on the shared XOSTOR SR; the other hosts forward their heartbeat through it">
+  <g fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.28)">
+    <rect x="20" y="20" width="190" height="170" rx="8"/>
+    <rect x="225" y="20" width="190" height="170" rx="8"/>
+    <rect x="430" y="20" width="190" height="170" rx="8"/>
+  </g>
+  <g fontSize="12.5" fill="#c6d2e1" textAnchor="middle">
+    <text x="115" y="42">XCP-ng A</text>
+    <text x="320" y="42">XCP-ng B</text>
+    <text x="525" y="42">XCP-ng C</text>
+  </g>
+  <g fill="rgba(74,144,226,0.14)" stroke="#4a90e2" strokeOpacity="0.85">
+    <rect x="46" y="52" width="138" height="26" rx="5"/>
+    <rect x="251" y="52" width="138" height="26" rx="5"/>
+    <rect x="456" y="52" width="138" height="26" rx="5"/>
+  </g>
+  <g fontSize="11" fill="#c6d2e1" textAnchor="middle">
+    <text x="115" y="69">XHA daemon</text>
+    <text x="320" y="69">XHA daemon</text>
+    <text x="525" y="69">XHA daemon</text>
+  </g>
+  <g stroke="#4a90e2" strokeWidth="1.8">
+    <line x1="184" y1="65" x2="251" y2="65"/>
+    <line x1="389" y1="65" x2="456" y2="65"/>
+  </g>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)">
+    <rect x="46" y="92" width="138" height="26" rx="5"/>
+    <rect x="251" y="92" width="138" height="26" rx="5"/>
+    <rect x="456" y="92" width="138" height="26" rx="5"/>
+  </g>
+  <g fontSize="10.5" fill="#c6d2e1" textAnchor="middle">
+    <text x="115" y="109">NBD HTTP server</text>
+    <text x="320" y="109">NBD HTTP server</text>
+    <text x="525" y="109">NBD HTTP server</text>
+  </g>
+  <rect x="46" y="140" width="138" height="30" rx="5" fill="rgba(86,194,136,0.14)" stroke="#56c288" strokeOpacity="0.85"/>
+  <text x="115" y="159" fontSize="10.5" fill="#56c288" textAnchor="middle">HTTP disk server ★</text>
+  <g fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.15)">
+    <rect x="251" y="140" width="138" height="30" rx="5"/>
+    <rect x="456" y="140" width="138" height="30" rx="5"/>
+  </g>
+  <g fontSize="10" fill="#5b6577" textAnchor="middle">
+    <text x="320" y="159">HTTP disk server (idle)</text>
+    <text x="525" y="159">HTTP disk server (idle)</text>
+  </g>
+  <g stroke="#56c288" strokeWidth="1.6" fill="none">
+    <line x1="115" y1="78" x2="115" y2="92"/>
+    <line x1="320" y1="78" x2="320" y2="92"/>
+    <line x1="525" y1="78" x2="525" y2="92"/>
+    <line x1="115" y1="118" x2="115" y2="140"/>
+    <path d="M251 105 C 215 105, 205 130, 188 148"/>
+    <path d="M456 105 C 446 205, 260 215, 165 174"/>
+    <path d="M115 170 C 115 220, 150 260, 178 304"/>
+  </g>
+  <rect x="140" y="250" width="360" height="150" rx="8" fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.28)"/>
+  <text x="488" y="388" fontSize="12" fill="#c6d2e1" textAnchor="end">Shared XOSTOR SR</text>
+  <rect x="160" y="306" width="130" height="32" rx="6" fill="rgba(224,169,74,0.14)" stroke="#e0a94a" strokeOpacity="0.85"/>
+  <text x="225" y="326" fontSize="11" fill="#e0a94a" textAnchor="middle">ha-statefile</text>
+  <text x="225" y="352" fontSize="9.5" fill="#7a8699" textAnchor="middle">DRBD · primary on A</text>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)">
+    <rect x="330" y="290" width="92" height="24" rx="5"/>
+    <rect x="330" y="324" width="92" height="24" rx="5"/>
+  </g>
+  <g fontSize="10" fill="#7a8699" textAnchor="middle">
+    <text x="376" y="306">vol_1</text>
+    <text x="376" y="340">vol_2</text>
+    <text x="376" y="366">… VM disks</text>
+  </g>
+  <text x="630" y="462" fontSize="10" fill="#7a8699" textAnchor="end">★ single active instance · another host takes over if A crashes</text>
+</svg>
+</Schema>
 
 To support the fact that only one DRBD volume can be PRIMARY, and to avoid making significant changes to the xha/XHAPI modules, we had to be a bit creative. Instead of writing to or reading directly from the heartbeat volume on all hosts, we use an `NBD HTTP server` daemon. It's a process that listens through an NBD device, which is seen as the heartbeat volume by the XHA daemon.
 

--- a/docs/management/hosts-pools.md
+++ b/docs/management/hosts-pools.md
@@ -1,0 +1,270 @@
+---
+sidebar_position: 5
+---
+
+# Hosts and pools operations
+
+Day-to-day operations on your XCP-ng hosts and resource pools: creating a pool, adding and removing hosts, maintenance mode, passwords, time synchronization, remote power-on and pool-wide settings.
+
+:::tip
+Almost everything on this page can be done in a few clicks from [Xen Orchestra](manage-at-scale/xo-web-ui.md), which is the recommended way to operate XCP-ng at scale. The `xe` commands are given so you can also work directly on a host, script operations, or troubleshoot when the orchestrator is not available.
+:::
+
+## 🎓 Concepts {#concepts}
+
+A **resource pool** is a group of up to 64 XCP-ng hosts managed as a single entity. One host is the **pool coordinator** (formerly called "pool master"): it exposes the XAPI endpoint for the whole pool, holds the pool database and forwards operations to the other members. All members keep a replicated copy of that database, which is why another host can take over the coordinator role if needed.
+
+Why create a pool rather than managing standalone hosts?
+
+* **Live migration** of VMs between hosts of the pool.
+* **Shared storage**: an SR created on the pool is visible to all members, so VMs can start anywhere.
+* **Single point of management**: one connection, one inventory, pool-wide networks and settings.
+* **[High availability](ha.md)** and [VM load balancing](vm-load-balancing.md) both operate at the pool level.
+
+<Schema label="A resource pool · one XAPI endpoint, a replicated database, shared storage" legend={[["#8e83fe", "XAPI"], ["#56c288", "replicated pool DB"]]} maxWidth="720px">
+<svg viewBox="0 0 640 312" role="img" aria-label="Clients talk to the pool coordinator's XAPI endpoint; the coordinator and two members each hold a copy of the pool database and all hosts reach the same shared SR">
+  <text x="130" y="30" fontSize="13" fill="#c6d2e1" textAnchor="middle">Xen Orchestra · xe · API</text>
+  <g fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.28)">
+    <rect x="20" y="90" width="180" height="120" rx="8"/>
+    <rect x="230" y="90" width="180" height="120" rx="8"/>
+    <rect x="440" y="90" width="180" height="120" rx="8"/>
+  </g>
+  <text x="110" y="114" fontSize="13" fill="#c6d2e1" textAnchor="middle">pool coordinator</text>
+  <text x="320" y="114" fontSize="13" fill="#c6d2e1" textAnchor="middle">member</text>
+  <text x="530" y="114" fontSize="13" fill="#c6d2e1" textAnchor="middle">member</text>
+  <rect x="36" y="128" width="148" height="30" rx="5" fill="rgba(142,131,254,0.14)" stroke="#8e83fe" strokeOpacity="0.85"/>
+  <text x="110" y="147" fontSize="11.5" fill="#8e83fe" textAnchor="middle">XAPI endpoint</text>
+  <g fill="rgba(86,194,136,0.14)" stroke="#56c288" strokeOpacity="0.8">
+    <rect x="36" y="168" width="148" height="28" rx="5"/>
+    <rect x="246" y="168" width="148" height="28" rx="5"/>
+    <rect x="456" y="168" width="148" height="28" rx="5"/>
+  </g>
+  <g fontSize="11" fill="#56c288" textAnchor="middle">
+    <text x="110" y="186">pool DB</text>
+    <text x="320" y="186">pool DB (copy)</text>
+    <text x="530" y="186">pool DB (copy)</text>
+  </g>
+  <path d="M125 38 C 118 60, 112 70, 108 88" stroke="#8e83fe" strokeWidth="1.6" fill="none"/>
+  <g stroke="#56c288" strokeWidth="1.2" strokeDasharray="4 4" fill="none">
+    <line x1="184" y1="182" x2="246" y2="182"/>
+    <line x1="394" y1="182" x2="456" y2="182"/>
+  </g>
+  <g stroke="#7a8699" strokeWidth="1.4">
+    <line x1="110" y1="210" x2="270" y2="252"/>
+    <line x1="320" y1="210" x2="310" y2="252"/>
+    <line x1="530" y1="210" x2="370" y2="252"/>
+  </g>
+  <rect x="240" y="252" width="160" height="34" rx="8" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)"/>
+  <text x="320" y="273" fontSize="12" fill="#c6d2e1" textAnchor="middle">shared SR</text>
+  <text x="608" y="304" fontSize="10.5" fill="#7a8699" textAnchor="end">VMs can start and migrate anywhere</text>
+</svg>
+</Schema>
+
+The requirements for pooling hosts (hardware, CPU vendor, versions…) are described in the [pool requirements](../installation/requirements.md#pool-requirements) section.
+
+:::info
+A standalone host is simply a pool of one: there's no special "pool creation" step. You create a pool by joining a second host to the first one.
+:::
+
+## 🏗️ Create a pool {#create-a-pool}
+
+### Name the pool
+
+A freshly installed host belongs to its own unnamed pool. Give it a name, which will be the pool's name once you add more hosts:
+
+<Terminal shell title="root@xcp-ng-host — Name the pool">{`
+xe pool-param-set uuid=<pool-uuid> name-label="My pool"
+`}</Terminal>
+
+From Xen Orchestra, simply edit the pool name from the pool view.
+
+### Add a host to the pool
+
+From Xen Orchestra: open the pool and use the **Add hosts** action, then pick the standalone host(s) to include.
+
+With `xe`, run this **on the host that should join** the pool:
+
+<Terminal shell title="root@xcp-ng-host — Add a host to the pool">{`
+xe pool-join master-address=<coordinator-ip-or-fqdn> master-username=root master-password=<password>
+`}</Terminal>
+
+What happens on join:
+
+* The host fetches the pool database and becomes a member: from now on, you manage it through the pool coordinator.
+* Its local SRs remain available, as local storage of that member.
+* Pool-wide settings (networks, TLS verification, update channels…) are inherited from the pool.
+
+:::warning
+The joining host must be "clean": no running or suspended VMs, and its version must match the rest of the pool. VMs should be exported/moved before the join, or shut down.
+:::
+
+### Heterogeneous pools
+
+Hosts with different CPUs (same vendor!) can be pooled: XAPI automatically levels the CPU feature set exposed to VMs down to the common denominator, so live migration stays safe across all members. Mixing Intel and AMD hosts in the same pool is not possible.
+
+If the hosts differ in a way that blocks a regular join, you can force it, and take responsibility for the consequences:
+
+<Terminal shell title="root@xcp-ng-host — Heterogeneous pools">{`
+xe pool-join master-address=<coordinator> master-username=root master-password=<password> force=true
+`}</Terminal>
+
+## 🚪 Remove a host from a pool {#remove-a-host-from-a-pool}
+
+From Xen Orchestra, use the host's **Detach** action. With `xe`:
+
+<Terminal shell title="root@xcp-ng-host — Remove a host from a pool">{`
+xe pool-eject host-uuid=<host-uuid>
+`}</Terminal>
+
+:::warning
+Ejecting a host **reinstalls its XAPI state**: the host reboots and comes back as a fresh standalone host. The contents of its **local SRs are destroyed** in the process. Move or export any VM disk you care about beforehand. Shared SR contents are not affected.
+:::
+
+If the host to remove is dead and cannot be ejected cleanly, you can remove its record from the pool database instead:
+
+<Terminal shell title="root@xcp-ng-host — Remove a host from a pool">{`
+xe host-forget uuid=<host-uuid>
+`}</Terminal>
+
+`host-forget` doesn't touch the (dead) host itself: if it ever comes back online, it will still believe it belongs to the pool, so reinstall it before reuse.
+
+## 👑 Change the pool coordinator {#change-the-pool-coordinator}
+
+### Planned change
+
+With all hosts up and reachable, you can hand the coordinator role to another member at any time. This is transparent for running VMs:
+
+<Terminal shell title="root@xcp-ng-host — Planned change">{`
+xe pool-designate-new-master host-uuid=<new-coordinator-uuid>
+`}</Terminal>
+
+### Coordinator is down
+
+If the coordinator is lost and you don't use [HA](ha.md) (which handles this automatically), promote a surviving member. Run these **on that member**:
+
+<Terminal shell title="root@xcp-ng-host — Coordinator is down">{`
+xe pool-emergency-transition-to-master
+xe pool-recover-slaves
+`}</Terminal>
+
+The first command makes the local host the new coordinator; the second tells the remaining members to point at it. See also [HA troubleshooting](../troubleshooting/troubleshooting-ha.md) when high availability is involved.
+
+## 🔧 Maintenance mode {#maintenance-mode}
+
+Before rebooting a host or working on its hardware, put it in maintenance mode: it stops accepting new VMs and evacuates the running ones (live migrating them to the other members).
+
+From Xen Orchestra: **Maintenance mode** toggle on the host view. With `xe`:
+
+<Terminal shell title="root@xcp-ng-host — Maintenance mode">{`
+xe host-disable uuid=<host-uuid>
+xe host-evacuate uuid=<host-uuid>
+`}</Terminal>
+
+If some VMs cannot be moved (e.g. a disk on that host's local SR, or not enough memory elsewhere), the evacuation tells you why; you can also ask beforehand:
+
+<Terminal shell title="root@xcp-ng-host — Maintenance mode">{`
+xe host-get-vms-which-prevent-evacuation uuid=<host-uuid>
+`}</Terminal>
+
+When you're done, bring the host back into service:
+
+<Terminal shell title="root@xcp-ng-host — Maintenance mode">{`
+xe host-enable uuid=<host-uuid>
+`}</Terminal>
+
+See also the dedicated guide about [rebooting or shutting down a host](../guides/host-reboot.md), and the [updates documentation](updates.md) for the recommended way to patch a whole pool (Rolling Pool Update in Xen Orchestra).
+
+## 🔑 Root password {#root-password}
+
+The `root` password of the hosts is what XAPI clients (Xen Orchestra, XO Lite, `xe`…) use to authenticate. All members of a pool are meant to share the same root password (a joining host adopts the pool's credentials).
+
+To change it, from the pool coordinator:
+
+<Terminal shell title="root@xcp-ng-host — Root password">{`
+xe user-password-change old=<current-password> new=<new-password>
+`}</Terminal>
+
+You can also use `xsconsole` (the text console you get on the host's physical/serial display), in **Authentication** → **Change Password**.
+
+Lost the root password? See the [reset procedure](../troubleshooting/common-problems.md#reset-xcp-ng-root-password) in the troubleshooting section.
+
+## ⏰ Time synchronization (NTP) {#time-synchronization-ntp}
+
+Correct and consistent clocks across the pool matter more than on ordinary servers: XAPI coordination, live migration, HA heartbeats, logs correlation and Windows guests (which get their initial time from the host) all rely on it. NTP servers are normally configured at [installation time](../installation/install-xcp-ng.md).
+
+To change them afterwards on XCP-ng 8.3, edit `/etc/chrony.conf`, then:
+
+<Terminal shell title="Time synchronization (NTP)">{`
+systemctl restart chronyd
+chronyc sources
+`}</Terminal>
+
+On XCP-ng 8.2, the NTP daemon is `ntpd`: edit `/etc/ntp.conf`, then `systemctl restart ntpd` and check with `ntpq -p`. In both cases, `xsconsole` also offers an NTP configuration menu under **Network and Management Interface**.
+
+## 🔌 Remote host power-on {#remote-host-power-on}
+
+XCP-ng can power hosts back on remotely, using either Wake-on-LAN or the server's out-of-band controller. Configure the method per host:
+
+<Terminal shell title="root@xcp-ng-host — Remote host power-on">{`
+xe host-set-power-on-mode host=<host-uuid> power-on-mode=wake-on-lan
+`}</Terminal>
+
+`power-on-mode` also accepts `iLO`, `DRAC` or `custom` (with `power-on-config:` parameters for the controller's IP and credentials), or an empty string to disable the feature. Then, to power on a host from anywhere in the pool:
+
+<Terminal shell title="root@xcp-ng-host — Remote host power-on">{`
+xe host-power-on host=<host-uuid>
+`}</Terminal>
+
+This capability is also what allows [VM load balancing](vm-load-balancing.md) density plans to power hosts off and on according to the load.
+
+## 🤝 Pool-wide settings {#pool-wide-settings}
+
+### Rotate the pool secret
+
+Members of a pool authenticate each other with a shared secret. Rotate it if you suspect it leaked, or after removing hosts you don't fully trust anymore:
+
+<Terminal shell title="root@xcp-ng-host — Rotate the pool secret">{`
+xe pool-secret-rotate
+`}</Terminal>
+
+### IGMP snooping
+
+If your VMs use multicast, enabling IGMP snooping avoids flooding every VIF of a network with multicast traffic:
+
+<Terminal shell title="root@xcp-ng-host — IGMP snooping">{`
+xe pool-param-set uuid=<pool-uuid> igmp-snooping-enabled=true
+`}</Terminal>
+
+### Restrict port 80 (HTTPS only)
+
+Starting with XCP-ng 8.3, plain HTTP on port 80 is restricted by default. You can control it explicitly:
+
+<Terminal shell title="root@xcp-ng-host — Restrict port 80 (HTTPS only)">{`
+xe pool-param-set uuid=<pool-uuid> https-only=true
+`}</Terminal>
+
+Leave it to `true` unless something in your tooling still requires port 80.
+
+### Certificate verification
+
+XCP-ng 8.3 pools can verify TLS certificates for pool-internal communication:
+
+<Terminal shell title="root@xcp-ng-host — Certificate verification">{`
+xe pool-enable-tls-verification
+`}</Terminal>
+
+See the [TLS certificates guide](../guides/TLS-certificates-xcpng.md#pool-certificate-verification) for certificate management (custom certificates, renewal, resets).
+
+### Migration compression
+
+Starting with XCP-ng 8.3, the live migration memory stream can be compressed. Very useful when the migration network is the bottleneck, at the cost of some dom0 CPU:
+
+<Terminal shell title="root@xcp-ng-host — Migration compression">{`
+xe pool-param-set uuid=<pool-uuid> migration-compression=true
+`}</Terminal>
+
+The setting applies pool-wide to subsequent migrations; Xen Orchestra also exposes it in the pool's advanced settings.
+
+## 🩺 Pool database backup {#pool-database-backup}
+
+The pool database (all your XAPI objects: VMs, SRs, networks…) is replicated on every member, and can also be exported and restored: see the [backup page](backup.md) for pool metadata backup and restore procedures.

--- a/docs/management/infrastructure-as-code.md
+++ b/docs/management/infrastructure-as-code.md
@@ -9,14 +9,14 @@ You can use various 3rd party tools to manage your XCP-ng/XO stack "as code".
 | Terraform XO     | XO API   | Available      | [Link](https://registry.terraform.io/providers/vatesfr/xenorchestra/latest/docs)        |   |
 | Ansible XO       | XO API   | Available      | [Link](https://docs.ansible.com/ansible/latest/collections/community/general/xen_orchestra_inventory.html)
 
-## 📦 Packer
+## 📦 Packer {#packer}
 
 Packer is a free and open source tool for creating golden images for multiple platforms from a single source configuration. Combined with XCP-ng, you can create and regenerate templates for your own requirements or for your customers.
 
 Here is a tutorial to start with Packer and XCP-ng: https://xcp-ng.org/blog/2024/02/22/using-packer-with-xcp-ng/
 
 
-## 🌍 Terraform / OpenTofu
+## 🌍 Terraform / OpenTofu {#terraform--opentofu}
 
 Terraform is an infrastructure as code software tool that enables you to safely and predictably create, change, and improve infrastructure. There's a series of blog posts to explain it in more details:
 
@@ -25,13 +25,13 @@ Terraform is an infrastructure as code software tool that enables you to safely 
 
 While Terraform used to be free and open-source, Hashicorp decided to relicense it. There is a free and open source fork called [OpenTofu](https://opentofu.org/) which can use Terraform's providers, though!
 
-## 🏷️ Ansible
+## 🏷️ Ansible {#ansible}
 
 Ansible is a suite of software tools that enables infrastructure as code. It is open-source and the suite includes software provisioning, configuration management, and application deployment functionality
 
 https://xen-orchestra.com/blog/virtops3-ansible-with-xen-orchestra/
 
-## 🗃️ Netbox
+## 🗃️ Netbox {#netbox}
 
 [NetBox](https://netbox.dev/) is the leading solution for modeling and documenting modern networks. By combining the traditional disciplines of IP address management (IPAM) and datacenter infrastructure management (DCIM) with powerful APIs and extensions, NetBox provides the ideal "source of truth" to power network automation. Available as open source software under the Apache 2.0 license, NetBox is employed by thousands of organizations around the world.
 

--- a/docs/management/manage-at-scale/xo-api.md
+++ b/docs/management/manage-at-scale/xo-api.md
@@ -8,7 +8,7 @@ There's two different APIs to manage XCP-ng at scale via Xen Orchestra:
 * a REST API, simple to use to read content
 * a JSON-RPC over websocket API, more complex but coming with all features
 
-## 📡 REST API
+## 📡 REST API {#rest-api}
 
 We developed XO original API to be used between the Web UI `xo-web` and the server backend, `xo-server`. That's why it's a JSON-RPC API connected via websockets, allowing us to update objects live in the browser. This is perfect for our usage, but a bit complicated for others.
 
@@ -265,7 +265,7 @@ $ curl \
 
 We are adding features and improving the REST API step by step. If you have interesting use cases or feedback, please ask directly at [the dedicated forum section](https://xcp-ng.org/forum/category/18/rest-api).
 
-## 🥋 JSON-RPC over websockets
+## 🥋 JSON-RPC over websockets {#json-rpc-over-websockets}
 
 This is the API used between Xen Orchestra web UI and the server part, `xo-server`. It's a bit harder to use than the REST API, but if you need a live subscription to events happening in your infrastructure, or to send advanced commands, this is the right one.
 

--- a/docs/management/manage-at-scale/xo-web-ui.md
+++ b/docs/management/manage-at-scale/xo-web-ui.md
@@ -35,7 +35,7 @@ Xen Orchestra is fully Open Source, and it comes in 2 "flavors":
 We advise to start using XOA by deploying it really easily in [few clicks on this page](https://vates.tech/deploy/). You can always decide later to build it yourself from GitHub.
 :::
 
-## 🚀 Deploy Xen Orchestra virtual Appliance
+## 🚀 Deploy Xen Orchestra virtual Appliance {#deploy-xen-orchestra-virtual-appliance}
 You can deploy Xen Orchestra from a web UI, using:
 * [Web deploy directly](https://vates.tech/deploy/) (fastest & recommended)
 * Using [XO Lite](../manage-locally/xo-lite.md)
@@ -49,11 +49,12 @@ You can check the progress in [XO Lite](../manage-locally/xo-lite.md)
 ### Alternative way to deploy XOA
 
 From the CLI using a deploy script, by running this in your XCP-ng host:
-```
-bash -c "$(wget -qO- https://xoa.io/deploy)"
-```
 
-## 🪙 XOA vs XO from GitHub?
+<Terminal shell title="Alternative way to deploy XOA">{`
+bash -c "$(wget -qO- https://xoa.io/deploy)"
+`}</Terminal>
+
+## 🪙 XOA vs XO from GitHub? {#xoa-vs-xo-from-github}
 
 XOA is meant to be used as the easiest way to test it, but also to use it in production: this is the version **professionally supported**, with an updater and a support tunnel mechanism.
 
@@ -63,7 +64,7 @@ If you are an individual, feel free to enjoy the version from [GitHub directly](
 XO from the sources doesn't have QA and there's no stable version. It's great for a home lab or to make tests, but not for production.
 :::
 
-## 🌐 Web UI
+## 🌐 Web UI {#web-ui}
 
 You have access to all XCP-ng possibilities (and more!) from a web UI:
 

--- a/docs/management/manage-locally/api.md
+++ b/docs/management/manage-locally/api.md
@@ -8,13 +8,13 @@ XAPI is requested by multiple **clients**, like Xen Orchestra or `xe` CLI. See [
 We strongly encourage to build applications on top of XO API and not XAPI. In fact, XAPI is made with very specific calls (close to the Xen logic), so it's a lot better to build a solution on top of a more global API, the one [provided by Xen Orchestra](https://xen-orchestra.com/docs/architecture.html#api). It will act as a central point for all your pools and you won't have to handle all the Xen specifics.
 :::
 
-## 📐 Architecture
+## 📐 Architecture {#architecture}
 
 XAPI is using a database (Read/write on the master, replicated to slaves in read only). It's an XML file located at `/var/lib/xcp/state.db`. All the metadata and settings of your pool, hosts, VMs and so on are stored there.
 
 ![Diagram of the XAPI classes (too complex to describe here).](../../../static/img/xapiclasses.png)
 
-## 🧑‍⚕️ Troubleshooting
+## 🧑‍⚕️ Troubleshooting {#troubleshooting}
 
 ### Restarting the API
 
@@ -76,9 +76,10 @@ Common values are:
 After changing the configuration, restart the toolstack with `xe-toolstack-restart`. 
 
 Example with one command to enable HSTS and restart XAPI (example sets 1 year = 31536000):
-```bash
+
+<Terminal shell title="Set HSTS retained for 1y">{`
 echo "hsts_max_age = 31536000" > /etc/xapi.conf.d/hsts.conf' && sudo xe-toolstack-restart
-```
+`}</Terminal>
 
 :::note
 You can then type `xapi-wait-init-complete 30` to ensure that XAPI has fully started.

--- a/docs/management/manage-locally/cli.md
+++ b/docs/management/manage-locally/cli.md
@@ -6,51 +6,51 @@ The xe CLI can be used locally on any XCP-ng host, it's installed along with it.
 The complete set of all `xe` commands is available in the [Appendix section](../../../appendix/cli_reference).
 :::
 
-## ℹ️ Getting help with xe commands
+## ℹ️ Getting help with xe commands {#getting-help-with-xe-commands}
 
 Basic help is available for CLI commands on-host by typing the following:
 
-```
+<Terminal shell title="root@xcp-ng-host — Getting help with xe commands">{`
 xe help
-```
+`}</Terminal>
 
 Help for individual commands is available by typing:
 
-```
+<Terminal shell title="root@xcp-ng-host — Getting help with xe commands">{`
 xe help <command>
-```
+`}</Terminal>
 
 For example:
 
-```
-[ ~]# xe help host-cpu-info
+<Terminal title="root@xcp-ng-host — Getting help with xe commands">{`
+xe help host-cpu-info
 command name            : host-cpu-info
         reqd params     : 
         optional params : uuid
         description     : Lists information about the host's physical CPUs.
-```
+`}</Terminal>
 
 Or a list of all xe commands is displayed if you type:
 
-```
+<Terminal shell title="root@xcp-ng-host — Getting help with xe commands">{`
 xe help --all
-```
+`}</Terminal>
 
-## 🪧 Basic xe syntax
+## 🪧 Basic xe syntax {#basic-xe-syntax}
 
 The basic syntax of all XCP-ng xe CLI commands is:
 
-```
+<Terminal shell title="root@xcp-ng-host — Basic xe syntax">{`
 xe <command> <argument>=value <argument>=value
-```
+`}</Terminal>
 
 Each specific command contains its own set of arguments that are of the form `argument=value`. Some commands have required arguments, and most have some set of optional arguments. Typically a command assumes default values for some of the optional arguments when invoked without them.
 
 For example, adding a bootable ISO image as a mounted CD-Rom to a VM can be done with the following command:
 
-```
+<Terminal shell title="root@xcp-ng-host — Basic xe syntax">{`
 xe vm-cd-add uuid=679c70cb-b358-00e1-72c0-819e8f74f00c cd-name=ubuntu-20.04.2-live-server-amd64.iso device=1
-```
+`}</Terminal>
 
 If the xe command is executed remotely, extra arguments are used to connect and authenticate. These arguments also take the form argument=argument_value.
 
@@ -62,15 +62,15 @@ The optional port argument can be used to specify the agent port on the remote X
 
 Example: On the local XCP-ng server:
 
-```
+<Terminal shell title="root@xcp-ng-host — Basic xe syntax">{`
 xe vm-list
-```
+`}</Terminal>
 
 Example: On the remote XCP-ng server:
 
-```
+<Terminal shell title="root@xcp-ng-host — Basic xe syntax">{`
 xe vm-list -user username -password password -server hostname
-```
+`}</Terminal>
 
 Shorthand syntax is also available for remote connection arguments:
 
@@ -82,21 +82,21 @@ Shorthand syntax is also available for remote connection arguments:
 
 Example: On a remote XCP-ng server:
 
-```
+<Terminal shell title="root@xcp-ng-host — Basic xe syntax">{`
 xe vm-list -u myuser -pw mypassword -s hostname
-```
+`}</Terminal>
 
 Arguments are also taken from the environment variable `XE_EXTRA_ARGS`, in the form of comma-separated key/value pairs. For example, to enter commands that are run on a remote XCP-ng server, first run the following command:
 
-```
+<Terminal shell title="Basic xe syntax">{`
 export XE_EXTRA_ARGS="server=foobar,port=443,username=root,password=pass"
-```
+`}</Terminal>
 
 After running this command, you no longer have to specify the remote XCP-ng server parameters in each xe command that you run.
 
 Using the `XE_EXTRA_ARGS` environment variable also enables tab completion of xe commands when issued against a remote XCP-ng server, which is disabled by default.
 
-## 🀄 Special characters and syntax
+## 🀄 Special characters and syntax {#special-characters-and-syntax}
 
 To specify argument/value pairs on the xe command line, write: `argument=value`
 
@@ -110,7 +110,7 @@ When you use the CLI on your XCP-ng server, commands have a tab completion featu
 Tab completion does not normally work when executing commands on a remote XCP-ng server. However, if you set the `XE_EXTRA_ARGS` variable on the machine where you enter the commands, tab completion is enabled. For more information, see Basic xe syntax.
 :::
 
-## 🧮 Command types
+## 🧮 Command types {#command-types}
 
 The CLI commands can be split in two halves. Low-level commands are concerned with listing and parameter manipulation of API objects. Higher level commands are used to interact with VMs or hosts in a more abstract level.
 
@@ -172,7 +172,7 @@ Where class is one of:
 
 Not every value of class has the full set of class-param-action commands. Some values of class have a smaller set of commands.
 
-## 🧶 Parameter types
+## 🧶 Parameter types {#parameter-types}
 
 The objects that are addressed with the xe commands have sets of parameters that identify them and define their states.
 
@@ -197,15 +197,15 @@ The platform parameter has a list of items that represent key/value pairs. The k
 
 To filter on a map parameter or set a map parameter, use a colon (`:`) to separate the map parameter name and the key/value pair. For example, to set the value of the `foo` key of the other-config parameter of a VM to `baa`, the command would be
 
-```
+<Terminal shell title="root@xcp-ng-host — Parameter types">{`
 xe vm-param-set uuid=VM uuid other-config:foo=baa
-```
+`}</Terminal>
 
 :::note
 In previous releases, the hyphen character (-) was used to specify map parameters. This syntax still works but is deprecated.
 :::
 
-## 🔬 Low-level parameter commands
+## 🔬 Low-level parameter commands {#low-level-parameter-commands}
 
 There are several commands for operating on parameters of objects: class-param-get, class-param-set, class-param-add, class-param-remove, class-param-clear, and class-param-list. Each of these commands takes a uuid parameter to specify the particular object. Since these commands are considered low-level commands, they must use the `UUID` and not the VM name label.
 
@@ -233,7 +233,7 @@ Removes either a key/value pair from a map, or a key from a set.
 
 Completely clears a set or a map.
 
-## 📜 Low-level list commands
+## 📜 Low-level list commands {#low-level-list-commands}
 
 The class-list command lists the objects of type class. By default, this type of command lists all objects, printing a subset of the parameters. This behavior can be modified in the following ways:
 
@@ -242,15 +242,15 @@ The class-list command lists the objects of type class. By default, this type of
 
 To change the parameters that are printed, specify the argument params as a comma-separated list of the required parameters. For example:
 
-```
+<Terminal shell title="root@xcp-ng-host — Low-level list commands">{`
 xe vm-list params=name-label,other-config
-```
+`}</Terminal>
 
 Alternatively, to list all of the parameters, use the syntax:
 
-```
+<Terminal shell title="root@xcp-ng-host — Low-level list commands">{`
 xe vm-list params=all
-```
+`}</Terminal>
 
 The list command doesn’t show some parameters that are expensive to calculate. These parameters are shown as, for example:
 
@@ -262,9 +262,9 @@ To obtain these fields, use either the command class-param-list or class-param-g
 
 To filter the list, the CLI matches parameter values with those values specified on the command-line, only printing objects that match all of the specified constraints. For example:
 
-```
+<Terminal shell title="root@xcp-ng-host — Low-level list commands">{`
 xe vm-list HVM-boot-policy="BIOS order" power-state=halted
-```
+`}</Terminal>
 
 This command lists only those VMs for which both the field power-state has the value halted and the field `HVM-boot-policy` has the value BIOS order.
 
@@ -276,7 +276,7 @@ When scripting, a useful technique is passing `--minimal` on the command line, c
 a85d6717-7264-d00e-069b-3b1d19d56ad9,aaa3eec5-9499-bcf3-4c03-af10baea96b7, 42c044de-df69-4b30-89d9-2c199564581d
 ```
 
-## 🙊 Secrets
+## 🙊 Secrets {#secrets}
 
 XCP-ng provides a secrets mechanism to avoid passwords being stored in plaintext in command-line history or on API objects. XenCenter uses this feature automatically and it can also be used from the xe CLI for any command that requires a password.
 
@@ -286,14 +286,14 @@ Password secrets cannot be used to authenticate with a XCP-ng host from a remote
 
 To create a secret object, run the following command on your XCP-ng host.
 
-```
+<Terminal shell title="root@xcp-ng-host — Secrets">{`
 xe secret-create value=my-password
-```
+`}</Terminal>
 
 A secret is created and stored on the XCP-ng host. The command outputs the UUID of the secret object. For example, `99945d96-5890-de2a-3899-8c04ef2521db`. Append `_secret` to the name of the password argument to pass this UUID to any command that requires a password.
 
 Example: On the XCP-ng host where you created the secret, you can run the following command:
 
-```
+<Terminal shell title="root@xcp-ng-host — Secrets">{`
 xe sr-create device-config:location=sr_address device-config:type=cifs device-config:username=cifs_username device-config:cifspassword_secret=secret_uuid name-label="CIFS ISO SR" type="iso" content-type="iso" shared="true"
-```
+`}</Terminal>

--- a/docs/management/manage-locally/xo-lite.md
+++ b/docs/management/manage-locally/xo-lite.md
@@ -22,13 +22,13 @@ XO Lite uses a self-signed certificate. You need to accept the certificate (foll
 XO Lite is still a work in progress! However, it's meant to cover all basic actions you need to boostrap your infrastructure or just do basic operation on your VMs.
 :::
 
-## 🔐 Credentials
+## 🔐 Credentials {#credentials}
 
 XO Lite credentials are the same than the host (SSH credentials), usually `root` as user and the password chosen during the installation process.
 
 ![The XO Lite login page.](../../../static/img/xolitelogin.png)
 
-## 📊 Dashboard
+## 📊 Dashboard {#dashboard}
 
 Once logged, you can see the dashboard:
 
@@ -38,7 +38,7 @@ Once logged, you can see the dashboard:
 XO Lite isn't a multi-cluster orchestrator, it's just a local management console. If you want to orchestrate your VMs at scale (load balancing, backup, warm migration and so on), you MUST use [Xen Orchestra](../manage-at-scale/xo-web-ui.md)!
 :::
 
-## Disabling XO Lite
+## 🚫 Disabling XO Lite {#disabling-xo-lite}
 
 First, let's emphasize that XO Lite is merely an XAPI client. While it is made readily available by the web server on XCP-ng, it actually runs entirely in your web browser. It does **not** increase the attack surface on XCP-ng servers. Additionally, in a properly configured XCP-ng deployment, the management interface resides on a dedicated network, accessible only to administrators.
 
@@ -50,12 +50,12 @@ disable-webserver=true
 
 Here's a one-liner to do that:
 
-```
+<Terminal shell title="Disabling XO Lite">{`
 echo "disable-webserver=true" > /etc/xapi.conf.d/disable-webserver.conf
-```
+`}</Terminal>
 
 You must perform this step on every host in the pool, followed by a toolstack restart (ensure no critical tasks are running before doing so):
 
-```
+<Terminal shell title="Disabling XO Lite">{`
 xe-toolstack-restart
-```
+`}</Terminal>

--- a/docs/management/management.md
+++ b/docs/management/management.md
@@ -2,7 +2,7 @@
 
 You have multiple ways to manage your hosts and your pool: all of those are called **clients**.
 
-## 🔭 Local management
+## 🔭 Local management {#local-management}
 
 If you have one host or small pool (a cluster), you can use those following tools:
 
@@ -11,7 +11,7 @@ If you have one host or small pool (a cluster), you can use those following tool
 * [Xen API](manage-locally/api) (XAPI)
 * [*XCP-ng Center*](https://github.com/xcp-ng/xenadmin/) (Windows client, deprecated and **not supported** :warning:)
 
-## 🛰️ Manage at scale
+## 🛰️ Manage at scale {#manage-at-scale}
 
 As soon you start to management multiple hosts and/or pools, you might need a single/central orchestrator. That's the point of Xen Orchestra, which can be used via a web UI, a CLI or its API:
 
@@ -23,3 +23,14 @@ As soon you start to management multiple hosts and/or pools, you might need a si
 :::tip
 Xen Orchestra is not just an XCP-ng orchestrator at scale: it's also a backup tool. See the [backup section](backup.md) for more details.
 :::
+
+## 🗺️ Common operations {#common-operations}
+
+Whatever the client you use, the main operation guides are here:
+
+* [Hosts and pools operations](hosts-pools.md) (pool creation, maintenance mode, passwords, NTP...)
+* [Updates](updates.md)
+* [Backup](backup.md) and [High availability](ha.md)
+* [Monitoring and alerts](monitoring.md)
+* [Users and permissions](users-permissions.md)
+* [VM load balancing](vm-load-balancing.md)

--- a/docs/management/monitoring.md
+++ b/docs/management/monitoring.md
@@ -1,0 +1,85 @@
+---
+sidebar_position: 6
+---
+
+# Monitoring and alerts
+
+How to watch the health and performance of your hosts, VMs and storage, and get alerted before users notice a problem.
+
+## 🛰️ With Xen Orchestra {#with-xen-orchestra}
+
+Xen Orchestra is the natural place to monitor a whole XCP-ng infrastructure:
+
+* **Dashboards and stats**: every pool, host, VM and SR has a *Stats* view (CPU, RAM, network, disk I/O) with history, plus a global dashboard with health indicators (orphaned VDIs, missing patches, unhealthy VDI chains...).
+* **Performance alerts**: the *perf-alert* plugin emails you when CPU usage, memory usage or SR usage crosses a threshold you define, for the objects you select.
+* **Backup reports**: every backup job can send a detailed success/failure report (email, and messaging platforms via plugins).
+* **Audit trail**: records who did what on your infrastructure.
+
+See the [Xen Orchestra documentation](https://docs.xen-orchestra.com/) for the details of each feature.
+
+## 📊 Host-level metrics (RRDs) {#host-level-metrics-rrds}
+
+Each host continuously records metrics (CPU, memory, network, storage, per-VM and per-host) in round-robin databases (RRDs), with several months of history at decreasing granularity. This is what powers the graphs in Xen Orchestra and XO Lite.
+
+You can query these metrics yourself:
+
+<Terminal shell title="root@xcp-ng-host — Host-level metrics (RRDs)">{`
+# List the metrics recorded for a host, then fetch values
+xe host-data-source-list host=<host>
+xe host-data-source-query host=<host> data-source=cpu_avg
+
+# Same for a VM
+xe vm-data-source-list vm=<vm>
+xe vm-data-source-query vm=<vm> data-source=memory_internal_free
+`}</Terminal>
+
+Individual data sources can be enabled or disabled (`xe host-data-source-record`/`-forget`, same for VMs), and the `rrd2csv` tool (shipped with XAPI) streams selected metrics as CSV for quick exports.
+
+The raw RRDs are also exposed over HTTP for external collectors: `https://<host>/rrd_updates?start=<unix-timestamp>&host=true` returns everything that changed since the given time, in XML. This endpoint is a simple way to feed XCP-ng metrics into your own tooling without installing anything in dom0.
+
+## 🖥️ Live view on the host {#live-view-on-the-host}
+
+For an instant view directly on a host (SSH or console):
+
+* `xentop`: per-VM CPU, memory, network and disk usage, as seen from the hypervisor. The `%CPU` column is relative to one physical CPU.
+* `xl info`: global hypervisor information (total/free memory, number of pCPUs...).
+* Standard Linux tools (`top`, `iostat`...) inside dom0 show the control domain's own resource usage. Remember that dom0 only sees its own slice of the machine: use `xentop` for the whole picture.
+
+High dom0 load, or dom0 running out of memory, degrades every VM on the host: see the [dom0 memory guide](../guides/dom0-memory.md).
+
+## 📡 Netdata {#netdata}
+
+For detailed real-time dashboards on a host, XCP-ng provides `netdata` packages, and Xen Orchestra Premium can install and integrate them in one click (host view, *Advanced* tab). Netdata gives you per-second metrics with a modern web UI, and can stream to a central Netdata parent if you have one.
+
+You can also install it manually as an [additional package](additional-packages.md), keeping in mind the general rule: dom0 is not a regular Linux box, keep extra software minimal.
+
+## 🔔 SNMP and external supervision {#snmp-and-external-supervision}
+
+If your organization has a central supervision system (Zabbix, Centreon, LibreNMS, Prometheus...), a few options:
+
+* **Agentless**: scrape the RRD HTTP endpoint (above), or use the supervision system's API integration with Xen Orchestra.
+* **SNMP**: `net-snmp` is available in the XCP-ng repositories as an [additional package](additional-packages.md):
+
+<Terminal shell title="root@xcp-ng-host — SNMP and external supervision">{`
+yum install net-snmp
+# configure a read-only community in /etc/snmp/snmpd.conf, e.g.: rocommunity monitoring 192.0.2.0/24
+systemctl enable --now snmpd
+`}</Terminal>
+
+  Then open UDP port 161 in the dom0 firewall (add the rule to `/etc/sysconfig/iptables` and restart `iptables`, so it survives reboots). Keep the community/users **read-only**.
+* **NRPE**: XCP-ng doesn't ship a Nagios NRPE integration. For Nagios-family systems, use SNMP (above), or netdata's collectors.
+* **Dedicated agents** (Zabbix agent...) can be installed in dom0 as additional packages, with the usual caution about keeping dom0 minimal.
+
+:::warning
+Whatever you install, never let a monitoring agent modify dom0's configuration or update its packages: see the [additional packages rules](additional-packages.md#rules).
+:::
+
+## 🚨 What should I watch? {#what-should-i-watch}
+
+A reasonable minimal set of alerts for an XCP-ng infrastructure:
+
+* **SR free space**: a full SR stops VMs from writing. Watch thin-provisioned SRs closely, snapshots and [coalesce](../storage/storage.md#coalesce) can consume space quickly.
+* **Host memory**: pool capacity to absorb a host failure ([HA](ha.md) needs headroom).
+* **dom0 CPU and memory**: an overloaded control domain slows every VM.
+* **Backup job results**: a backup that silently stopped working is only discovered when you need it.
+* **Hardware**: use your server vendor's out-of-band management (iDRAC, iLO...) for disks, PSUs and fans; XCP-ng won't see everything the BMC sees.

--- a/docs/management/updates.md
+++ b/docs/management/updates.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 This page details how to keep your XCP-ng system updated (bug fixes and security fixes) between [upgrades](../../installation/upgrade).
 
-## ⚡ Quick start
+## ⚡ Quick start {#quick-start}
 
 If you want to manage your XCP-ng updates, we suggest that you use Xen Orchestra. It's the fastest & easiest way to keep your infrastructure up-to-date. See the [dedicated section](updates.md#from-xen-orchestra). If you want to learn more about Xen Orchestra, also check the [management section](management.md).
 
@@ -14,7 +14,7 @@ If you want to manage your XCP-ng updates, we suggest that you use Xen Orchestra
 Each update is covered by a dedicated blog post. Browse all update posts at https://xcp-ng.org/blog/tag/update/
 :::
 
-## ♻️ Support cycle
+## ♻️ Support cycle {#support-cycle}
 
 We maintain one or several releases in parallel:
 * LTS releases (currently `8.3`).
@@ -22,7 +22,7 @@ We maintain one or several releases in parallel:
 
 If your version is lower than `8.3`, it will not receive updates anymore. To keep benefiting from bugfixes and security fixes you need to [upgrade](../../installation/upgrade).
 
-## ℹ️ Prerequisites
+## ℹ️ Prerequisites {#prerequisites}
 
 ### Access to the repository
 
@@ -40,10 +40,11 @@ For specific repositories:
 
 Set a system-wide proxy that will be used for everything, not only yum:
 - Export the `http_proxy` and `https_proxy` variables in `/etc/environment`:
-```bash
+
+<Terminal shell title="Proxy configuration">{`
 export http_proxy=<proxy_url>
 export https_proxy=<proxy_url>
-```
+`}</Terminal>
 
 :::warning
 These changes will be remain intact through standard updates, but they will be lost if you upgrade to a new major version.
@@ -62,7 +63,7 @@ In any case, installing extra packages from outside the XCP-ng repositories can 
 
 More at [Additional packages](../../management/additional-packages).
 
-## 💡 Get information about the updates
+## 💡 Get information about the updates {#get-information-about-the-updates}
 
 Every update is first tested and discussed on a forum thread dedicated to update candidates for a given XCP-ng release. We highly recommend to subscribe to these threads (activate e-mail notifications in your forum settings if you want to be notified of new messages). You will thus know about coming updates in advance and be able to help us validate them. No one would like updates to be delayed because of lack of feedback there.
 
@@ -88,7 +89,7 @@ XCP-ng 8.2 is EOL. This 8.2-specific information is retained solely to assist wi
 * [List of immediate **update candidates**](https://koji.xcp-ng.org/builds?inherited=0&tagID=89&order=-build_id&latest=1)
 * [List of **testing** packages prepared for a future update](https://koji.xcp-ng.org/builds?inherited=0&tagID=43&order=-build_id&latest=1)
 
-## 🚸 Precautions
+## 🚸 Precautions {#precautions}
 
 :::warning
 **Always update the pool master first. Other pool members must never run a higher version than the master.**
@@ -105,7 +106,7 @@ If you update any other host before the pool master, **it will lose the ability 
 *Some people systematically run `xe vm-cd-eject --multiple` to eject all virtual CDs/DVDs from the VMs before updating and/or migrating.*
 * Do not update from an interactive shell that was directly started from the XCP-ng console (`xsconsole`), nor from the host's remote console that is available through the VNC protocol in Xen Orchestra or XCP-ng Center. The update process may restart those, kill the current shell and thus kill the update process which would leave the system in an unclean state (duplicate RPMs).
 
-## 🦮 How to apply the updates
+## 🦮 How to apply the updates {#how-to-apply-the-updates}
 
 ### From command line
 
@@ -119,31 +120,34 @@ LINSTOR expects that we always use satellites and controllers with the same vers
 Without precautions and after a reboot of a just updated host, it's possible that a machine can no longer communicate with other hosts through LINSTOR satellites.
 
 To avoid problems, it is strongly recommended to update all satellites, controllers packages of each host without rebooting:
-```
+
+<Terminal shell title="root@xcp-ng-host — 2. Additional steps regarding…">{`
 yum update linstor-satellite linstor-controller
-```
+`}</Terminal>
 
 After updating all hosts without reboot:
-```
+
+<Terminal shell title="2. Additional steps regarding XOSTOR SRs">{`
 systemctl stop linstor-controller # "stop" is not a typo, it will auto restart the controller.
 systemctl restart linstor-satellite
-```
+`}</Terminal>
 
 Then you can follow the next CLI instructions to manually update the pool.
 
 #### 3. Understand what kind of update is needed
 
 Depending on the packages being updated, only the control plane might need to be restarted, or the whole host might need a restart.
-Please consult the [updates tag](https://xcp-ng.org/blog/tag/update/) in the XCP-ng blog for more information on whether restarting the control plane is enough or not to apply the update. If in doubt, follow the procedure to restart the hosts, there's more information in the section "[When to reboot?](#-when-to-reboot)".
+Please consult the [updates tag](https://xcp-ng.org/blog/tag/update/) in the XCP-ng blog for more information on whether restarting the control plane is enough or not to apply the update. If in doubt, follow the procedure to restart the hosts, there's more information in the section "[When to reboot?](#when-to-reboot)".
 
 #### 4. Updating with host reboot
 
 To update each of the hosts, they need to be disabled, evacuated, updated and finally restarted, one host at a time, and starting with the pool coordinator:
-```
+
+<Terminal shell title="root@xcp-ng-host — 4. Updating with host reboot">{`
 xe host-disable uuid=<uuid>
 xe host-evacuate uuid=<uuid>
 yum update
-```
+`}</Terminal>
 
 Instead of being evacuated, you may choose to shut down the VMs if interrupting the services that the VM provides is acceptable.
 This might be desirable if the VM is using local storage and migrating will take too long, there's not enough storage in other servers, or it's the only host in the pool.
@@ -152,13 +156,15 @@ Once you've made sure that there are no tasks happening in the host by running `
 
 Once the host has restarted, it should be enabled back again. If it hasn't enabled itself, enable it with `xe host-enable uuid=<uuid>`, and repeat the procedure with another host of the pool, until all are updated.
 
-### 5. Updating with a control plane restart
+#### 5. Updating with a control plane restart
 
 To update each of the hosts, they need to be disabled, updated and finally the control plane needs to be restarted, one host at a time, and starting with the pool coordinator:
-```
+
+<Terminal shell title="root@xcp-ng-host — 5. Updating with a control plane…">{`
 xe host-disable uuid=<uuid>
 yum update
-```
+`}</Terminal>
+
 Once you've made sure that there are no tasks happening in the host by running `xe task-list`, you can restart the control plane with `xe-toolstack-restart`.
 
 Once the control plane has been fully restarted, it should be enabled back again. If it hasn't enabled itself, enable it with `xe host-enable uuid=<uuid>`, and repeat the procedure with another host of the pool, until all are updated.
@@ -196,15 +202,17 @@ Rolling Pool Updates (RPUs) can handle pools that utilize XOSTOR, if:
 What happens with older versions of the XAPI plugins is that, after rebooting a recently updated host, it might no longer be able to communicate with other hosts through LINSTOR satellites. In fact, LINSTOR expects that we always use satellites and controllers with the same version.
 
 To avoid problems, it is strongly recommended to update the satellites, controllers packages of each host without rebooting:
-```
+
+<Terminal shell title="root@xcp-ng-host — XOSTOR support">{`
 yum update linstor-satellite linstor-controller
-```
+`}</Terminal>
 
 After updating all hosts without reboot:
-```
+
+<Terminal shell title="XOSTOR support">{`
 systemctl stop linstor-controller # "stop" is not a typo, it will auto restart the controller.
 systemctl restart linstor-satellite
-```
+`}</Terminal>
 
 Then you can follow the instructions in the documentation to manually update the pool.
 :::
@@ -231,7 +239,7 @@ You can see hosts that will require a reboot via a small blue triangle:
 We do NOT recommend to install updates to individual hosts. Obviously except if they are alone in their own pool. Running hosts in the same pool with different level of updates should be avoided as possible. We leave that option in case you have a specific need, but again, we discourage that usage as possible. Note that even a host alone in its pool can be updated via the "Pool update" button!
 :::
 
-## 🏁 When to reboot?
+## 🏁 When to reboot? {#when-to-reboot}
 
 There is currently no way for XCP-ng to automatically tell you if a reboot is required.
 
@@ -245,7 +253,7 @@ Else base your decision on an educated guess. Look at the list of the updated pa
 
 All updates are announced on the [XCP-ng Blog](https://xcp-ng.org/blog/tag/update/) along with information about what steps are required after installing the update (reboot, toolstack restart, service restart...).
 
-## 🔥 XCP-ng 7.5/7.6 and live migrations
+## 🔥 XCP-ng 7.5/7.6 and live migrations {#xcp-ng-7576-and-live-migrations}
 
 Since the component that handles live migrations in XenServer is closed-source, we had to write our own. However, it took several tries before we reached a fully functional replacement, that's why only hosts that have had the latest updates of the `xcp-emu-manager` package have the fully working replacement. Previous versions will or will not manage to migrate your VMs, depending on various contextual factors, including the VM's load.
 

--- a/docs/management/users-permissions.md
+++ b/docs/management/users-permissions.md
@@ -1,0 +1,47 @@
+---
+sidebar_position: 7
+---
+
+# Users and permissions
+
+Who can access your XCP-ng infrastructure, and with which rights.
+
+## 🎓 The model in short {#the-model-in-short}
+
+There are two distinct layers:
+
+1. **On the hosts**: a single `root` account. It's what XAPI clients (Xen Orchestra, XO Lite, `xe`) and SSH use. Everyone who knows it can do everything on the pool, so treat it like the infrastructure key it is.
+2. **In Xen Orchestra**: real user management. Individual accounts, groups, external identity providers, fine-grained ACLs, self-service and an audit log. This is where "users" as an organization understands them belong.
+
+In other words: XCP-ng authenticates *management planes*, Xen Orchestra authenticates *people*.
+
+## 🔑 Host level: the root account {#host-level-the-root-account}
+
+* Change the password with `xe user-password-change` or `xsconsole`: see [root password management](hosts-pools.md#root-password).
+* All pool members share the same root password.
+* Protect SSH access as you would on any critical Linux server (strong password, or keys plus disabled password authentication). XCP-ng 8.3 also tightened the default SSH ciphers and configuration. SSH can be disabled entirely from `xsconsole` (**Remote Service Configuration** → **Enable/Disable Remote Shell**) if your policies require it.
+* XAPI listens on HTTPS (port 443): you can install a proper TLS certificate, see the [TLS certificates guide](../guides/TLS-certificates-xcpng.md), and on XCP-ng 8.3, [certificate verification](../releases/release-8-3.md#certificate-verification-xs) between pool members.
+
+:::info
+XAPI historically supports external authentication (Active Directory) and role-based access control at the host level. In XCP-ng this path is deprecated (see the [8.3 release notes](../releases/release-8-3.md#active-directory-in-xcp-ng)) and not recommended: user management is done in Xen Orchestra, which offers much more flexibility without touching dom0.
+:::
+
+## 👥 Xen Orchestra: users, groups and ACLs {#xen-orchestra-users-groups-and-acls}
+
+What Xen Orchestra provides on top of your pools:
+
+* **Users and groups**: local accounts, or synchronized from your identity provider via plugins (LDAP/Active Directory, SAML, OIDC, GitHub...).
+* **ACLs**: grant a user or group a role on specific objects (a VM, a pool, an SR, a network). Three roles: *Viewer* (see), *Operator* (use: start, stop, snapshot...), *Admin* (full control including destroy).
+* **Self-service**: delegate a quota of CPU, RAM and disk to a group; its members create and manage their own VMs inside that envelope, without seeing the rest of the infrastructure.
+* **Audit log**: traceability of the actions performed through XO.
+
+See the Xen Orchestra documentation for details: [users](https://docs.xen-orchestra.com/xo5/users), [ACLs](https://docs.xen-orchestra.com/xo5/users#acls), [self-service](https://docs.xen-orchestra.com/xo5/users#self-service-portal).
+
+## 🧭 Recommended setup {#recommended-setup}
+
+For a team of any size:
+
+1. Keep the hosts' `root` password in a password manager, known to as few people as possible. Day to day, nobody should log into a host directly.
+2. Connect Xen Orchestra to your identity provider, create groups matching your teams.
+3. Give admins ACLs on the pools, and application teams self-service resource sets or per-VM ACLs.
+4. Enable the audit log plugin if you need traceability.

--- a/docs/management/vm-load-balancing.md
+++ b/docs/management/vm-load-balancing.md
@@ -1,6 +1,6 @@
 # VM Load balancing
 
-## 📋 Introduction
+## 📋 Introduction {#introduction}
 
 A generic definition (from Wikipedia), is:
 
@@ -12,7 +12,7 @@ In the case of virtualization, you have multiple physical hosts, which runs your
 Maybe you already heard about VMWare DRS (Distributed Resource Scheduler): that's the same principle here, but for XCP-ng.
 :::
 
-## 🎓 Concepts
+## 🎓 Concepts {#concepts}
 So the first objective is to adapt your VM placement in live (without service interruption), depending of the load. Because [Xen Orchestra](../manage-at-scale/xo-web-ui) is connected to multiple pools and XCP-ng supports live storage motion, we can perform load balancing on a **whole XCP-ng infrastructure** (even between remote datacenters). A load balancing policy is called a "**plan**".
 
 Let's take a simple example, with these 2 hosts running 6 VMs:
@@ -41,7 +41,7 @@ But it's not the only way to see this: there is multiple possibilities to "optim
 
 Those ways can be also called modes: "performance" for 1, "density" for number 2 and "mixed" for the last.
 
-## 🔧 Configure a plan
+## 🔧 Configure a plan {#configure-a-plan}
 
 In this coming new view, you'll be able to configure a new load balancing plan, or edit an existing one.
 
@@ -98,7 +98,7 @@ The global situation (resource usage) is examined **every minute**.
 TODO: more details to come here
 :::
 
-## ↔️ VM anti-affinity
+## ↔️ VM anti-affinity {#vm-anti-affinity}
 
 VM anti-affinity is a feature that prevents VMs with the same user tags from running on the same host. This functionality is available directly in the load-balancer plugin.
 This way, you can avoid having pairs of redundant VMs or similar running on the same host.

--- a/docs/migrate-to-xcp-ng/_category_.json
+++ b/docs/migrate-to-xcp-ng/_category_.json
@@ -1,5 +1,0 @@
-{
-    "label": "Migrate to XCP-ng",
-    "position": 5,
-    "link": {"type": "doc", "id": "migrate-to-xcp-ng"}
-}

--- a/docs/networking/networking.md
+++ b/docs/networking/networking.md
@@ -6,9 +6,9 @@ XCP-ng is using Open vSwitch as its core, and supports various features from it.
 Even if one NIC can be enough for your host, having a dedicated NIC for storage will be really important to get consistent performances (especially if you use shared storage like iSCSI or NFS).
 :::
 
-## 🎓 Concepts
+## 🎓 Concepts {#concepts}
 
-This section describes the general concepts of networking in XCP-ng. For a deeper dive, check the [Network Architecture section](../../project/architecture/#%EF%B8%8F-network).
+This section describes the general concepts of networking in XCP-ng. For a deeper dive, check the [Network Architecture section](../../project/architecture/#network).
 
 XCP-ng creates a network for each physical NIC during installation. When you add a server to a pool, the default networks **are merged**. This is meant to be sure that all physical NICs with the same device name are attached to the same network, authorizing seamless VM flexibility on any host of the pool.
 
@@ -51,7 +51,7 @@ Each XCP-ng server has one or more networks, which are virtual Ethernet switches
 
 #### Definition
 
-The **Maximum Transmission Unit (MTU)** represents the largest packet size, measured in bytes, that a network layer—such as Ethernet or TCP/IP—can transmit without fragmenting the data. It effectively sets the upper limit for the payload size of a single network packet.
+The **Maximum Transmission Unit (MTU)** represents the largest packet size, measured in bytes, that a network layer (such as Ethernet or TCP/IP) can transmit without fragmenting the data. It effectively sets the upper limit for the payload size of a single network packet.
 
 #### Typical MTU values
 
@@ -75,7 +75,7 @@ Non-standard MTUs are supported on **storage interfaces**. However, jumbo frames
 
 While these limitations may be addressed in future updates, **stick to default MTU settings on management interfaces** to ensure **operational stability**.
 
-## 🏷️ VLANs
+## 🏷️ VLANs {#vlans}
 
 VLANs, as defined by the IEEE 802.1Q standard, allow a single physical network to support multiple logical networks. XCP-ng hosts support VLANs in multiple ways.
 
@@ -137,11 +137,134 @@ In this configuration, when a VM sends a 9000-byte packet on the VLAN, it arrive
 
 **Solution:** Raise the physical interface's MTU to at least match the VLAN network's MTU before creating the VLAN network with jumbo frames.
 
-## 🔗 Bonds
+## 🔗 Bonds {#bonds}
 
-It's same as previous section, just check the "Bonded Network" and select multiple PIFs in the Interface selector. You can either use VLANs or not, it doesn't matter!
+A bond aggregates 2 to 4 physical NICs into one logical interface, for redundancy (a cable, NIC or switch failure doesn't cut traffic) and, depending on the mode, more total bandwidth. Bonds work for VM traffic, management and storage alike, with or without VLANs on top.
 
-## 🌐 Manage physical NICs
+### Bond modes
+
+* **Active-active** (`balance-slb`, the default): all links carry traffic. VM traffic is spread by source MAC address and rebalanced periodically. No specific switch configuration needed, which makes it the easy and safe choice. One given VIF's traffic uses one link at a time, so a single VM won't exceed one NIC's bandwidth.
+* **Active-passive** (`active-backup`): one link carries everything, the others are standby. No switch configuration either, and the most predictable failover behavior. Choose it when your switches don't support anything better or when you bond across two independent, non-stackable switches.
+* **LACP** (`lacp`): the NICs form an 802.3ad link aggregation group with the switch, so **the switch ports must be configured as an LACP LAG** (and the switches stacked/MLAG if you spread the bond across two of them). Traffic can be hashed by source MAC or by IP and port, the latter letting a single VM use several links for multiple flows:
+
+<Terminal shell title="root@xcp-ng-host — Bond modes">{`
+xe bond-param-set uuid=<bond-uuid> properties:hashing_algorithm=tcpudp_ports
+`}</Terminal>
+
+(`src_mac` is the other value.)
+
+:::tip
+If you plan to install or upgrade a host whose management interface is on an LACP bond, read the [LACP install guide](../guides/lacp-install-upgrade.md) first: the installer doesn't speak LACP.
+:::
+
+### Create a bond
+
+From Xen Orchestra: **New** → **Network**, check "Bonded network", select the member PIFs and the mode. XO takes care of creating it properly on every host of the pool.
+
+With `xe`, create a new network then the bond on each host, starting with the pool coordinator:
+
+<Terminal shell title="root@xcp-ng-host — Create a bond">{`
+xe network-create name-label="bond0"
+xe bond-create network-uuid=<network-uuid> pif-uuids=<pif1-uuid>,<pif2-uuid> mode=balance-slb
+`}</Terminal>
+
+Notes:
+
+* Do this from a NIC that is *not* part of the future bond (or from a serial/physical console): connectivity on the member NICs drops when the bond forms. If the management interface is among the members, XAPI moves it onto the bond automatically.
+* The bond takes the MAC address of its first member; you can override it with `mac=` at creation.
+* The failover reactivity is controlled by the bond's up delay (31000 ms by default, to avoid flapping): `xe pif-param-set uuid=<bond-pif-uuid> other-config:bond-updelay=<ms>` then replug the PIF.
+
+### Remove a bond
+
+<Terminal shell title="root@xcp-ng-host — Remove a bond">{`
+xe bond-destroy uuid=<bond-uuid>
+`}</Terminal>
+
+The member NICs come back as individual PIFs. If the management interface was on the bond, it moves back to the primary member.
+
+## 🎯 Dedicated storage NIC {#dedicated-storage-nic}
+
+To keep storage (or backup) traffic away from the management and VM networks, give a spare NIC its own IP and use that subnet for your NFS/iSCSI targets:
+
+<Terminal shell title="root@xcp-ng-host — Dedicated storage NIC">{`
+xe pif-list host-name-label=<host> device=eth2       # find the PIF
+xe pif-reconfigure-ip uuid=<pif-uuid> mode=static IP=10.10.10.11 netmask=255.255.255.0
+xe pif-param-set uuid=<pif-uuid> disallow-unplug=true other-config:management_purpose="Storage"
+`}</Terminal>
+
+From Xen Orchestra: host → **Network** tab, edit the PIF's IP configuration directly.
+
+The host routes storage traffic through that NIC simply because the storage target's IP belongs to its subnet, so use a dedicated subnet (and ideally a dedicated VLAN) for storage. This also composes with [multipathing](../storage/multipathing.md), which uses several such NICs on separate paths.
+
+## 🧭 Management interface {#management-interface}
+
+The management interface is the PIF carrying XAPI traffic (pool communication, Xen Orchestra connections, migrations by default...). A few operations around it:
+
+### Move it to another NIC (or bond, or VLAN)
+
+<Terminal shell title="root@xcp-ng-host — Move it to another NIC (or bond…">{`
+xe pif-list host-name-label=<host>                  # find the target PIF
+xe pif-reconfigure-ip uuid=<new-pif-uuid> mode=dhcp # the future management PIF needs an IP config
+xe host-management-reconfigure pif-uuid=<new-pif-uuid>
+`}</Terminal>
+
+Do this from a console that won't be cut (physical, serial, or the current management NIC if it stays connected): your management sessions will reconnect to the new address.
+
+### Change its IP configuration
+
+<Terminal shell title="root@xcp-ng-host — Change its IP configuration">{`
+xe pif-reconfigure-ip uuid=<mgmt-pif-uuid> mode=static IP=<ip> netmask=<mask> gateway=<gw> DNS=<dns>
+xe host-management-reconfigure pif-uuid=<mgmt-pif-uuid>
+`}</Terminal>
+
+On the pool coordinator, members will reconnect automatically; if a member gets lost after a coordinator IP change, point it to the new address with `xe pool-recover-slaves` from the coordinator. If you locked yourself out entirely, use the [emergency network reset](#emergency-network-reset).
+
+### Change the hostname
+
+<Terminal shell title="root@xcp-ng-host — Change the hostname">{`
+xe host-set-hostname-live host-uuid=<host-uuid> host-name=<new-hostname>
+`}</Terminal>
+
+### DNS servers
+
+DNS is part of the management PIF's IP configuration (`DNS=` in `pif-reconfigure-ip` above, comma-separated). For DNS *search domains*, see [DNS search domains](#dns-search-domains).
+
+## 🚦 Limit a VM's network bandwidth (QoS) {#limit-a-vms-network-bandwidth-qos}
+
+An outgoing rate limit can be set per virtual interface:
+
+<Terminal shell title="root@xcp-ng-host — Limit a VM's network bandwidth…">{`
+xe vif-param-set uuid=<vif-uuid> qos_algorithm_type=ratelimit qos_algorithm_params:kbps=10240
+`}</Terminal>
+
+(here about 10 MB/s). Unplug/replug the VIF, or restart the VM, to apply. Remove it by setting `qos_algorithm_type=""`. This limits what the VM can *send*; incoming traffic shaping is a job for your physical network.
+
+## 📛 Restrict what a VM can send (switch port locking) {#switch-port-locking}
+
+By default, a VM can emit any traffic on its networks. You can lock a virtual interface down to its expected addresses (anti-spoofing), or block it entirely. Useful when you don't fully trust what runs inside the VMs, e.g. in hosting scenarios.
+
+<Terminal shell title="root@xcp-ng-host — Restrict what a VM can send…">{`
+# Only allow this VIF to send from a given IP
+xe vif-param-set uuid=<vif-uuid> locking-mode=locked
+xe vif-param-set uuid=<vif-uuid> ipv4-allowed=192.0.2.10
+
+# Block a VIF entirely
+xe vif-param-set uuid=<vif-uuid> locking-mode=disabled
+`}</Terminal>
+
+A network-wide default can be set for all VIFs that stay in `default` mode: `xe network-param-set uuid=<network-uuid> default-locking-mode=disabled` (or `unlocked`). Changes on a running VM need a VIF replug or a VM restart. See the [CLI reference](../appendix/cli_reference.md#vif-commands) for the full parameter list.
+
+## 🚛 NBD backup network {#nbd-backup-network}
+
+Xen Orchestra's NBD-enabled backups read disk data over the NBD protocol (port 10809), on networks you have explicitly allowed. To dedicate a network (for example your storage or a backup network) to that traffic:
+
+<Terminal shell title="root@xcp-ng-host — NBD backup network">{`
+xe network-param-add uuid=<network-uuid> param-name=purpose param-key=nbd
+`}</Terminal>
+
+The network needs an IP on each host (a [dedicated NIC](#dedicated-storage-nic) works perfectly). See the [backup page](../management/backup.md) for the XO side.
+
+## 🌐 Manage physical NICs {#manage-physical-nics}
 
 ### Add a new NIC
 
@@ -150,19 +273,22 @@ Once a NIC is physically installed, in Xen Orchestra, go to your host's networki
 ![XO's Network tab with the refresh button highlighted.](../../assets/img/screenshots/PIFs-refresh.png)
 
 This can also be done on the command line. After physically installing a new NIC, you'll need to run a `xe pif-scan` command on the host to get this NIC added as an available PIF.
-```
+
+<Terminal shell title="root@xcp-ng-host — Add a new NIC">{`
 xe pif-scan host-uuid=<HOST UUID>
-```
+`}</Terminal>
 
 Check new NIC by UUID:
-```
+
+<Terminal shell title="root@xcp-ng-host — Add a new NIC">{`
 xe pif-list
-```
+`}</Terminal>
 
 Plug new NIC:
-```
+
+<Terminal shell title="root@xcp-ng-host — Add a new NIC">{`
 xe pif-plug uuid=<NIC UUID>
-```
+`}</Terminal>
 
 ### Renaming NICs
 
@@ -174,51 +300,62 @@ If for some reason the NIC order between hosts doesn't match up, you can fix it 
 These commands are meant to be done on non-active interfaces. Typically this will be done directly after install, before even joining a pool.
 :::
 
-```
+<Terminal shell title="Renaming NICs">{`
 interface-rename --help
-```
+`}</Terminal>
+
 This will display all available options.
 
-```
+<Terminal shell title="Renaming NICs">{`
 interface-rename --list
-```
+`}</Terminal>
+
 This will display the current interface mapping/assignments.
 
 Interfaces you wish to rename need to be downed first:
-```
+
+<Terminal shell title="Renaming NICs">{`
 ifconfig eth4 down
 ifconfig eth8 down
-```
+`}</Terminal>
 
 The most common use will be an update statement like the following:
-```
+
+<Terminal shell title="Renaming NICs">{`
 interface-rename --update eth4=00:24:81:80:19:63 eth8=00:24:81:7f:cf:8b
-```
+`}</Terminal>
+
 This example will set the mac-address for eth4 & eth8, switching them in the process.
 
 The XAPI database needs the old PIFs removed. First list your PIFs for the affected NICs:
-```
+
+<Terminal shell title="root@xcp-ng-host — Renaming NICs">{`
 xe pif-list
 xe pif-forget uuid=<uuid of eth4>
 xe pif-forget uuid=<uuid of eth8>
-```
+`}</Terminal>
+
 Reboot the host to apply these settings.
 
 The interfaces by their new names need to be re-enabled:
-```
+
+<Terminal shell title="Renaming NICs">{`
 ifconfig eth4 up
 ifconfig eth8 up
-```
+`}</Terminal>
 
 The new interfaces need to be introduced to the PIF database:
-```
+
+<Terminal shell title="root@xcp-ng-host — Renaming NICs">{`
 xe host-list
-```
+`}</Terminal>
+
 Make note of the host uuid. Then introduce the interfaces:
-```
+
+<Terminal shell title="root@xcp-ng-host — Renaming NICs">{`
 xe pif-introduce device=eth4 host-uuid=<host uuid> mac=<mac>
 xe pif-introduce device=eth8 host-uuid=<host uuid> mac=<mac>
-```
+`}</Terminal>
 
 By renaming/updating interfaces like this, you can assure all your hosts have the same interface order.
 
@@ -227,14 +364,16 @@ By renaming/updating interfaces like this, you can assure all your hosts have th
 
 Before removing a physical NIC, ensure that no VMs are using the interface. Shutdown the host, physically remove the NIC and boot.
 After boot, the PIF will need to be removed. You can do it this way:
-```
+
+<Terminal shell title="root@xcp-ng-host — Remove a physical NIC">{`
 xe pif-forget uuid=<PIF UUID>
-```
+`}</Terminal>
+
 The `<PIF UUID>` can be obtained with either `xe pif-list` or with Xen Orchestra. This command only needs to be ran once on the pool. 
 
-## 🛞 SDN controller
+## 🛞 SDN controller {#sdn-controller}
 
-An SDN controller is provided by a [Xen Orchestra](../management#%EF%B8%8F-manage-at-scale) plugin. Thanks to that, you can enjoy advanced network features.
+An SDN controller is provided by a [Xen Orchestra](../management#manage-at-scale) plugin. Thanks to that, you can enjoy advanced network features.
 
 ### GRE/VXLAN tunnels
 
@@ -298,7 +437,7 @@ It means the TLS certificate, used to identify an SDN controller, on the host do
 
 The issue should be fixed.
 
-## 🚏 Static routes
+## 🚏 Static routes {#static-routes}
 
 Sometimes you need to add extra routes to an XCP-ng host. It can be done manually with an `ip route add 10.88.0.0/14 via 10.88.113.193` (for example). But it won't persist after a reboot.
 
@@ -306,31 +445,35 @@ To properly create persistent static routes, first create your xen network inter
 
 Now insert the UUID in the below example command. Also change the IPs to what you need, using the following format: `<network>/<netmask>/gateway IP>`. For example, our previous `ip route add 10.88.0.0/14 via 10.88.113.193` will be translated into:
 
-```
+<Terminal shell title="root@xcp-ng-host — Static routes">{`
 xe network-param-set uuid=<network UUID> other-config:static-routes=10.88.0.0/14/10.88.113.193
-```
+`}</Terminal>
 
 :::tip
 You **must** restart the toolstack on **all hosts in the pool** for the new route to be added!
 :::
 
 You can check the result with a `route -n` afterwards to see if the route is now present. If you must add multiple static routes, it must be in one command, and the routes separated by commas. For example, to add both 10.88.0.0/14 via 10.88.113.193 *and* 10.0.0.0/24 via 192.168.1.1, you would use this:
-```
+
+<Terminal shell title="root@xcp-ng-host — Static routes">{`
 xe network-param-set uuid=<network UUID> other-config:static-routes=10.88.0.0/14/10.88.113.193,10.0.0.0/24/192.168.1.1
-```
+`}</Terminal>
+
 ### Removing static routes
 
 To **remove** static routes you have added, stick the same network UUID from before in the below command:
-```
+
+<Terminal shell title="root@xcp-ng-host — Removing static routes">{`
 xe network-param-remove uuid=<network UUID> param-key=static-routes param-name=other-config
-```
+`}</Terminal>
+
 A toolstack restart is needed as before, on all hosts in the pool.
 
 :::tip
 XAPI might not remove the already-installed route until the host is rebooted. If you need to remove it ASAP,  you can use `ip route del 10.88.0.0/14 via 10.88.113.193`. Check that it's gone with `route -n`.
 :::
 
-## 🕸️ Full mesh network
+## 🕸️ Full mesh network {#full-mesh-network}
 
 This page describes how to configure a three node meshed network ([see Wikipedia](https://en.wikipedia.org/wiki/Mesh_networking)) which is a very cheap approach to create a 3 node HA cluster, that can be used to host a Ceph cluster, or similar clustered solutions that require 3 nodes in order to operate with full high-availability.
 
@@ -423,45 +566,49 @@ This setup will save you costs of 2 network switches you would otherwise have to
 * Forum post: [https://xcp-ng.org/forum/topic/1897/mesh-network](https://xcp-ng.org/forum/topic/1897/mesh-network)
 * Proxmox wiki: [https://pve.proxmox.com/wiki/Full_Mesh_Network_for_Ceph_Server](https://pve.proxmox.com/wiki/Full_Mesh_Network_for_Ceph_Server)
 
-## 🔎 DNS Search Domains
+## 🔎 DNS Search Domains {#dns-search-domains}
 
 When XCP-ng is configured for static IP configuration there are no DNS search domains added. It is possible to add search domains into `/etc/resolv.conf`, however those won't persist across reboots. Use `xe pif-param-set` to add search domains that should persist across reboots.
 
 * First identify the PIF used as management interface.
-```
-# xe pif-list host-name-label=xcpng-srv01 management=true
+
+<Terminal title="root@xcp-ng-host — DNS Search Domains">{`
+xe pif-list host-name-label=xcpng-srv01 management=true
 uuid ( RO)                  : 76608ca2-e099-9344-af36-5b63c0022913
                 device ( RO): bond0
     currently-attached ( RO): true
                   VLAN ( RO): -1
           network-uuid ( RO): cc966455-d5f8-0257-04a7-d3d7c671636b
-```
+`}</Terminal>
+
 * Take note of the `uuid` field and pass that to `xe pif-param-set`
-```
-# xe pif-param-set uuid=76608ca2-e099-9344-af36-5b63c0022913 other-config:domain=searchdomain1.com,searchdomain2.com,searchdomain3.com
-```
+
+<Terminal shell title="root@xcp-ng-host — xe pif-list…">{`
+xe pif-param-set uuid=76608ca2-e099-9344-af36-5b63c0022913 other-config:domain=searchdomain1.com,searchdomain2.com,searchdomain3.com
+`}</Terminal>
+
 This procedure has to be done for all hosts in the same pool.
 
-## 👷 Network Troubleshooting
+## 👷 Network Troubleshooting {#network-troubleshooting}
 
 ### Network corruption
 
 Disabling TX offload might help to diagnose NIC issues:
 
-```
+<Terminal shell title="root@xcp-ng-host — Network corruption">{`
 xe pif-param-set uuid=<PIF UUID> other-config:ethtool-tx=off
-```
+`}</Terminal>
 
 ### Disabling FCoE
 
 If you are using bonds on FCoE capable devices, it's preferable to disable it entirely:
 
-```
+<Terminal shell title="Disabling FCoE">{`
 systemctl stop fcoe
 systemctl stop xs-fcoe
 systemctl mask fcoe
 systemctl mask xs-fcoe
-```
+`}</Terminal>
 
 See [https://github.com/xcp-ng/xcp/issues/138](https://github.com/xcp-ng/xcp/issues/138).
 
@@ -515,23 +662,25 @@ You can't live migrate a VM with SR-IOV enabled. Use it only if you really need 
 
 Then, you can enable and configure it with `xe` CLI:
 
-```
+<Terminal shell title="root@xcp-ng-host — Setup">{`
 xe network-create name-label=SRIOV
 xe network-sriov-create network-uuid=<network_uuid> pif-uuid=<physical_pif_uuid>
 xe network-sriov-param-list uuid=<SR-IOV Network_uuid>
-```
+`}</Terminal>
 
 The last command will tell you if you need to reboot or not.
 
 Assign the SR-IOV network to your VM:
-```
+
+<Terminal shell title="root@xcp-ng-host — Setup">{`
 xe vif-create device=<device index> mac=<vf_mac_address> network-uuid=<sriov_network> vm-uuid=<vm_uuid>
-```
+`}</Terminal>
 
 If you want to disable it:
-```
+
+<Terminal shell title="root@xcp-ng-host — Setup">{`
 xe network-sriov-destroy uuid=<network_sriov_uuid>
-```
+`}</Terminal>
 
 :::tip
 You can read a Citrix guide here: [https://support.citrix.com/article/CTX235044](https://support.citrix.com/article/CTX235044)
@@ -541,9 +690,9 @@ You can read a Citrix guide here: [https://support.citrix.com/article/CTX235044]
 
 With kernel version 4.15 a fix in the e1000e driver [has been introduced](https://github.com/torvalds/linux/commit/b10effb92e272051dd1ec0d7be56bf9ca85ab927). However, this fix slightly slows down DMA access times to prevent the NIC to hang up on heavy UDP traffic. This impacts the TCP performance. A workaround to regain full transfer speeds, you can turn off TCP segmentation offloading via the following command:
 
-```
+<Terminal shell title="Intel i218/i219 slow speed">{`
 ethtool -K <interface> tso off gso off
-```
+`}</Terminal>
 
 There is currently no fix available / announced that allows offloading TCP segmentation to the NIC without sacrificing performance.
 

--- a/docs/project/_category_.json
+++ b/docs/project/_category_.json
@@ -1,6 +1,6 @@
 {
     "label": "Project",
-    "position": 11,
+    "position": 12,
     "link": {
       "type": "generated-index",
       "description": "Everything related to XCP-ng as a project"

--- a/docs/project/about.md
+++ b/docs/project/about.md
@@ -1,6 +1,6 @@
 # About XCP-ng
 
-## 🌱 The origin
+## 🌱 The origin {#the-origin}
 
 XCP-ng stands as more than a mere product-it's a dynamic project fostered by an engaged community. Originating from the free [Xen Cloud Platform](https://wiki.xen.org/wiki/XCP_Overview) (XCP) and its commercial counterpart, Citrix XenServer, the landscape shifted when Citrix made XenServer open source, leading to the discontinuation of XCP.
 
@@ -12,7 +12,7 @@ XCP-ng was conceived as a friendly fork of XenServer, characterized by an approa
 
 You can now read more details about the [origin of the project on Wikipedia!](https://en.wikipedia.org/wiki/XCP-ng)
 
-## 💬 Community
+## 💬 Community {#community}
 
 Most of the community is on [XCP-ng Forum](https://xcp-ng.org/forum). Feel free go there and ask anything! We also have a [Discord server](https://discord.gg/Hr98F6wRvx) for live chat, or even on [Reddit](https://www.reddit.com/r/xcpng/) (however, the forum is the most active place).
 
@@ -24,7 +24,7 @@ You can also find us on many social networks:
 * IRC on OFTC at #xcp-ng
 
 
-## 📜 History of XCP-ng
+## 📜 History of XCP-ng {#history-of-xcp-ng}
 
 Here is a video recorded at FOSDEM19:
 

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -2,11 +2,79 @@
 
 This page contains advanced info regarding XCP-ng architecture.
 
-## 💽 Storage
+## 💽 Storage {#storage}
 
 ### Virtual disks on HVMs and PV guests
 
-![Diagram of virtual disk inner working, explained in the following paragraphs.](../../assets/img/tapdisk-architecture.jpg)
+<Schema label="Virtual disk I/O path · from a guest process down to the real storage" legend={[["#56c288", "guest side"], ["#4a90e2", "dom0 side"], ["#e0a94a", "shared ring (blkif)"]]} maxWidth="720px">
+<svg viewBox="0 0 720 350" role="img" aria-label="In the guest, a user process goes through libc, the block layer and blkfront; requests cross to dom0 through a shared blkif ring using grant tables and event channels; in dom0, tapdisk picks them up, uses libaio through the block layer and device driver to reach the VHD data on the physical storage; qemu-dm handles the emulated path">
+  <g fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.28)">
+    <rect x="20" y="20" width="270" height="310" rx="8"/>
+    <rect x="430" y="20" width="270" height="310" rx="8"/>
+  </g>
+  <text x="155" y="44" fontSize="17" fill="#56c288" textAnchor="middle">Guest VM (domU)</text>
+  <text x="565" y="44" fontSize="17" fill="#4a90e2" textAnchor="middle">Control domain (dom0)</text>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)">
+    <rect x="90" y="60" width="130" height="30" rx="5"/>
+    <rect x="90" y="128" width="130" height="30" rx="5"/>
+    <rect x="90" y="196" width="130" height="30" rx="5"/>
+  </g>
+  <rect x="90" y="264" width="130" height="30" rx="5" fill="rgba(86,194,136,0.14)" stroke="#56c288" strokeOpacity="0.85"/>
+  <g fontSize="14" fill="#c6d2e1" textAnchor="middle">
+    <text x="155" y="79">user process</text>
+    <text x="155" y="147">block layer</text>
+    <text x="155" y="215">/dev/xvda</text>
+  </g>
+  <text x="155" y="283" fontSize="14" fill="#56c288" textAnchor="middle">blkfront</text>
+  <g fontSize="11.5" fill="#7a8699">
+    <text x="166" y="112">libc · syscalls</text>
+    <text x="166" y="180">guest kernel</text>
+    <text x="166" y="248">PV disk driver</text>
+  </g>
+  <g stroke="#56c288" strokeWidth="1.6">
+    <line x1="155" y1="90" x2="155" y2="128"/>
+    <line x1="155" y1="158" x2="155" y2="196"/>
+    <line x1="155" y1="226" x2="155" y2="264"/>
+  </g>
+  <rect x="310" y="240" width="100" height="78" rx="8" fill="rgba(224,169,74,0.12)" stroke="#e0a94a" strokeOpacity="0.85"/>
+  <text x="360" y="264" fontSize="12.5" fill="#e0a94a" textAnchor="middle">shared ring</text>
+  <text x="360" y="279" fontSize="12.5" fill="#e0a94a" textAnchor="middle">(blkif)</text>
+  <text x="360" y="302" fontSize="11" fill="#7a8699" textAnchor="middle">grant tables +</text>
+  <text x="360" y="313" fontSize="11" fill="#7a8699" textAnchor="middle">event channels</text>
+  <g stroke="#e0a94a" strokeWidth="1.6">
+    <line x1="220" y1="279" x2="310" y2="279"/>
+    <line x1="410" y1="279" x2="460" y2="279"/>
+  </g>
+  <rect x="460" y="252" width="120" height="30" rx="5" fill="rgba(74,144,226,0.14)" stroke="#4a90e2" strokeOpacity="0.85"/>
+  <text x="520" y="271" fontSize="14" fill="#4a90e2" textAnchor="middle">tapdisk</text>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)">
+    <rect x="600" y="252" width="86" height="30" rx="5"/>
+    <rect x="460" y="184" width="120" height="30" rx="5"/>
+    <rect x="460" y="116" width="120" height="30" rx="5"/>
+  </g>
+  <g fontSize="12.5" fill="#c6d2e1" textAnchor="middle">
+    <text x="643" y="271">qemu-dm</text>
+    <text x="520" y="203">block layer</text>
+    <text x="520" y="135">device driver</text>
+  </g>
+  <g fontSize="11.5" fill="#7a8699">
+    <text x="531" y="240">libaio · aio syscalls</text>
+    <text x="531" y="172">dom0 kernel</text>
+  </g>
+  <text x="643" y="298" fontSize="11" fill="#7a8699" textAnchor="middle">emulated devices</text>
+  <g stroke="#4a90e2" strokeWidth="1.6">
+    <line x1="520" y1="252" x2="520" y2="214"/>
+    <line x1="520" y1="184" x2="520" y2="146"/>
+    <line x1="520" y1="116" x2="520" y2="86"/>
+  </g>
+  <line x1="580" y1="267" x2="600" y2="267" stroke="rgba(255,255,255,0.35)" strokeWidth="1.4"/>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)">
+    <rect x="470" y="56" width="100" height="30" rx="12"/>
+  </g>
+  <text x="520" y="75" fontSize="12.5" fill="#c6d2e1" textAnchor="middle">VHD data</text>
+  <text x="531" y="104" fontSize="11.5" fill="#7a8699">physical storage</text>
+</svg>
+</Schema>
 
 #### `qemu-dm` and `tapdisk` at startup
 
@@ -19,7 +87,7 @@ For each read/write in the VM disk, requests pass through an emulated driver, th
 The process described above is used for HVMs and also for PV guests (at startup, PV drivers are not loaded).
 After starting a PV guest, the emulated driver in the VM is replaced by `blkfront` (a PV driver) which allows to communicate directly with `tapdisk` using a protocol: `blkif`; `blktap` and `qemu-dm` then become useless to handle devices requests. Note that system calls are used with two drivers: `eventchn dev` and `gntdev` to map VM memory pages in the user space of the host. Thus a shared ring can be used to receive requests directly from `tapdisk` in host user space instead of using the kernel space.
 
-## ↕️ Components for VDI I/O
+## ↕️ Components for VDI I/O {#components-for-vdi-io}
 
 ### XenStore
 
@@ -44,7 +112,7 @@ Generally the communication is made between a `front` and `back` driver. The fro
 Note: Like said in the top section, it's not always the case but we can avoid usage of a back driver, we can use a process in the host user space. In the case of XCP-ng, `tapdisk`/`tapback` are used instead of `blkback` to talk with `blkfront`.
 
 
-#### Negociation and connection
+#### Negotiation and connection
 
 Implementation of a `Xenbus` driver in `blkfront`:
 
@@ -403,7 +471,7 @@ The persistent grants are not used in `tapdisk`.
 
 The read steps are similar, the main difference is that we must copy from the `Dom0` VHD file to the `guest` buffer.
 
-## 📡 API
+## 📡 API {#api}
 
 XCP-ng uses **XAPI** as main API. This API is used by all clients. For more details go to [XAPI website](https://xapi-project.github.io/).
 
@@ -415,7 +483,80 @@ If you want to build an application on top of XCP-ng, we strongly suggest the Xe
 
 XAPI is a toolstack split in two parts: `xenopsd` and XAPI itself (see the diagram below):
 
-![Diagram comparing XCP-ng, Xen + libvirt and Xen. XCP-ng uses the XAPI to expose its management to xe, XCP-ng Center, Xen Orchestra and CloudStack.](https://xcp-ng.org/assets/img/Xenstack.png)
+<Schema label="Toolstack comparison · XCP-ng (XAPI) next to plain Xen setups" legend={[["#56c288", "OCaml"], ["#4a90e2", "C"]]} maxWidth="760px">
+<svg viewBox="0 0 760 420" role="img" aria-label="Three columns: XCP-ng where clients like xe, Xen Orchestra and CloudStack drive XAPI over xenops, libxc and Xen; Xen with libvirt where virsh and OpenStack drive libvirt over libxl; and plain Xen driven by the xl CLI">
+  <g fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.28)">
+    <rect x="20" y="20" width="240" height="360" rx="8"/>
+    <rect x="280" y="20" width="220" height="360" rx="8"/>
+    <rect x="520" y="20" width="220" height="360" rx="8"/>
+  </g>
+  <g fontSize="13" fill="#c6d2e1" textAnchor="middle">
+    <text x="140" y="44">XCP-ng</text>
+    <text x="390" y="44">Xen + libvirt</text>
+    <text x="630" y="44">plain Xen</text>
+  </g>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)">
+    <rect x="36" y="60" width="98" height="24" rx="5"/>
+    <rect x="146" y="60" width="98" height="24" rx="5"/>
+    <rect x="36" y="92" width="98" height="24" rx="5"/>
+    <rect x="146" y="92" width="98" height="24" rx="5"/>
+    <rect x="296" y="60" width="90" height="24" rx="5"/>
+    <rect x="398" y="60" width="90" height="24" rx="5"/>
+    <rect x="536" y="60" width="188" height="24" rx="5"/>
+  </g>
+  <g fontSize="10" fill="#c6d2e1" textAnchor="middle">
+    <text x="85" y="76">xe (CLI)</text>
+    <text x="195" y="76">Xen Orchestra</text>
+    <text x="85" y="108">XCP-ng Center</text>
+    <text x="195" y="108">CloudStack</text>
+    <text x="341" y="76">virsh</text>
+    <text x="443" y="76">OpenStack</text>
+    <text x="630" y="76">xl CLI</text>
+  </g>
+  <rect x="36" y="152" width="208" height="34" rx="5" fill="rgba(86,194,136,0.14)" stroke="#56c288" strokeOpacity="0.85"/>
+  <text x="140" y="174" fontSize="12.5" fill="#56c288" textAnchor="middle">XAPI</text>
+  <rect x="36" y="202" width="208" height="30" rx="5" fill="rgba(86,194,136,0.14)" stroke="#56c288" strokeOpacity="0.85"/>
+  <text x="140" y="222" fontSize="11.5" fill="#56c288" textAnchor="middle">xenopsd</text>
+  <rect x="296" y="152" width="192" height="34" rx="5" fill="rgba(74,144,226,0.14)" stroke="#4a90e2" strokeOpacity="0.85"/>
+  <text x="390" y="174" fontSize="12.5" fill="#4a90e2" textAnchor="middle">libvirt</text>
+  <rect x="296" y="202" width="192" height="30" rx="5" fill="rgba(74,144,226,0.14)" stroke="#4a90e2" strokeOpacity="0.85"/>
+  <text x="390" y="222" fontSize="11.5" fill="#4a90e2" textAnchor="middle">libxl</text>
+  <rect x="536" y="152" width="188" height="34" rx="5" fill="rgba(74,144,226,0.14)" stroke="#4a90e2" strokeOpacity="0.85"/>
+  <text x="630" y="174" fontSize="12.5" fill="#4a90e2" textAnchor="middle">libxl</text>
+  <g fill="rgba(74,144,226,0.14)" stroke="#4a90e2" strokeOpacity="0.85">
+    <rect x="36" y="248" width="208" height="30" rx="5"/>
+    <rect x="296" y="248" width="192" height="30" rx="5"/>
+    <rect x="536" y="248" width="188" height="30" rx="5"/>
+    <rect x="36" y="300" width="208" height="44" rx="5"/>
+    <rect x="296" y="300" width="192" height="44" rx="5"/>
+    <rect x="536" y="300" width="188" height="44" rx="5"/>
+  </g>
+  <g fontSize="11" fill="#4a90e2" textAnchor="middle">
+    <text x="140" y="268">libxc (libxenctrl)</text>
+    <text x="390" y="268">libxc (libxenctrl)</text>
+    <text x="630" y="268">libxc (libxenctrl)</text>
+  </g>
+  <g fontSize="12.5" fill="#4a90e2" textAnchor="middle">
+    <text x="140" y="327">Xen</text>
+    <text x="390" y="327">Xen</text>
+    <text x="630" y="327">Xen</text>
+  </g>
+  <g stroke="rgba(255,255,255,0.3)" strokeWidth="1.3">
+    <line x1="140" y1="116" x2="140" y2="152"/>
+    <line x1="140" y1="186" x2="140" y2="202"/>
+    <line x1="140" y1="232" x2="140" y2="248"/>
+    <line x1="140" y1="278" x2="140" y2="300"/>
+    <line x1="390" y1="88" x2="390" y2="152"/>
+    <line x1="390" y1="186" x2="390" y2="202"/>
+    <line x1="390" y1="232" x2="390" y2="248"/>
+    <line x1="390" y1="278" x2="390" y2="300"/>
+    <line x1="630" y1="88" x2="630" y2="152"/>
+    <line x1="630" y1="186" x2="630" y2="248"/>
+    <line x1="630" y1="278" x2="630" y2="300"/>
+  </g>
+  <text x="140" y="368" fontSize="10" fill="#7a8699" textAnchor="middle">what XCP-ng runs</text>
+</svg>
+</Schema>
 
 :::warning
 XCP-ng is meant to use XAPI. Don't use it with `xl` or anything else!
@@ -423,21 +564,445 @@ XCP-ng is meant to use XAPI. Don't use it with `xl` or anything else!
 
 #### General design
 
-![Diagram presenting the interaction of various part inside XCP-ng, too complex to be describe in a few sentences unfortunately.](https://xapi-project.github.io/xapi/xapi.png)
+<Schema label="Inside xapi · one daemon, many subsystems" legend={[["#56c288", "entry points"], ["#e0a94a", "storage"], ["#ef6a5f", "high availability"]]} maxWidth="920px">
+<svg viewBox="0 0 920 620" role="img" aria-label="Clients from the outside world reach xapi's XML-RPC and HTTP handlers on ports 80 and 443; requests go through message forwarding which locks and dispatches to the subsystems: authentication, CLI server, storage access over SMAPI, high availability with xhad, VM lifecycle via xenopsd, host plugins and the replicated database">
+  <text x="90" y="34" fontSize="11" fill="#7a8699">the outside world</text>
+  <g fill="rgba(255,255,255,0.05)" stroke="rgba(255,255,255,0.28)">
+    <rect x="120" y="46" width="130" height="24" rx="5"/>
+    <rect x="270" y="46" width="130" height="24" rx="5"/>
+    <rect x="420" y="46" width="130" height="24" rx="5"/>
+    <rect x="570" y="46" width="130" height="24" rx="5"/>
+    <rect x="720" y="46" width="90" height="24" rx="5"/>
+  </g>
+  <g fontSize="10" fill="#c6d2e1" textAnchor="middle">
+    <text x="185" y="62">Xen Orchestra</text>
+    <text x="335" y="62">XCP-ng Center</text>
+    <text x="485" y="62">OpenStack</text>
+    <text x="635" y="62">CloudStack</text>
+    <text x="765" y="62">xe CLI</text>
+  </g>
+  <rect x="270" y="110" width="380" height="40" rx="6" fill="rgba(86,194,136,0.12)" stroke="#56c288" strokeOpacity="0.85"/>
+  <text x="460" y="128" fontSize="11.5" fill="#56c288" textAnchor="middle">XenAPI (XML-RPC) · HTTP GET/PUT</text>
+  <text x="460" y="143" fontSize="9" fill="#7a8699" textAnchor="middle">ports 80 / 443</text>
+  <g stroke="#56c288" strokeWidth="1.3" fill="none">
+    <path d="M185 70 C 185 92, 300 100, 340 110"/>
+    <path d="M335 70 C 335 92, 390 98, 410 110"/>
+    <path d="M485 70 L 470 110"/>
+    <path d="M635 70 C 635 92, 560 98, 530 110"/>
+    <path d="M765 70 C 765 94, 640 100, 600 110"/>
+  </g>
+  <rect x="290" y="186" width="340" height="36" rx="6" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.35)"/>
+  <text x="460" y="204" fontSize="11.5" fill="#c6d2e1" textAnchor="middle">message forwarding</text>
+  <text x="460" y="217" fontSize="9" fill="#7a8699" textAnchor="middle">locking · dispatch</text>
+  <line x1="460" y1="150" x2="460" y2="186" stroke="#56c288" strokeWidth="1.5"/>
+  <path d="M630 200 L 730 200" stroke="#56c288" strokeWidth="1.3"/>
+  <text x="740" y="196" fontSize="9.5" fill="#7a8699">other hosts</text>
+  <text x="740" y="209" fontSize="9.5" fill="#7a8699">in the pool (443)</text>
+  <rect x="40" y="180" width="180" height="76" rx="6" fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.28)"/>
+  <text x="130" y="200" fontSize="10.5" fill="#c6d2e1" textAnchor="middle">authentication</text>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.25)">
+    <rect x="52" y="212" width="74" height="30" rx="4"/>
+    <rect x="136" y="212" width="72" height="30" rx="4"/>
+  </g>
+  <text x="89" y="226" fontSize="9" fill="#c6d2e1" textAnchor="middle">PAM</text>
+  <text x="89" y="237" fontSize="8" fill="#7a8699" textAnchor="middle">/etc/passwd</text>
+  <text x="172" y="230" fontSize="9" fill="#c6d2e1" textAnchor="middle">AD</text>
+  <line x1="290" y1="204" x2="220" y2="210" stroke="rgba(255,255,255,0.3)" strokeWidth="1.3"/>
+  <g fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.28)">
+    <rect x="40" y="300" width="150" height="60" rx="6"/>
+    <rect x="640" y="470" width="140" height="90" rx="6"/>
+    <rect x="40" y="470" width="170" height="90" rx="6"/>
+  </g>
+  <text x="115" y="325" fontSize="10.5" fill="#c6d2e1" textAnchor="middle">CLI server</text>
+  <text x="115" y="342" fontSize="8.5" fill="#7a8699" textAnchor="middle">handles xe commands</text>
+  <rect x="230" y="300" width="260" height="90" rx="6" fill="rgba(224,169,74,0.08)" stroke="#e0a94a" strokeOpacity="0.7"/>
+  <text x="360" y="320" fontSize="10.5" fill="#e0a94a" textAnchor="middle">storage access</text>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.25)">
+    <rect x="244" y="332" width="110" height="24" rx="4"/>
+    <rect x="366" y="332" width="110" height="24" rx="4"/>
+  </g>
+  <text x="299" y="348" fontSize="9.5" fill="#c6d2e1" textAnchor="middle">SMAPIv2</text>
+  <text x="421" y="348" fontSize="9.5" fill="#c6d2e1" textAnchor="middle">usage tracking</text>
+  <text x="421" y="378" fontSize="8.5" fill="#7a8699" textAnchor="middle">storage.db</text>
+  <rect x="530" y="300" width="260" height="90" rx="6" fill="rgba(239,106,95,0.08)" stroke="#ef6a5f" strokeOpacity="0.7"/>
+  <text x="660" y="320" fontSize="10.5" fill="#ef6a5f" textAnchor="middle">high availability</text>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.25)">
+    <rect x="544" y="332" width="110" height="24" rx="4"/>
+    <rect x="666" y="332" width="110" height="24" rx="4"/>
+  </g>
+  <text x="599" y="348" fontSize="9.5" fill="#c6d2e1" textAnchor="middle">failure planner</text>
+  <text x="721" y="348" fontSize="9.5" fill="#c6d2e1" textAnchor="middle">liveset monitor</text>
+  <rect x="820" y="326" width="70" height="30" rx="4" fill="rgba(239,106,95,0.12)" stroke="#ef6a5f" strokeOpacity="0.8"/>
+  <text x="855" y="345" fontSize="9.5" fill="#ef6a5f" textAnchor="middle">xhad</text>
+  <line x1="776" y1="344" x2="820" y2="342" stroke="#ef6a5f" strokeWidth="1.3"/>
+  <text x="855" y="308" fontSize="8.5" fill="#7a8699" textAnchor="middle">other hosts (694)</text>
+  <line x1="855" y1="326" x2="855" y2="314" stroke="#ef6a5f" strokeWidth="1.2"/>
+  <rect x="230" y="470" width="240" height="90" rx="6" fill="rgba(224,169,74,0.08)" stroke="#e0a94a" strokeOpacity="0.7"/>
+  <text x="350" y="490" fontSize="10.5" fill="#e0a94a" textAnchor="middle">SMAPIv1 drivers</text>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.25)">
+    <rect x="244" y="504" width="46" height="22" rx="4"/>
+    <rect x="298" y="504" width="46" height="22" rx="4"/>
+    <rect x="352" y="504" width="46" height="22" rx="4"/>
+    <rect x="406" y="504" width="52" height="22" rx="4"/>
+  </g>
+  <g fontSize="8.5" fill="#c6d2e1" textAnchor="middle">
+    <text x="267" y="519">EXT</text>
+    <text x="321" y="519">NFS</text>
+    <text x="375" y="519">LVM</text>
+    <text x="432" y="519">LVMoISCSI…</text>
+  </g>
+  <line x1="299" y1="356" x2="330" y2="470" stroke="#e0a94a" strokeWidth="1.3"/>
+  <text x="125" y="494" fontSize="10.5" fill="#c6d2e1" textAnchor="middle">VM lifecycle</text>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.25)">
+    <rect x="54" y="506" width="66" height="24" rx="4"/>
+    <rect x="130" y="506" width="66" height="24" rx="4"/>
+  </g>
+  <text x="87" y="522" fontSize="9" fill="#c6d2e1" textAnchor="middle">xenopsd</text>
+  <text x="163" y="522" fontSize="9" fill="#c6d2e1" textAnchor="middle">xcp-rrdd</text>
+  <rect x="500" y="470" width="120" height="90" rx="6" fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.28)"/>
+  <text x="560" y="494" fontSize="10.5" fill="#c6d2e1" textAnchor="middle">host plugins</text>
+  <text x="560" y="512" fontSize="8" fill="#7a8699" textAnchor="middle">/etc/xapi.d/plugins</text>
+  <text x="710" y="494" fontSize="10.5" fill="#c6d2e1" textAnchor="middle">database</text>
+  <text x="710" y="512" fontSize="8.5" fill="#7a8699" textAnchor="middle">+ events</text>
+  <text x="710" y="524" fontSize="8.5" fill="#7a8699" textAnchor="middle">+ replication</text>
+  <g stroke="rgba(255,255,255,0.3)" strokeWidth="1.3" fill="none">
+    <path d="M340 222 C 250 250, 160 270, 120 300"/>
+    <path d="M420 222 C 400 250, 380 270, 370 300"/>
+    <path d="M520 222 C 560 250, 610 270, 640 300"/>
+    <path d="M320 222 C 220 300, 140 380, 122 470"/>
+    <path d="M520 222 C 505 300, 512 400, 552 470"/>
+    <path d="M628 220 C 810 290, 815 400, 718 470"/>
+  </g>
+</svg>
+</Schema>
 
 #### Objects
 
-![Diagram of XAPI objects and their interactions.](https://xapi-project.github.io/xen-api/classes.png)
+<Schema label="XAPI object model · the main classes and their references" legend={[["#e0a94a", "storage objects"], ["#8e83fe", "network objects"], ["#7a8699", "metrics and auxiliaries"]]} maxWidth="760px">
+<svg viewBox="0 0 760 500" role="img" aria-label="A user opens a session on a host; hosts connect to SRs through PBDs; VDIs live in SRs and attach to VMs through VBDs; PIFs and VIFs connect hosts and VMs to networks; most objects have companion metrics classes; pool, task and event stand on their own">
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.35)">
+    <rect x="30" y="200" width="70" height="28" rx="5"/>
+    <rect x="120" y="200" width="80" height="28" rx="5"/>
+    <rect x="220" y="200" width="80" height="30" rx="5"/>
+  </g>
+  <g fontSize="10.5" fill="#c6d2e1" textAnchor="middle">
+    <text x="65" y="218">user</text>
+    <text x="160" y="218">session</text>
+    <text x="260" y="219">host</text>
+  </g>
+  <g fill="rgba(224,169,74,0.12)" stroke="#e0a94a" strokeOpacity="0.8">
+    <rect x="270" y="90" width="70" height="26" rx="5"/>
+    <rect x="360" y="40" width="70" height="28" rx="5"/>
+    <rect x="470" y="90" width="70" height="26" rx="5"/>
+    <rect x="470" y="160" width="70" height="26" rx="5"/>
+  </g>
+  <g fontSize="10" fill="#e0a94a" textAnchor="middle">
+    <text x="305" y="107">PBD</text>
+    <text x="395" y="58">SR</text>
+    <text x="505" y="107">VDI</text>
+    <text x="505" y="177">VBD</text>
+  </g>
+  <rect x="360" y="0" width="70" height="24" rx="5" fill="rgba(255,255,255,0.05)" stroke="rgba(255,255,255,0.25)"/>
+  <text x="395" y="16" fontSize="9.5" fill="#7a8699" textAnchor="middle">SM</text>
+  <rect x="580" y="200" width="80" height="34" rx="5" fill="rgba(255,255,255,0.08)" stroke="rgba(255,255,255,0.45)"/>
+  <text x="620" y="221" fontSize="11" fill="#c6d2e1" textAnchor="middle">VM</text>
+  <g fill="rgba(142,131,254,0.12)" stroke="#8e83fe" strokeOpacity="0.8">
+    <rect x="220" y="330" width="70" height="26" rx="5"/>
+    <rect x="350" y="380" width="90" height="28" rx="5"/>
+    <rect x="490" y="330" width="70" height="26" rx="5"/>
+  </g>
+  <g fontSize="10" fill="#8e83fe" textAnchor="middle">
+    <text x="255" y="347">PIF</text>
+    <text x="395" y="398">network</text>
+    <text x="525" y="347">VIF</text>
+  </g>
+  <g fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.22)">
+    <rect x="80" y="130" width="90" height="24" rx="10"/>
+    <rect x="80" y="270" width="100" height="24" rx="10"/>
+    <rect x="600" y="90" width="100" height="24" rx="10"/>
+    <rect x="670" y="160" width="86" height="24" rx="10"/>
+    <rect x="670" y="250" width="86" height="24" rx="10"/>
+    <rect x="590" y="290" width="120" height="24" rx="10"/>
+    <rect x="600" y="420" width="90" height="24" rx="10"/>
+    <rect x="160" y="420" width="90" height="24" rx="10"/>
+    <rect x="330" y="200" width="70" height="24" rx="10"/>
+    <rect x="330" y="250" width="70" height="24" rx="10"/>
+    <rect x="440" y="225" width="70" height="24" rx="10"/>
+  </g>
+  <g fontSize="8.5" fill="#7a8699" textAnchor="middle">
+    <text x="125" y="146">host_cpu</text>
+    <text x="130" y="286">host_metrics</text>
+    <text x="650" y="106">VBD_metrics</text>
+    <text x="713" y="176">crashdump</text>
+    <text x="713" y="266">VM_metrics</text>
+    <text x="650" y="306">VM_guest_metrics</text>
+    <text x="645" y="436">VIF_metrics</text>
+    <text x="205" y="436">PIF_metrics</text>
+    <text x="365" y="216">pool</text>
+    <text x="365" y="266">task</text>
+    <text x="475" y="241">event</text>
+  </g>
+  <g stroke="rgba(255,255,255,0.35)" strokeWidth="1.2">
+    <line x1="100.0" y1="214.0" x2="120.0" y2="214.0"/>
+    <line x1="200.0" y1="214.4" x2="220.0" y2="214.6"/>
+    <line x1="266.0" y1="200.0" x2="299.8" y2="116.0"/>
+    <line x1="328.9" y1="90.0" x2="369.3" y2="68.0"/>
+    <line x1="395.0" y1="24.0" x2="395.0" y2="40.0"/>
+    <line x1="475.8" y1="90.0" x2="426.4" y2="68.0"/>
+    <line x1="505.0" y1="116.0" x2="505.0" y2="160.0"/>
+    <line x1="539.0" y1="186.0" x2="580.0" y2="201.7"/>
+    <line x1="147.2" y1="154.0" x2="232.3" y2="200.0"/>
+    <line x1="153.3" y1="270.0" x2="230.9" y2="230.0"/>
+    <line x1="255.5" y1="330.0" x2="259.4" y2="230.0"/>
+    <line x1="290.0" y1="355.8" x2="356.6" y2="380.0"/>
+    <line x1="491.9" y1="356.0" x2="430.7" y2="380.0"/>
+    <line x1="534.8" y1="330.0" x2="607.2" y2="234.0"/>
+    <line x1="625.5" y1="114.0" x2="531.5" y2="160.0"/>
+    <line x1="688.2" y1="184.0" x2="655.1" y2="200.0"/>
+    <line x1="688.2" y1="250.0" x2="655.1" y2="234.0"/>
+    <line x1="645.8" y1="290.0" x2="626.0" y2="234.0"/>
+    <line x1="628.8" y1="420.0" x2="542.5" y2="356.0"/>
+    <line x1="211.7" y1="420.0" x2="247.7" y2="356.0"/>
+  </g>
+</svg>
+</Schema>
 
 #### Pool design
 
-![How a pool is managed, a shared storage in the center, XAPI on each host. The pool master creates a disk, xapi from another host uses the disk. The various XAPIs talk to each other to handle configuration and VM migrations.](https://xapi-project.github.io/getting-started/pool.png)
+<Schema label="Pool design · every host runs XAPI, requests converge on the coordinator" legend={[["#56c288", "XenAPI over TLS (443)"], ["#7a8699", "storage and migration traffic"]]} maxWidth="720px">
+<svg viewBox="0 0 720 380" role="img" aria-label="Four hosts each run xapi and talk to each other over TLS port 443; XenAPI clients target the pool coordinator which redirects requests as needed; the shared storage sits in the middle: the coordinator creates a disk, any member can then use it; VM migrations stream memory directly between hosts">
+  <text x="120" y="30" fontSize="12" fill="#c6d2e1" textAnchor="middle">XenAPI clients</text>
+  <g fill="rgba(86,194,136,0.14)" stroke="#56c288" strokeOpacity="0.85">
+    <rect x="40" y="70" width="160" height="40" rx="6"/>
+  </g>
+  <g fill="rgba(255,255,255,0.05)" stroke="rgba(255,255,255,0.28)">
+    <rect x="40" y="170" width="160" height="40" rx="6"/>
+    <rect x="520" y="70" width="160" height="40" rx="6"/>
+    <rect x="520" y="170" width="160" height="40" rx="6"/>
+  </g>
+  <g fontSize="12" fill="#c6d2e1" textAnchor="middle">
+    <text x="120" y="88">xapi</text>
+    <text x="120" y="188">xapi</text>
+    <text x="600" y="88">xapi</text>
+    <text x="600" y="188">xapi</text>
+  </g>
+  <g fontSize="9.5" fill="#7a8699" textAnchor="middle">
+    <text x="120" y="103">pool coordinator</text>
+    <text x="120" y="203">host</text>
+    <text x="600" y="103">host</text>
+    <text x="600" y="203">host</text>
+  </g>
+  <path d="M120 38 L 120 68" stroke="#56c288" strokeWidth="1.6"/>
+  <g stroke="#56c288" strokeWidth="1.4" fill="none">
+    <line x1="120" y1="110" x2="120" y2="170"/>
+    <line x1="600" y1="110" x2="600" y2="170"/>
+    <path d="M200 84 C 320 60, 420 60, 520 84"/>
+    <path d="M200 196 C 320 224, 420 224, 520 196"/>
+  </g>
+  <text x="360" y="60" fontSize="9.5" fill="#56c288" textAnchor="middle">TLS · port 443</text>
+  <rect x="280" y="110" width="160" height="70" rx="14" fill="rgba(255,255,255,0.05)" stroke="rgba(255,255,255,0.3)"/>
+  <text x="360" y="142" fontSize="11.5" fill="#c6d2e1" textAnchor="middle">shared storage</text>
+  <text x="360" y="160" fontSize="9.5" fill="#7a8699" textAnchor="middle">(SR)</text>
+  <g stroke="rgba(255,255,255,0.35)" strokeWidth="1.4" fill="none">
+    <path d="M200 96 C 250 100, 280 102, 300 110"/>
+    <path d="M520 100 C 470 102, 440 104, 420 110"/>
+  </g>
+  <g fontSize="9" fill="#7a8699">
+    <text x="212" y="92">create disk</text>
+    <text x="448" y="96" textAnchor="end">use disk</text>
+  </g>
+  <path d="M200 204 C 320 250, 420 250, 520 204" stroke="rgba(255,255,255,0.35)" strokeWidth="1.4" fill="none" strokeDasharray="5 4"/>
+  <text x="360" y="252" fontSize="9" fill="#7a8699" textAnchor="middle">VM migration: memory image streamed host to host</text>
+  <g fontSize="9.5" fill="#7a8699">
+    <text x="40" y="290">All XenAPI requests are redirected to the coordinator,</text>
+    <text x="40" y="304">except stats, consoles and import/export,</text>
+    <text x="40" y="318">which go straight to the host concerned.</text>
+  </g>
+  <text x="680" y="318" fontSize="10" fill="#7a8699" textAnchor="end">a resource pool: a unit of shared storage</text>
+</svg>
+</Schema>
 
-## 🕸️ Network
+## 🕸️ Network {#network}
 
 ### Overview
 
-![Network architecture diagram showing the interaction between Dom0, DomU, Open vSwitch, its bridges and physical network interfaces.](../../assets/img/networking/Network-overview.png)
+<Schema label="Network architecture · from the toolstack to the wire" legend={[["#8e83fe", "PV path (netfront/netback)"], ["#4a90e2", "emulated path"], ["#e0a94a", "Open vSwitch"], ["#56c288", "control plane"]]} maxWidth="920px">
+<svg viewBox="0 0 920 800" role="img" aria-label="Clients reach XAPI in dom0 userland, which drives Open vSwitch; in the dom0 kernel, the openvswitch module hosts bridges connecting VM interfaces, VLAN fake bridges, a bond and the physical NICs; VM traffic flows through netfront/netback or through qemu-dm for emulated NICs; one NIC is passed through directly to a VM">
+  <g fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.28)">
+    <rect x="210" y="20" width="520" height="180" rx="8"/>
+    <rect x="210" y="230" width="520" height="390" rx="8"/>
+    <rect x="20" y="30" width="150" height="112" rx="8"/>
+    <rect x="20" y="310" width="150" height="104" rx="8"/>
+    <rect x="20" y="434" width="150" height="70" rx="8"/>
+    <rect x="760" y="300" width="140" height="70" rx="8"/>
+    <rect x="760" y="560" width="140" height="70" rx="8"/>
+    <rect x="210" y="650" width="520" height="30" rx="8"/>
+  </g>
+  <text x="470" y="40" fontSize="12.5" fill="#c6d2e1" textAnchor="middle">dom0 · userland</text>
+  <text x="240" y="252" fontSize="12.5" fill="#c6d2e1">dom0 · kernel</text>
+  <text x="470" y="670" fontSize="12" fill="#c6d2e1" textAnchor="middle">Xen hypervisor</text>
+  <text x="95" y="48" fontSize="10.5" fill="#7a8699" textAnchor="middle">management clients</text>
+  <g fill="rgba(86,194,136,0.10)" stroke="#56c288" strokeOpacity="0.5">
+    <rect x="28" y="56" width="134" height="22" rx="5"/>
+    <rect x="28" y="84" width="134" height="22" rx="5"/>
+    <rect x="28" y="112" width="134" height="22" rx="5"/>
+  </g>
+  <g fontSize="9.5" fill="#c6d2e1" textAnchor="middle">
+    <text x="95" y="70">Xen Orchestra</text>
+    <text x="95" y="98">remote xe</text>
+    <text x="95" y="126">xapi (pool members)</text>
+  </g>
+  <rect x="230" y="48" width="280" height="140" rx="6" fill="rgba(86,194,136,0.06)" stroke="#56c288" strokeOpacity="0.6"/>
+  <text x="370" y="66" fontSize="11" fill="#56c288" textAnchor="middle">XAPI toolstack</text>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)">
+    <rect x="246" y="78" width="110" height="22" rx="4"/>
+    <rect x="246" y="108" width="110" height="22" rx="4"/>
+    <rect x="246" y="152" width="110" height="22" rx="4"/>
+    <rect x="372" y="78" width="122" height="22" rx="4"/>
+    <rect x="372" y="108" width="122" height="22" rx="4"/>
+  </g>
+  <g fontSize="10" fill="#c6d2e1" textAnchor="middle">
+    <text x="301" y="93">xapi</text>
+    <text x="301" y="123">xe (local)</text>
+    <text x="301" y="167">networkd</text>
+    <text x="433" y="93">message-switch</text>
+    <text x="433" y="123">xenopsd</text>
+  </g>
+  <rect x="530" y="48" width="184" height="84" rx="6" fill="rgba(224,169,74,0.08)" stroke="#e0a94a" strokeOpacity="0.7"/>
+  <text x="622" y="66" fontSize="11" fill="#e0a94a" textAnchor="middle">Open vSwitch (userland)</text>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)">
+    <rect x="542" y="76" width="160" height="20" rx="4"/>
+    <rect x="542" y="104" width="160" height="20" rx="4"/>
+  </g>
+  <g fontSize="9.5" fill="#c6d2e1" textAnchor="middle">
+    <text x="622" y="90">ovsdb-server</text>
+    <text x="622" y="118">ovs-vswitchd · flow table</text>
+  </g>
+  <rect x="530" y="152" width="86" height="26" rx="4" fill="rgba(74,144,226,0.14)" stroke="#4a90e2" strokeOpacity="0.85"/>
+  <text x="573" y="169" fontSize="10" fill="#4a90e2" textAnchor="middle">qemu-dm</text>
+  <rect x="630" y="152" width="84" height="26" rx="4" fill="rgba(86,194,136,0.10)" stroke="#56c288" strokeOpacity="0.6"/>
+  <text x="672" y="169" fontSize="10" fill="#c6d2e1" textAnchor="middle">xenstore</text>
+  <g stroke="#56c288" strokeWidth="1.4" fill="none">
+    <path d="M162 67 C 200 67, 210 89, 244 89"/>
+    <path d="M162 95 C 200 95, 205 92, 244 90"/>
+    <path d="M162 123 C 200 123, 210 95, 244 92"/>
+  </g>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)">
+    <rect x="250" y="266" width="90" height="22" rx="4"/>
+    <rect x="380" y="266" width="90" height="22" rx="4"/>
+    <rect x="500" y="266" width="90" height="22" rx="4"/>
+  </g>
+  <g fontSize="10" fill="#c6d2e1" textAnchor="middle">
+    <text x="295" y="281">netlink</text>
+    <text x="425" y="281">xenbus</text>
+    <text x="545" y="281">tun/tap</text>
+  </g>
+  <g stroke="#56c288" strokeWidth="1.4">
+    <line x1="301" y1="174" x2="295" y2="266"/>
+    <line x1="672" y1="178" x2="429" y2="266"/>
+  </g>
+  <line x1="622" y1="132" x2="602" y2="298" stroke="#e0a94a" strokeWidth="1.4"/>
+  <line x1="573" y1="178" x2="548" y2="266" stroke="#4a90e2" strokeWidth="1.4"/>
+  <rect x="230" y="300" width="480" height="226" rx="6" fill="rgba(224,169,74,0.06)" stroke="#e0a94a" strokeOpacity="0.7"/>
+  <text x="470" y="318" fontSize="11" fill="#e0a94a" textAnchor="middle">openvswitch.ko</text>
+  <rect x="246" y="330" width="220" height="184" rx="5" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.25)"/>
+  <text x="356" y="346" fontSize="10" fill="#c6d2e1" textAnchor="middle">bridge xenbr0 · flow cache</text>
+  <g fill="rgba(142,131,254,0.12)" stroke="#8e83fe" strokeOpacity="0.7">
+    <rect x="258" y="356" width="120" height="20" rx="4"/>
+    <rect x="258" y="384" width="120" height="20" rx="4"/>
+  </g>
+  <rect x="258" y="412" width="120" height="20" rx="4" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)"/>
+  <g fontSize="9" fill="#c6d2e1" textAnchor="middle">
+    <text x="318" y="370">port vif1.0 (netback)</text>
+    <text x="318" y="398">port vif2.0 (netback)</text>
+    <text x="318" y="426">port eth0</text>
+  </g>
+  <rect x="258" y="442" width="196" height="62" rx="5" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.25)" strokeDasharray="4 3"/>
+  <text x="356" y="458" fontSize="9.5" fill="#c6d2e1" textAnchor="middle">xapi0 (fake bridge) · VLAN 42</text>
+  <rect x="270" y="468" width="120" height="20" rx="4" fill="rgba(142,131,254,0.12)" stroke="#8e83fe" strokeOpacity="0.7"/>
+  <text x="330" y="482" fontSize="9" fill="#c6d2e1" textAnchor="middle">port vif2.1 (netback)</text>
+  <rect x="486" y="330" width="208" height="184" rx="5" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.25)"/>
+  <text x="590" y="346" fontSize="10" fill="#c6d2e1" textAnchor="middle">bridge xapi1 · flow cache</text>
+  <rect x="498" y="356" width="110" height="20" rx="4" fill="rgba(74,144,226,0.14)" stroke="#4a90e2" strokeOpacity="0.7"/>
+  <text x="553" y="370" fontSize="9" fill="#c6d2e1" textAnchor="middle">port tap3.0</text>
+  <rect x="498" y="404" width="184" height="62" rx="5" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.25)"/>
+  <text x="590" y="420" fontSize="9.5" fill="#c6d2e1" textAnchor="middle">port bond0</text>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)">
+    <rect x="510" y="430" width="70" height="20" rx="4"/>
+    <rect x="596" y="430" width="70" height="20" rx="4"/>
+  </g>
+  <g fontSize="9" fill="#c6d2e1" textAnchor="middle">
+    <text x="545" y="444">eth1</text>
+    <text x="631" y="444">eth2</text>
+  </g>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)">
+    <rect x="280" y="544" width="80" height="22" rx="4"/>
+    <rect x="440" y="544" width="80" height="22" rx="4"/>
+    <rect x="580" y="544" width="80" height="22" rx="4"/>
+  </g>
+  <g fontSize="9.5" fill="#c6d2e1" textAnchor="middle">
+    <text x="320" y="559">eth0 netdev</text>
+    <text x="480" y="559">eth1 netdev</text>
+    <text x="620" y="559">eth2 netdev</text>
+  </g>
+  <rect x="250" y="580" width="440" height="22" rx="4" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.2)"/>
+  <text x="470" y="595" fontSize="9.5" fill="#7a8699" textAnchor="middle">device drivers</text>
+  <g stroke="rgba(255,255,255,0.3)" strokeWidth="1.3">
+    <line x1="318" y1="432" x2="320" y2="544"/>
+    <line x1="545" y1="450" x2="480" y2="544"/>
+    <line x1="631" y1="450" x2="620" y2="544"/>
+    <line x1="320" y1="566" x2="320" y2="580"/>
+    <line x1="480" y1="566" x2="480" y2="580"/>
+    <line x1="620" y1="566" x2="620" y2="580"/>
+  </g>
+  <text x="95" y="328" fontSize="11" fill="#c6d2e1" textAnchor="middle">VM2</text>
+  <g fill="rgba(142,131,254,0.12)" stroke="#8e83fe" strokeOpacity="0.85">
+    <rect x="32" y="340" width="126" height="22" rx="4"/>
+    <rect x="32" y="372" width="126" height="22" rx="4"/>
+    <rect x="32" y="462" width="126" height="22" rx="4"/>
+  </g>
+  <g fontSize="9.5" fill="#c6d2e1" textAnchor="middle">
+    <text x="95" y="355">eth0 (netfront)</text>
+    <text x="95" y="387">eth1 (netfront)</text>
+    <text x="95" y="477">eth0 (netfront)</text>
+  </g>
+  <text x="95" y="452" fontSize="11" fill="#c6d2e1" textAnchor="middle">VM1</text>
+  <g stroke="#8e83fe" strokeWidth="1.5" fill="none">
+    <path d="M158 351 C 210 351, 220 394, 256 394"/>
+    <path d="M158 383 C 210 383, 225 478, 268 478"/>
+    <path d="M158 473 C 205 473, 215 366, 256 366"/>
+  </g>
+  <text x="830" y="318" fontSize="11" fill="#c6d2e1" textAnchor="middle">VM3</text>
+  <rect x="772" y="330" width="116" height="22" rx="4" fill="rgba(74,144,226,0.14)" stroke="#4a90e2" strokeOpacity="0.85"/>
+  <text x="830" y="345" fontSize="9.5" fill="#c6d2e1" textAnchor="middle">eth0 (emulated)</text>
+  <path d="M573 178 C 573 214, 700 212, 770 240 C 815 262, 828 290, 828 330" stroke="#4a90e2" strokeWidth="1.4" fill="none"/>
+  <text x="830" y="578" fontSize="11" fill="#c6d2e1" textAnchor="middle">VM4</text>
+  <rect x="772" y="590" width="116" height="22" rx="4" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.35)"/>
+  <text x="830" y="605" fontSize="9.5" fill="#c6d2e1" textAnchor="middle">eth0 (passthrough)</text>
+  <g fill="rgba(255,255,255,0.05)" stroke="rgba(255,255,255,0.3)">
+    <rect x="280" y="710" width="80" height="24" rx="5"/>
+    <rect x="440" y="710" width="80" height="24" rx="5"/>
+    <rect x="580" y="710" width="80" height="24" rx="5"/>
+    <rect x="790" y="710" width="80" height="24" rx="5"/>
+  </g>
+  <g fontSize="10" fill="#c6d2e1" textAnchor="middle">
+    <text x="320" y="726">NIC1</text>
+    <text x="480" y="726">NIC2</text>
+    <text x="620" y="726">NIC3</text>
+    <text x="830" y="726">NIC4</text>
+  </g>
+  <g stroke="rgba(255,255,255,0.3)" strokeWidth="1.3">
+    <line x1="320" y1="710" x2="320" y2="602"/>
+    <line x1="480" y1="710" x2="480" y2="602"/>
+    <line x1="620" y1="710" x2="620" y2="602"/>
+  </g>
+  <line x1="830" y1="710" x2="830" y2="630" stroke="rgba(255,255,255,0.45)" strokeWidth="1.5"/>
+  <text x="822" y="676" fontSize="9" fill="#7a8699" textAnchor="end">PCI passthrough</text>
+  <path d="M548 288 C 500 320, 486 340, 496 364" stroke="#4a90e2" strokeWidth="1.4" fill="none"/>
+  <line x1="295" y1="288" x2="300" y2="300" stroke="#56c288" strokeWidth="1.4"/>
+  <text x="470" y="770" fontSize="9.5" fill="#7a8699" textAnchor="middle">VM1/VM2: PV datapath · VM3: emulated NIC through qemu-dm and tap · VM4: direct hardware access</text>
+</svg>
+</Schema>
 
 At the highest level, Xen Orchestra and `xe` commands interact with XAPI to manage network configuration. The `xapi` daemon provides the main API, receiving requests and passing them to `message-switch`, which dispatches commands to the appropriate daemon. For networking, this is `xcp-networkd`, which applies the required configuration using Open vSwitch (OVS) commands.
 
@@ -592,10 +1157,11 @@ Additionally, `ovs-vsctl show` does not display it as a separate bridge, but ins
 ```
 
 Although its ports are added to `xenbr0` it does have a list of its own ports:
-```
-# ovs-vsctl list-ports xapi9
+
+<Terminal title="ovs-ofctl dump-flows xapi0">{`
+ovs-vsctl list-ports xapi9
 vif20.1
-```
+`}</Terminal>
 
 This makes it easier to identify its ports and interfaces than trying to match the tags to a port.
 
@@ -639,7 +1205,7 @@ To see the overall organization, use `ovs-vsctl show`:
 
 #### Global Private Networks (tunnels)
 
-Global private networks are managed by Xen Orchestra's [SDN Controller plugin](https://docs.xen-orchestra.com/sdn_controller), also documented in the [XCP-ng SDN Controller documentation](../../networking/#-sdn-controller). Here, we explain their setup within OVS.
+Global private networks are managed by Xen Orchestra's [SDN Controller plugin](https://docs.xen-orchestra.com/sdn_controller), also documented in the [XCP-ng SDN Controller documentation](../../networking/#sdn-controller). Here, we explain their setup within OVS.
 
 A network is created, and its associated bridge is created on the required hosts. Unlike other network types, these can span multiple pools, which is why the SDN Controller plugin is needed as XAPI is not aware of other pools. After the bridge is created, tunnels (GRE or VXLAN, encrypted or not) are established between the center host and all hosts in the included pools. For encrypted tunnels, libreswan is used for IPsec, establishing routes at the kernel level. This currently limits you to one encrypted tunnel per protocol, as multiple tunnels would attempt to set the same route.
 

--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -4,7 +4,7 @@ How to contribute to XCP-ng? There are many ways of contributing:
 * by giving some of your time to work on the project. Code isn't the only way! Community support, translation, documentation, testing…
 * with money, by subscribing to [Pro Support](https://vates.tech), which funds further developments.
 
-## 💁 Help others
+## 💁 Help others {#help-others}
 
 You don't have to be a programmer/IT-nerd to help at this project. Just ask or offer your help:
 
@@ -14,15 +14,15 @@ You don't have to be a programmer/IT-nerd to help at this project. Just ask or o
 
 We are happy about every helping hand!
 
-## 🌍 Translations
+## 🌍 Translations {#translations}
 
 [Help us translate the built-in web interface (XO Lite) in more languages!](http://translate.vates.tech/engage/xen-orchestra/)
 
-## ✍️ Write documentation
+## ✍️ Write documentation {#write-documentation}
 
 Contribute to our documentation with pull requests modifying the files in this very documentation. At the bottom of each page (including this one!), you can find a "🖊️ Edit this page" link. Click on it and contribute!
 
-## 🧑‍🔬 Test
+## 🧑‍🔬 Test {#test}
 
 It's important to test XCP-ng on many different platforms and devices. You have gear laying around or access to some special devices? -> be a tester and test all the features of XCP-ng 🚀
 
@@ -37,7 +37,7 @@ Most community testing is organized on the forum, on dedicated threads.
 
 You can also read [this](../development-process/tests) for test ideas.
 
-## 🧑‍💻 Develop
+## 🧑‍💻 Develop {#develop}
 
 You are a developer and want to code with us? Cool!
 
@@ -49,17 +49,17 @@ There are many components, in various languages: C, ocaml, python and more.
     * Forum -> Development Corner: [https://xcp-ng.org/forum/category/7/development](https://xcp-ng.org/forum/category/7/development)
 * Read [this introduction](../development-process/development). The rest of the [Development Process Tour](../../category/development-process) is also of interest for anyone who wants to help on development.
 
-## 📦 Package
+## 📦 Package {#package}
 
 Development is one thing, but for your changes to reach actual users, they need to be packaged into RPMs.
 
 See the [Development Process Tour](../../category/development-process) for an introduction about the packaging process, and useful tips (like: [how to rebuild a RPM for XCP-ng locally](../development-process/local-rpm-build)).
 
-## 📣 Talk about us
+## 📣 Talk about us {#talk-about-us}
 
 Another valuable way to help is by talking about XCP-ng to people you know or to your audience.
 
-## 🪪 Developer Certificate of Origin (DCO)
+## 🪪 Developer Certificate of Origin (DCO) {#developer-certificate-of-origin-dco}
 
 As a member of the Linux Foundation, XCP-ng asks that every contributor certifies that they are allowed to contribute the code or documentation they submit to us. This is done with a simple
 ```

--- a/docs/project/development-process/ISO-modification.md
+++ b/docs/project/development-process/ISO-modification.md
@@ -10,23 +10,24 @@ This page aims at guiding you through the modification of the installation ISO i
 
 Obviously, a modified installation image is not an official installation image anymore, so it's harder to provide support for that. However, it can still be useful in some cases and we also hope that letting you know how to modify the installer will help getting useful contributions on its [code base](https://github.com/xcp-ng/host-installer).
 
-## Extract an existing ISO image
+## 📤 Extract an existing ISO image {#extract-an-existing-iso-image}
 
-```
+<Terminal shell title="Extract an existing ISO image">{`
 mkdir tmpmountdir/
 mount -o loop filename.iso tmpmountdir/ # as root
 cp -a tmpmountdir/. iso
 umount tmpmountdir/ # as root
-```
+`}</Terminal>
 
 Now you have the contents of the ISO image in the `iso/` directory. Note that everything in the directory is read-only at this stage, so you will need to change the file permissions or be root to modify the files.
 
 For example:
-```
-chmod a+w iso/ -R
-```
 
-## Contents of the installation ISO image
+<Terminal shell title="Extract an existing ISO image">{`
+chmod a+w iso/ -R
+`}</Terminal>
+
+## 🗂️ Contents of the installation ISO image {#contents-of-the-installation-iso-image}
 
 We'll only list the files that are used during an installation or upgrade. The other files in the ISO are documentation or additional tools.
 
@@ -37,11 +38,11 @@ We'll only list the files that are used during an installation or upgrade. The o
 * `repodata/`: yum metadata about the RPMs
 * `.treeinfo`: often forgotten when one copies the contents of the ISO for network installation, this hidden file contains necessary metadata about XCP-ng and its version
 
-## Create a fully automated installation image
+## 🤖 Create a fully automated installation image {#create-a-fully-automated-installation-image}
 
 [A guide is available in the *Installation* page](../../../installation/install-xcp-ng#unattended-installation-with-a-custom-iso-image).
 
-## Modify the installer itself
+## 🛠️ Modify the installer itself {#modify-the-installer-itself}
 
 The steps to modify the installer are:
 * (extract the ISO image, see above)
@@ -63,21 +64,26 @@ cd ..
 ### Navigate in the installer's filesystem
 
 If you want to use commands in the installer's filesystem context, as root:
-```
+
+<Terminal shell title="Navigate in the installer's filesystem">{`
 chroot install/
-```
+`}</Terminal>
+
 To use `yum` or `rpm`, you'll also need to mount `urandom` in your chrooted dir.
 From outside the chroot run:
-```
+
+<Terminal shell title="Navigate in the installer's filesystem">{`
 touch install/dev/urandom
 mount -B /dev/urandom install/dev/urandom # As root!
-```
+`}</Terminal>
+
 Then useful commands will be available to you in the context of that filesystem, such as `rpm`, `yum`, etc.
 
 For example, you can list all RPMs present in that "system":
-```
+
+<Terminal shell title="root@xcp-ng-host — Navigate in the installer's…">{`
 rpm -qa | sort
-```
+`}</Terminal>
 
 Exit chroot with `exit` or Ctrl + D.
 
@@ -97,9 +103,11 @@ Example use cases:
 ### Modify the installer code itself
 
 The installer is a `python` program that comes from the `host-installer`. In chroot, you can easily locate its files with:
-```
+
+<Terminal shell title="root@xcp-ng-host — Modify the installer code itself">{`
 rpm -ql host-installer
-```
+`}</Terminal>
+
 Most of them are in `/opt/xensource/installer/`
 
 Our git repository for the installer is: [https://github.com/xcp-ng/host-installer](https://github.com/xcp-ng/host-installer). Feel free to create pull requests for your enhancements or bug fixes.
@@ -107,15 +115,16 @@ Our git repository for the installer is: [https://github.com/xcp-ng/host-install
 ### Build a new `install.img` with your changes
 
 From the `iso/` directory
-```
+
+<Terminal shell title="Build a new install.img with your changes">{`
 cd install/
 find . | cpio -o -H newc | bzip2 > ../install.img # as root!
 rm install/ -rf # as root too. Or move it somewhere else. We don't want it in the final ISO.
-```
+`}</Terminal>
 
 Then you can either read the next section or jump to "Build a new ISO image with your changes".
 
-## Change the list of installed RPMs
+## 📦 Change the list of installed RPMs {#change-the-list-of-installed-rpms}
 
 You may want the installer to install more packages, or updated packages.
 
@@ -130,7 +139,7 @@ To achieve this:
   createrepo_c . -o .
   ```
 
-## Build a new ISO image with your changes
+## 💿 Build a new ISO image with your changes {#build-a-new-iso-image-with-your-changes}
 
 From the `iso/` directory:
 ```

--- a/docs/project/development-process/build-system.md
+++ b/docs/project/development-process/build-system.md
@@ -14,7 +14,7 @@ What follows is important if you want to understand how our official RPMs are bu
 However, for local builds meant for testing your changes (e.g. add a few patches to see how the component behaves with them), check the [Local RPM build](../local-rpm-build) section.
 :::
 
-## Enter Koji
+## 🏭 Enter Koji {#enter-koji}
 
 When building RPMs, many things can and must be automated. This is what a build system is for. Ours is [Koji](https://koji.xcp-ng.org/), which [comes from the Fedora project](https://pagure.io/koji).
 
@@ -30,7 +30,7 @@ And with a bit of scripting or additional components:
 * GPG signing of RPMs.
 * Creation of RPM repositories.
 
-## Koji's concepts
+## 🎓 Koji's concepts {#kojis-concepts}
 
 (see also [https://pagure.io/docs/koji/](https://pagure.io/docs/koji/) though its howto is very Fedora-centric)
 
@@ -109,7 +109,7 @@ Another (fictitious) example:
 
 This is just to show that build tag and destination tag **can** be different. Build dependencies will be pulled from `v8.x-testing` and the result will be put in `v8.x-sandbox`. This means that builds to the sandbox will never use packages that are already in the sandbox as build dependencies. Why would we do that? To guarantee that builds made in the sandbox are never influenced by other builds made there, possibly by other users. This is a fictitious situation, just to illustrate the concepts of build tag and destination tag.
 
-## Build and release process
+## 🪜 Build and release process {#build-and-release-process}
 Here's how to update a package in XCP-ng, step by step. This process requires writing rights on the git repository corresponding to the package at [https://github.com/xcp-ng-rpms/](https://github.com/xcp-ng-rpms/) and submit rights in Koji. Others are invited to fork one the repositories at [https://github.com/xcp-ng-rpms/](https://github.com/xcp-ng-rpms/), [build RPMs locally in our build container](../local-rpm-build), and then create pull requests. Reading the steps below will still be useful to you to help make appropriate changes.
 
 This applies only to packages that we build in Koji. There are also packages that are not built in Koji. Most packages from CentOS, for example, are imported directly from CentOS into our Koji instance.
@@ -161,19 +161,19 @@ Then, if it is an **update candidate** for an existing package:
     * What to test.
     * Is a reboot required…
 
-## Special case: new packages
+## 🆕 Special case: new packages {#special-case-new-packages}
 Importing new packages requires extra steps.
 
 **TODO**
 
-## Special case: packages not built by us
+## 🤝 Special case: packages not built by us {#special-case-packages-not-built-by-us}
 Most packages imported from CentOS or EPEL are not built by our Koji instance. We import the source RPM and the built RPMs directly.
 
 **TODO**
 
 Bits of information can be inferred from [Import-RPM-build-dependencies-from-CentOS-and-EPEL](https://github.com/xcp-ng/xcp/wiki/Import-RPM-build-dependencies-from-CentOS-and-EPEL)
 
-## Other tags
+## 🏷️ Other tags {#other-tags}
 In a previous section, I've tried to explain what tags are used for in Koji. We use them also for something else. We probably even misuse them.
 
 Once a day, we run a job that makes sure every *build* in our Koji instance is tagged with one of the following tags:
@@ -190,10 +190,10 @@ Example: [https://koji.xcp-ng.org/buildinfo?buildID=655](https://koji.xcp-ng.org
 
 All those tags have no purpose in Koji's workflow. They are just useful pieces of information for us.
 
-## RPM signing
+## ✍️ RPM signing {#rpm-signing}
 We automatically sign the RPMs built by or imported to Koji before exporting them towards the RPM repositories.
 
-[More information about RPM signing](../../../project/mirrors#-security).
+[More information about RPM signing](../../../project/mirrors#security).
 
-## Repository generation
+## 🗃️ Repository generation {#repository-generation}
 Handled by a cron job on koji's server. Then the repository is synchronised to [https://updates.xcp-ng.org/](https://updates.xcp-ng.org/).

--- a/docs/project/development-process/commit-message-conventions.md
+++ b/docs/project/development-process/commit-message-conventions.md
@@ -6,13 +6,13 @@ sidebar_position: 11
 
 Our conventions on commit messages.
 
-## Foreword
+## 📖 Foreword {#foreword}
 
 XCP-ng and Xen Orchestra are made of many different projects and components. This document is an attempt at defining a minimal, common set of rules for git commit messages we want to follow in the context of those projects. They should be generic and consensual enough that we can follow them for our internal commits, but also when contributing upstream (while following the upstream project's rules, of course).
 
 Individual projects part of XCP-ng or Xen Orchestra can also define additional rules and exceptions. For example, Xen Orchestra developers follow [additional rules coming from the AngularJS guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y).
 
-## Goals
+## 🎯 Goals {#goals}
 
 The main goals behind the commit message rules are:
 
@@ -24,7 +24,7 @@ The main goals behind the commit message rules are:
 
 There could be more goals, but they are not covered by the minimal set of rules in this document. For example: permitting scripting changelog generation, with a separation between security fixes, features and bug fixes. This is left for each individual project to define.
 
-## Structure of a commit message
+## 🧱 Structure of a commit message {#structure-of-a-commit-message}
 
 The widely accepted structure is:
 
@@ -40,7 +40,7 @@ changes
 Footer
 ```
 
-## First line: short subject
+## ✏️ First line: short subject {#first-line-short-subject}
 
 Here's a challenge: it must remain really short (50 characters is the convention, but in this minimal set of rules we'll allow up to 70 characters), but also ideally answer three essential questions:
 
@@ -64,11 +64,11 @@ On the other side, here's an example of a commit subject that doesn't follow a s
 
 When there's no structured convention, ask yourself: are the type, the scope and the change obvious in the subject I wrote?
 
-## Second line: blank
+## ⬜ Second line: blank {#second-line-blank}
 
 Nothing on that line. Period. No exceptions.
 
-## Message body: commit description
+## 📝 Message body: commit description {#message-body-commit-description}
 
 This part gets easily forgotten, but it's really important. You don't know who will read your commit, when (could be in ten years from now), what knowledge they will have about the project or about the code. Maybe they're someone from the support that has only minimal knowledge in the programming language. Maybe they're a project manager. Maybe it's a developer who took over this component after you left. And often enough, it will just be yourself scratching your head and asking yourself: "Why the h\*\*\* did I make this change???".
 
@@ -93,7 +93,7 @@ For good examples, go look at the commit history [from the Xen project](http://x
 
 Verbs that describe what you did are in the imperative form. Lines should not be longer than 70 characters.
 
-## Message footer
+## 🦶 Message footer {#message-footer}
 
 ### Referencing issues
 
@@ -111,4 +111,4 @@ Be careful with "Fixes" or "Closes", because they can automatically close issues
 
 ### Developer Certificate of Origin (DCO)
 
-As a member of the Linux Foundation, XCP-ng asks every contributor to certify that they are allowed to contribute the code or documentation they submit to us. See our [contributing](../../contributing#-developer-certificate-of-origin-dco) section for details. This is enforced for every repository under the GitHub `xcp-ng` and `xcp-ng-rpms` organizations.
+As a member of the Linux Foundation, XCP-ng asks every contributor to certify that they are allowed to contribute the code or documentation they submit to us. See our [contributing](../../contributing#developer-certificate-of-origin-dco) section for details. This is enforced for every repository under the GitHub `xcp-ng` and `xcp-ng-rpms` organizations.

--- a/docs/project/development-process/development.md
+++ b/docs/project/development-process/development.md
@@ -8,17 +8,17 @@ How XCP-ng is developed.
 
 Development in the context of the XCP-ng project means either to contribute to existing upstream projects, such as the Xen API ([XAPI](https://github.com/xapi-project/xen-api/), the [Xen project](https://xenproject.org/) and many other components of XCP-ng, or to develop new software specifically for the XCP-ng project.
 
-## Contribution to upstream projects
+## ⬆️ Contribution to upstream projects {#contribution-to-upstream-projects}
 Development (as in "write code") in XCP-ng project is mostly made of contributions to upstream projects such as [https://github.com/xapi-project/](https://github.com/xapi-project/), [https://wiki.xenproject.org/wiki/Submitting_Xen_Project_Patches](https://wiki.xenproject.org/wiki/Submitting_Xen_Project_Patches) or [https://github.com/xenserver/](https://github.com/xenserver/).
 
 For some pieces of upstream software, we have GitHub "forks" at [https://github.com/xcp-ng](https://github.com/xcp-ng). For others we contribute directly without a GitHub fork and apply the patches directly on the RPMs at [https://github.com/xcp-ng-rpms/](https://github.com/xcp-ng-rpms/).
 
-## Components we **are** the upstream for
+## 🌱 Components we **are** the upstream for {#components-we-are-the-upstream-for}
 Components for which we are the main developers.
 
 Our policy is to upstream everything if possible. However, there are some exceptions:
 * Components that have no "upstream" open source equivalent. `xcp-emu-manager` ([https://github.com/xcp-ng/xcp-emu-manager](https://github.com/xcp-ng/xcp-emu-manager)) is such a component that we had to write from scratch because the corresponding component in XenServer, `emu-manager`, is closed-source.
 * Bits specific to the act of building XCP-ng (various scripts, branding stuff...). The main example is [https://github.com/xcp-ng/xcp](https://github.com/xcp-ng/xcp).
 
-## How to help at development
+## 🤝 How to help at development {#how-to-help-at-development}
 It all depends on your skills and areas of interest so it's hard to tell specifically in advance. It usually starts with a feature that you want, or a bug that is annoying you. Alternatively, having a look at the open GitHub issues and picking one ([https://github.com/xcp-ng/xcp/issues](https://github.com/xcp-ng/xcp/issues)) can be a way to get started. Even if you don't know where to start, just come and talk with us (see [Where discussion happens](../release-process-overview#where-discussion-happens) above).

--- a/docs/project/development-process/kernel-module-policy.md
+++ b/docs/project/development-process/kernel-module-policy.md
@@ -6,14 +6,14 @@ sidebar_position: 9
 
 Our policy regarding kernel modules.
 
-In XCP-ng, there is only one version of the kernel that is supported at a given time. There's also an [alternate kernel](../../../installation/hardware#-alternate-kernel) available for troubleshooting. The policy differs whether the kernel modules are for XCP-ng's supported kernel or for an alternate kernel.
+In XCP-ng, there is only one version of the kernel that is supported at a given time. There's also an [alternate kernel](../../../installation/hardware#alternate-kernel) available for troubleshooting. The policy differs whether the kernel modules are for XCP-ng's supported kernel or for an alternate kernel.
 
-## What are kernel modules?
+## 🎓 What are kernel modules? {#what-are-kernel-modules}
 See [https://en.wikipedia.org/wiki/Loadable_kernel_module](https://en.wikipedia.org/wiki/Loadable_kernel_module)
 
 They can be loaded (or unloaded) dynamically into the kernel to provide more functionality: device drivers, filesystem drivers, etc.
 
-## Definitions: supported modules, alternate modules, additional modules
+## 📚 Definitions: supported modules, alternate modules, additional modules {#definitions-supported-modules-alternate-modules-additional-modules}
 
 A base installation of XCP-ng comes with:
 * a Linux kernel (the `kernel` RPM), including lots of modules already,
@@ -24,7 +24,7 @@ Through our RPM repositories (configured by default on the hosts for `yum` to in
 * **alternate modules**, which are alternate versions of the officially supported modules. The supported modules can either be built-in kernel modules or modules provided through supported separate RPMs such as the `qlogic-netxtreme2` RPM. Their name is usually the same as the package they override, with an added `-alt` suffix (example: `broadcom-bnxt-en-alt`). Alternate versions can be installed for better support of recent hardware or in the hope that bugs in the supported drivers have been fixed in newer versions. They won't remove the supported drivers from the system, but the kernel will load the alternate ones instead. **Warning**: *they receive less testing than the supported modules*.
 * **additional (or "extra") modules** for **additional features** (can be experimental). Example: `kmod-zfs-4.4.0+10` for ZFS support in the `4.4.0+10` kernel, or `ceph-module` for CephFS support. To know whether such a module is experimental or is fully supported, read its description or search the wiki.
 
-## Module Updates
+## ♻️ Module Updates {#module-updates}
 
 This section discusses the kind of updates kernel modules can receive during the maintenance cycle of a given release of XCP-ng (e.g. XCP-ng 8.2). For information about the general update process, see [Updates Howto](../../../management/updates).
 
@@ -34,7 +34,7 @@ Updates for *alternate modules* are offered only if the given alternate modules 
 
 Updates for *additional modules* are offered only if the given additional modules are installed on the host. We may update them to a newer version of the module at any time - more likely if the module is considered experimental, less likely if it's supported officially.
 
-## Module package naming conventions
+## 🏷️ Module package naming conventions {#module-package-naming-conventions}
 
 We'll now discuss naming conventions for packages that provide kernel modules. This is mostly targeted at packagers, but can also be useful to users who wish to understand the naming schemes. We've tried to make it simple and to use meaningful naming conventions, but legacy and the variety of situations led to a mixed result, so hold on!
 
@@ -80,7 +80,7 @@ Examples:
 * `broadcom-bnxt-en-alt`
 * `tn40xx-module-alt` (fictitious)
 
-## Versioning of the RPMs
+## 🔢 Versioning of the RPMs {#versioning-of-the-rpms}
 
 Since we only support one version of the kernel, we don't need to include the kernel version in the package name in addition to the module version. So the `Version` tag of the RPM is that of the module.
 
@@ -92,7 +92,7 @@ Example `ceph-module-4.4.176` is a version of the `ceph` module extracted from k
 
 Exceptions: the abovementioned `kmod`-packages such as `kmod-zfs-4.4.0+10-0.7.11-1.el7.centos.x86_64.rpm` include the kernel version in the name. In this example the kernel version is `4.4.0+10` and the module version is `0.7.11`.
 
-## Where the modules are installed on the system
+## 📍 Where the modules are installed on the system {#where-the-modules-are-installed-on-the-system}
 
 Intended mostly for packagers, this section can also be useful to users.
 
@@ -105,11 +105,12 @@ Kernel modules can be present in several places. In XCP-ng, we use the following
 * alternate optional versions of the default modules are installed in `/lib/modules/{kernel_version}/override`. This is not a standard directory for modules, so we alter the configuration of `depmod` to give the priority to modules in this directory. See "`depmod` configuration for alternate modules" below.
 
 We can have up to three versions of the same module on the system, one from the kernel, one from XCP-ng's set of supported or additional modules, and one alternate modules that overrides both:
-```
+
+<Terminal shell title="Where the modules are installed on the system">{`
 /usr/lib/modules/4.4.0+10/kernel/drivers/net/ethernet/broadcom/bnxt/bnxt_en.ko
 /usr/lib/modules/4.4.0+10/updates/bnxt_en.ko
 /usr/lib/modules/4.4.0+10/override/bnxt_en.ko
-```
+`}</Terminal>
 
 ### `depmod` configuration for alternate modules
 
@@ -131,7 +132,7 @@ search override updates extra built-in weak-updates
 
 This makes `depmod` search in the `override` module directory before trying other module directories, for all modules.
 
-## How to use alternate or additional modules
+## 🦮 How to use alternate or additional modules {#how-to-use-alternate-or-additional-modules}
 
 First, a warning: alternate modules and additional modules are provided as a convenience, but they do not get the same amount of testing as the modules that are installed by default or through updates. So keep that in mind, test, and be ready to uninstall them if any issue arises.
 
@@ -139,27 +140,31 @@ First, a warning: alternate modules and additional modules are provided as a con
 
 #### List available alternate modules
 You can list the available RPMs for alternate modules with the command below, that will search for packages whose name ends in `-alt`. Only packages that are not currently installed or have an available update will be listed.
-```
+
+<Terminal shell title="root@xcp-ng-host — List available alternate modules">{`
 yum list available | grep -e '-alt.x86_64'
-```
+`}</Terminal>
 
 #### List available additional modules
 You can list the available RPMs for alternate modules with the command below, that will search for packages whose name ends in `-module`, or begins with `kmod-` and contains the current kernel version. Only packages that are not currently installed or have an available update will be listed.
-```
+
+<Terminal shell title="root@xcp-ng-host — List available additional modules">{`
 yum list available | grep -e '-module.x86_64' -e '^kmod-.*-'$(uname -r)
-```
+`}</Terminal>
 
 #### Get more information about a package
 
 To get more information about one of the listed packages, use `yum info`:
-```
+
+<Terminal shell title="root@xcp-ng-host — Get more information about a…">{`
 yum info {package-name}
-```
+`}</Terminal>
 
 ### How to install
-```
+
+<Terminal shell title="root@xcp-ng-host — How to install">{`
 yum install {package-name}
-```
+`}</Terminal>
 
 Installing the RPM will make the module available and give it priority in most cases. It will not unload any version that is already running on your system (check with `lsmod`) if there's one, nor load the new one. This is normal. Do **not** remove the RPM that contains the supported module. The chain of dependencies would lead you to remove the `xcp-ng-deps` meta package, which is necessary for updates and upgrades.
 
@@ -185,28 +190,30 @@ As we said, if the module is expected to load at boot, we advise to reboot ultim
 When there's already a version of the module running, there is no way to load a new driver without unloading the old one, so be prepared for issues to arise if the module is in use for important tasks (disks, network, ...).
 
 Now that you've been warned:
-```
+
+<Terminal shell title="How to load the new module without a reboot">{`
 modprobe -rv {module_name}
-```
+`}</Terminal>
 
 **Load the new module**
-```
+
+<Terminal shell title="How to load the new module without a reboot">{`
 modprobe -v {module_name}
-```
+`}</Terminal>
 
 ### How to remove an additional or an alternate module
 
-```
+<Terminal shell title="root@xcp-ng-host — How to remove an additional or…">{`
 yum remove {package-name}
-```
+`}</Terminal>
 
 In the case of an alternate module, we have made it so that you can simply uninstall the RPM and the base supported module will get used instead at next reboot or manual unload/reload of the module. After uninstalling the RPM, follow the same steps as when you installed it (described above): `modinfo`, reboot, check `dmesg`...
 
 In the case of an additional module, uninstalling the RPM will simply leave your system without that module, but shouldn't remove it from the currently loaded modules until next reboot or until you unload it.
 
-## Kernel modules for alternate kernels
+## 🚒 Kernel modules for alternate kernels {#kernel-modules-for-alternate-kernels}
 
-The policy for [alternate kernels](../../../installation/hardware#-alternate-kernel) is simpler, because there are no alternate modules (with the meaning of *alternate modules* as described earlier). There's just the kernel's built-in modules and possibly additional or updated modules in `/lib/modules/{kernel_version}/updates`. This means that when an alternate kernel is updated, people who have installed it will get the update through the standard updates process. There's no support for cherry-picking specific versions of previous packages we may have released in the past. If there's a bug, please open a bug report. To avoid bugs, please take part in the testing phase.
+The policy for [alternate kernels](../../../installation/hardware#alternate-kernel) is simpler, because there are no alternate modules (with the meaning of *alternate modules* as described earlier). There's just the kernel's built-in modules and possibly additional or updated modules in `/lib/modules/{kernel_version}/updates`. This means that when an alternate kernel is updated, people who have installed it will get the update through the standard updates process. There's no support for cherry-picking specific versions of previous packages we may have released in the past. If there's a bug, please open a bug report. To avoid bugs, please take part in the testing phase.
 
 RPMs that provide modules for an alternate kernel must follow these conventions:
 * The name must always end with `-kernel{MAJOR.MINOR}` (we don't include the patch version because we won't provide two competing kernel packages for the same MAJOR + MINOR versions).

--- a/docs/project/development-process/koji-initial-setup.md
+++ b/docs/project/development-process/koji-initial-setup.md
@@ -6,7 +6,7 @@ sidebar_position: 14
 
 How to configure Koji as a user.
 
-## Certificates
+## 🪪 Certificates {#certificates}
 
 Once accepted as a proven packager or as an apprentice, you will receive your connection certificate as well as the server's CA public certificate:
 
@@ -25,7 +25,7 @@ You may also receive a browser certificate for the connection to Koji's web inte
 ```
 You need to import it into your web browser's certificate store and then use it when you log in to [https://koji.xcp-ng.org/](https://koji.xcp-ng.org/)
 
-## Installing koji
+## 📥 Installing koji {#installing-koji}
 The preferred, distro-independent way is to install it from PyPi with `pip`, `uv` or your preferred tool. Alternatively, your distro might provide the `koji` client as a package you can install from its repositories. You could also run it from a Fedora container, but that's mostly a last resort option if anything else fails for some reason.
 
 Example on Ubuntu 24.04+:
@@ -37,7 +37,7 @@ sudo apt install -y build-essential python3-dev libkrb5-dev krb5-user libssl-dev
 pipx install koji
 ```
 
-## Configuring koji
+## ⚙️ Configuring koji {#configuring-koji}
 Put this in `~/.koji/config`:
 ```
 [koji]
@@ -68,19 +68,20 @@ authtype = ssl
 
 In some cases (with older versions of koji), we've found that the `cert` directive in `~/.koji/config ` was not used if there was no such directive in `/etc/koji.conf`. Workaround: add a `cert = ~/.koji/client.crt` to `/etc/koji.conf`, or possibly even `cp ~/.koji/config /etc/koji.conf`.
 
-## Test your connection
+## 🧪 Test your connection {#test-your-connection}
 `koji moshimoshi`. If it greats you (in any language), then your connection to the server works.
 
-## Get more permissions
+## 🔑 Get more permissions {#get-more-permissions}
 After your first connection, your user gets added by koji to its database. Now you need permissions to be able to tag builds. Ask an administrator for the `build` permission.
 
 You can verify the permissions for a given user `$USER` with:
-```
+
+<Terminal shell title="Get more permissions">{`
 koji list-users # Check if $USER is listed
 koji list-permissions --user=$USER # Adapt $USER if needed
-```
+`}</Terminal>
 
-## Koji in Docker container
+## 🐳 Koji in Docker container {#koji-in-docker-container}
 
 This used to be useful when our koji server was a bit too old for recent crypto, but now **installing from `PyPi` is probably the best choice**.
 
@@ -95,9 +96,10 @@ EOF
 ```
 
 Then, to run koji with it, which will use the `~/.koji` directory that you've prepared outside the container:
-```
+
+<Terminal shell title="Koji in Docker container">{`
 docker run -it --rm -v$HOME/.koji:/root/.koji:ro koji:latest koji moshimoshi
-```
+`}</Terminal>
 
 ### Alternative as a one-liner
 
@@ -106,7 +108,7 @@ This command does the same as above, but relies on docker caching the result of 
 docker run -it --rm -v$HOME/.koji:/root/.koji:ro $(docker build -q - <<<$'FROM fedora:41\nRUN dnf install -qy koji') koji moshimoshi
 ```
 
-## Useful commands
+## 🧰 Useful commands {#useful-commands}
 
 Just a quick list. Make sure to have read and understood our [development process tour](../../../category/development-process).
 

--- a/docs/project/development-process/local-rpm-build.md
+++ b/docs/project/development-process/local-rpm-build.md
@@ -8,10 +8,10 @@ How to build RPMs locally.
 
 Koji, the build system, is used only for official builds or update candidates. For daily development or community builds, we provide a simpler build environment using docker.
 
-## `xcp-ng-build-env`
+## 📦 `xcp-ng-build-env` {#xcp-ng-build-env}
 We provide a build environment that can run locally on your computer: [https://github.com/xcp-ng/xcp-ng-build-env](https://github.com/xcp-ng/xcp-ng-build-env). It revolves around docker containers and a few convenience scripts. This is what we use for development, before we send the actual changes to our official build system, `koji`.
 
-## Guide to local RPM rebuild
+## 🦮 Guide to local RPM rebuild {#guide-to-local-rpm-rebuild}
 With some prior knowledge about development and RPM packaging, the documentation of [https://github.com/xcp-ng/xcp-ng-build-env](https://github.com/xcp-ng/xcp-ng-build-env) should be enough to get you started. However, in what follows, we provide a step by step guide for anyone to become accustomed to the process.
 
 ### Requirements
@@ -68,7 +68,7 @@ We can't cover every situation here, so we will address a simple case: add patch
 
 Then follow the same steps as before to build the RPM.
 
-## An XCP-ng host as a build environment
+## 🖥️ An XCP-ng host as a build environment {#an-xcp-ng-host-as-a-build-environment}
 You can also turn any XCP-ng host (preferrably installed in a VM. Don't sacrifice a physical host for that) into a build environment: all the tools and build dependencies are available from the default RPM repositories for XCP-ng, or from CentOS and EPEL repositories.
 
 You won't benefit from the convenience scripts from [xcp-ng-build-env](https://github.com/xcp-ng/xcp-ng-build-env) though.

--- a/docs/project/development-process/performance-tests.md
+++ b/docs/project/development-process/performance-tests.md
@@ -10,7 +10,7 @@ Basic ways to test XCP-ng performances.
 - compare speed of interfaces in the old and in the new release
 - (add more here...)
 
-## Example Storage Performance Tests Using fio
+## 💽 Example Storage Performance Tests Using fio {#example-storage-performance-tests-using-fio}
 
 ### Random write test for IOP/s, i.e. lots of small files
 
@@ -37,14 +37,14 @@ sync;fio --randrepeat=1 --ioengine=libaio --direct=1 --gtod_reduce=1 --name=test
 sync;fio --randrepeat=1 --ioengine=libaio --direct=1 --gtod_reduce=1 --name=test --filename=test --bs=4M --iodepth=64 --size=4G --readwrite=read --ramp_time=4
 ```
 
-## VM Export / Import
+## 📤 VM Export / Import {#vm-export--import}
 
 * Export using ZSTD compression
 * Import using ZSTD compression
 * Export using gzip compression
 * Import using gzip compression
 
-## Guest tools and drivers
+## 🛠️ Guest tools and drivers {#guest-tools-and-drivers}
 
 * Linux VM created on an older pool, with older guest tools not updated
 * Update existing Linux guest tools

--- a/docs/project/development-process/release-process-overview.md
+++ b/docs/project/development-process/release-process-overview.md
@@ -8,7 +8,7 @@ How we make a release process.
 
 Let's first discuss the RPM repository structure and define stable and development releases. Then we'll see development and packaging aspects.
 
-## XCP-ng's RPM repositories
+## 🗃️ XCP-ng's RPM repositories {#xcp-ngs-rpm-repositories}
 *A new repository structure has been introduced with XCP-ng 8.0, which is what this section will cover. For the structure used in XCP-ng 7.5 and 7.6, see [https://xcp-ng.org/forum/topic/185/structure-of-the-rpm-repositories](https://xcp-ng.org/forum/topic/185/structure-of-the-rpm-repositories).*
 
 First, the *goals* behind the RPM repository structure are:
@@ -64,12 +64,12 @@ Note that having lots of additional packages in `base` and `updates` does not me
 * if you voluntarily install them (`yum install ...`),
 * or when pulled as a dependency of another update (in which case we do want that).
 
-## Stable release vs development release
+## ⚖️ Stable release vs development release {#stable-release-vs-development-release}
 This is very common: released stable versions only get non-disruptive updates during their support lifetime: bug fixes and security fixes. Those are first published to the `testing` RPM repository and then moved to the `updates` RPM repository so that it is offered to all users (see [Updates Howto](../../../management/updates)). We also allow ourselves to add features to an existing stable version as optional packages, or as updates to existing packages provided that we can do it without creating risks of regression. Example: we added support for `zstd` compression for VM exports to an already released XCP-ng 7.6.
 
 On the contrary, the development version (aka the next stable release) can get any kind of breaking change until the day of release. Packages are then usually directly pushed to the `base` repository.
 
-## How a RPM package is built for XCP-ng
+## 🏭 How a RPM package is built for XCP-ng {#how-a-rpm-package-is-built-for-xcp-ng}
 There are two sides of the coin: **development** and **RPM packaging**. For a given RPM package that does not come from CentOS or EPEL, we always provide packaging work. We can also provide development work, depending on the package, either as contributors to an upstream project, or as our own upstream.
 
 Here are the usual steps. We will expand on them afterwards:
@@ -83,7 +83,7 @@ Here are the usual steps. We will expand on them afterwards:
   * **Publish the build** to the appropriate RPM repository (`testing` for stable releases, `base` for development release of XCP-ng)
 * **Installer ISO image generation**: in the case of a development release of XCP-ng, when all the above has been done for all the RPMs, generate an ISO image with the installer and the required RPMs.
 
-## Where discussion happens
+## 💬 Where discussion happens {#where-discussion-happens}
 Usually discussion will happen:
 * On [GitHub issues](https://github.com/xcp-ng/xcp/issues).
 * In [the forum](https://xcp-ng.org/forum/).

--- a/docs/project/development-process/rpm-packaging.md
+++ b/docs/project/development-process/rpm-packaging.md
@@ -6,7 +6,7 @@ sidebar_position: 5
 
 Creating packages that can be installed on the user's system is called **packaging**.
 
-## Introduction to RPM
+## 🎓 Introduction to RPM {#introduction-to-rpm}
 RPM is the package format used by Fedora, Red Hat, CentOS, Mageia, OpenSUSE and other Linux distributions. It is also what we use in XCP-ng. A RPM package contains the files to be installed, metadata such as version and dependencies, and various scripts executed during installation, upgrade, uninstallation or other events.
 
 A RPM is built from a source RPM (SRPM), which is usually made of:
@@ -22,13 +22,13 @@ More about RPM:
 * [https://en.wikipedia.org/wiki/RPM_Package_Manager](https://en.wikipedia.org/wiki/RPM_Package_Manager)
 * [https://rpm.org/documentation.html](https://rpm.org/documentation.html)
 
-## Where to find our source RPMs
+## 📍 Where to find our source RPMs {#where-to-find-our-source-rpms}
 Two places.
 
 1. As SRPM files (`.src.rpm`), they are all available in our RPM repositories at [https://updates.xcp-ng.org/](https://updates.xcp-ng.org/). Example: [https://updates.xcp-ng.org/8/8.2/base/Source/SPackages/](https://updates.xcp-ng.org/8/8.2/base/Source/SPackages/).
 
 2. All RPMs built by us have been built from one of the git repositories at [https://github.com/xcp-ng-rpms/](https://github.com/xcp-ng-rpms/), containing the spec file and sources. The name of the repository matches that of the source package. `git-lfs` is required for cloning from and committing to them, because we use it to store the source tarballs.
 
-## Packaging guidelines
+## 📐 Packaging guidelines {#packaging-guidelines}
 
 See [RPM Packaging guidelines](https://github.com/xcp-ng/xcp/wiki/RPM-Packaging-guidelines).

--- a/docs/project/development-process/tags-maintenance-branches-in-our-code.md
+++ b/docs/project/development-process/tags-maintenance-branches-in-our-code.md
@@ -16,7 +16,7 @@ The objectives of the branch and tag naming conventions are:
 
 The first question to ask ourselves is: **who is the upstream for the software**?
 
-## 1. We are upstream
+## ⬆️ 1. We are upstream {#1-we-are-upstream}
 
 We decide when to release a new version, and we decide the versioning.
 
@@ -41,7 +41,7 @@ Special case: if VERSION and XCPNGVERSION are always the same (example: `xcp-ng-
 * Tags: `vXCPNGVERSIONFULL` (`v8.2.0`)
 * Maintenance branch if needed: `XCPNGVERSION` (`8.2`)
 
-## 2. We are downstream
+## ⬇️ 2. We are downstream {#2-we-are-downstream}
 
 We do not decide how and when new versions and released, and how they are numbered. So we need to somewhat mix the upstream versioning with our own branch names and versioning. For maintenance branches and tags related to an XCP-ng release, notably.
 

--- a/docs/project/development-process/tests.md
+++ b/docs/project/development-process/tests.md
@@ -16,9 +16,9 @@ Not everyone can test everything, but everything must get tested in the end.
 
 If anything goes wrong, try to isolate [the logs](../../troubleshooting/log-files.md) related to that failure (and what happened just before), and try to identify a way to reproduce if possible. You can also [create a full status report](../../troubleshooting/log-files.md#produce-a-status-report) to let someone else try to identify the issue.
 
-Give priority to tests on actual hardware, but if you don't have any hardware available for those, then [testing in a nested environment](../../compute.md#-nested-virtualization) is useful too.
+Give priority to tests on actual hardware, but if you don't have any hardware available for those, then [testing in a nested environment](../../compute.md#nested-virtualization) is useful too.
 
-## Basic tests
+## ✅ Basic tests {#basic-tests}
 
 - verify installation
 - verify connectivity with your interfaces
@@ -33,7 +33,7 @@ Give priority to tests on actual hardware, but if you don't have any hardware av
 - [check your logs](../../troubleshooting/log-files.md) for uncommon info or warnings.
 - (add more here...)
 
-## Installer
+## 💿 Installer {#installer}
 
 * installation, upgrade
 * net-install with GPG check on
@@ -41,7 +41,7 @@ Give priority to tests on actual hardware, but if you don't have any hardware av
 * compatibility with driver disks from Citrix?
 * backup restore
 
-## Live migration tests
+## 🚚 Live migration tests {#live-migration-tests}
 
 Live migration needs to be tested, with or without storage motion (ie. moving the VM disk data to another storage repository). It is both a very important feature and something that can break in subtle ways, especially across different versions of XenServer or XCP-ng.
 
@@ -86,7 +86,7 @@ and
 This one is the most important and not the easiest to test. During a pool upgrade, the hosts of your pool have heterogeneous versions of XAPI, Xen and other components, and many features are disabled. This is a situation that is meant to be as short as possible. When live migration fails at this stage, it is never a nice situation.
 **That's why this is the kind of live migration that requires the most testing**.
 
-Note: if you don't have the hardware and VMs to test this, you can create a virtual pool using [nested virtualization](../../compute.md#-nested-virtualization).
+Note: if you don't have the hardware and VMs to test this, you can create a virtual pool using [nested virtualization](../../compute.md#nested-virtualization).
 
 If anything fails and you absolutely need to move forward, we advise to produce and save a full [status report](../../troubleshooting/log-files.md#produce-a-status-report) on both hosts involved before continuing.
 
@@ -101,7 +101,7 @@ Some bugs detected in the past during our tests when migrating from old versions
 
 We try to overcome these whenever possible, but bugs that require patching the old host cannot be fixed.
 
-## Cold migration tests
+## 🧊 Cold migration tests {#cold-migration-tests}
 
 Live migration is important, but let's not forget to test "cold" migration (migration of shutdown VMs).
 
@@ -134,7 +134,7 @@ and
 * cross-pool migration, same versions
 * migration from earlier releases, cross-pool
 
-## Test the Xen hypervisor itself
+## 🐼 Test the Xen hypervisor itself {#test-the-xen-hypervisor-itself}
 
 The Xen hypervisor, which is at the core of XCP-ng, will benefit from being tested on a wide range of hardware. There exist test suites for this. You don't need to run them on every host you own if they are truly identical, but it's good to run them on as wide a range of hardware as possible.
 
@@ -149,10 +149,11 @@ Please report any issue or unexpected result on [the forum](https://xcp-ng.org/f
 The first test suite is **XTF** (stands for Xen Test Framework)
 
 Enable HVM FEP on the host. This is not mandatory but if you don't, several tests that require it will be skipped:
-```
+
+<Terminal shell title="root@xcp-ng-host — XTF">{`
 /opt/xensource/libexec/xen-cmdline --set-xen hvm_fep
 reboot
-```
+`}</Terminal>
 
 Note: this debug setting is not recommended for production.
 
@@ -165,12 +166,14 @@ make -j8
 ```
 
 (Optional, protects your host from a crash if its hardware is vulnerable to [XSA-304](https://xenbits.xen.org/xsa/advisory-304.html)) Switch EPT superpages to secure mode:
-```
+
+<Terminal shell title="root@xcp-ng-host — XTF">{`
 xl set-parameters ept=no-exec-sp
-```
+`}</Terminal>
 
 Run the tests
-```
+
+<Terminal shell title="XTF">{`
 # self test
 ./xtf-runner selftest -q --host
 # all tests
@@ -178,12 +181,13 @@ Run the tests
 ./xtf-runner -aqq --host
 # check return code. Should be "3" which means "no failures but some tests were skipped":
 echo $?
-```
+`}</Terminal>
 
 Switch back EPT superpages to fast mode, if needed
-```
+
+<Terminal shell title="root@xcp-ng-host — check return code. Should be '3'…">{`
 xl set-parameters ept=exec-sp
-```
+`}</Terminal>
 
 There will be a few SKIPPED tests, but there shouldn't be many.
 
@@ -200,19 +204,20 @@ You can ignore skipped tests which belong to this list.
 The `xen-dom0-tests` RPM provides several test programs from the Xen Project.
 
 Install:
-```
+
+<Terminal shell title="root@xcp-ng-host — xen-dom0-tests">{`
 yum install xen-dom0-tests
-```
+`}</Terminal>
 
 Read `/usr/share/xen-dom0-tests-metadata.json`, then, for each test listed in it, run the corresponding binary found in `/usr/libexec/xen/bin/` and check the return code.
 
 For example:
 
-```
+<Terminal shell title="xen-dom0-tests">{`
 /usr/libexec/xen/bin/test-cpu-policy
 # check return code. Must be 0, otherwise this means there was a failure.
 echo $?
-```
+`}</Terminal>
 
 Here is a `bash` snippet which automates this process. It requires python3 and thus will only work on XCP-ng 8.3 or above.
 

--- a/docs/project/ecosystem.md
+++ b/docs/project/ecosystem.md
@@ -6,5 +6,5 @@ title: 'Ecosystem'
 :::tip
 We've moved the contents of this page to the [Vates VMS documentation](https://docs.vates.tech/), where we now gather everything related to Vates ecosystems and cross-disciplinary topics. 
 
-[Head there](https://docs.vates.tech/category/ecosystems) to explore how XCP-ng fits into the broader Vates ecosystem and discover all the integrations that connect our solutions together.
+[Head there](https://docs.vates.tech/compatible-solutions/xcp-ng-ecosystem) to explore how XCP-ng fits into the broader Vates ecosystem and discover all the integrations that connect our solutions together.
 :::

--- a/docs/project/gitrepo.md
+++ b/docs/project/gitrepo.md
@@ -2,18 +2,18 @@
 
 Here is a complete list of repositories used by this project.
 
-## 📚 Main repositories
+## 📚 Main repositories {#main-repositories}
 
 * [https://github.com/xcp-ng/](https://github.com/xcp-ng/)
 
-## 📦 Spec files and sources for RPMs
+## 📦 Spec files and sources for RPMs {#spec-files-and-sources-for-rpms}
 
 * [https://github.com/xcp-ng-rpms/](https://github.com/xcp-ng-rpms/)
 
-## 🖥️ XCP-ng Center
+## 🖥️ XCP-ng Center {#xcp-ng-center}
 
 * [https://github.com/xcp-ng/xenadmin](https://github.com/xcp-ng/xenadmin)
 
-## 🪟 Windows Guest Tools
+## 🪟 Windows Guest Tools {#windows-guest-tools}
 
 * [https://github.com/xcp-ng/win-pv-drivers](https://github.com/xcp-ng/win-pv-drivers) - Windows Guest Tools installer and releases

--- a/docs/project/mirrors.md
+++ b/docs/project/mirrors.md
@@ -6,13 +6,13 @@ Like a Linux distribution, XCP-ng's installation images and RPM repositories can
 
 XCP-ng uses [mirrorbits](https://github.com/etix/mirrorbits) to redirect download requests to an appropriate mirror based on their update status and geographical position.
 
-## 🏢 Original mirror
+## 🏢 Original mirror {#original-mirror}
 
 `mirrors.xcp-ng.org` is the base for all download links, either downloads of installation ISO images, or RPM repositories used by `yum` to download updates.
 
 Previous versions of XCP-ng used to download files directly from `https://updates.xcp-ng.org`, which since then has becomes one mirror among others (and a fallback in case of files missing from other mirrors).
 
-## 📋 List of mirrors
+## 📋 List of mirrors {#list-of-mirrors}
 
 You can check our live list of mirrors at this URL: [https://mirrors.xcp-ng.org/?mirrorstats](https://mirrors.xcp-ng.org/?mirrorstats)
 
@@ -20,7 +20,7 @@ You can check our live list of mirrors at this URL: [https://mirrors.xcp-ng.org/
 If loading this page fails due to too many redirections, just go to [https://xcp-ng.org](https://xcp-ng.org) once, then try again)
 :::
 
-## 📥 Add your mirror
+## 📥 Add your mirror {#add-your-mirror}
 
 Anyone or any entity can submit a mirror to our approval so that we add it to the list used by mirrorbits. It is a way to contribute to the XCP-ng project!
 
@@ -47,9 +47,10 @@ If one of those prerequisites is causing an issue to you as a mirror provider, t
 ### How to sync
 
 Here's how to sync from the main mirror. Adapt if syncing from another mirror.
-```
+
+<Terminal shell title="How to sync">{`
 rsync -rlptv --delete-delay updates.xcp-ng.org::repo/ /local/path/to/mirror
-```
+`}</Terminal>
 
 Note: if you sync from our main mirror, rsync access will be unlocked for your host after your application. See below.
 
@@ -104,7 +105,7 @@ Main contact: John Doe <john.doe@...>
 
 Feel free to ask any question in your application message.
 
-## 🔒 Security
+## 🔒 Security {#security}
 
 ### Context
 
@@ -129,26 +130,26 @@ Since XCP-ng 7.6, we use [GPG](https://gnupg.org/) to sign:
 Before you can use our public key to verify the authenticity of a downloaded file, you need to import it.
 
 Download the key
-```
+
+<Terminal shell title="Import the public key">{`
 wget https://xcp-ng.org/RPM-GPG-KEY-xcpng
-```
+`}</Terminal>
 
 A key is of no use if you can't trust it. So check its fingerprint.
-```
-gpg --quiet --with-fingerprint RPM-GPG-KEY-xcpng
-```
 
-Expected output:
-```
+<Terminal title="Import the public key">{`
+gpg --quiet --with-fingerprint RPM-GPG-KEY-xcpng
 pub  2048R/3FD3AC9E 2018-10-03 XCP-ng Key (XCP-ng Official Signing Key) <security@xcp-ng.org>
       Key fingerprint = 34AC 2EB6 8248 FED6 D076  838A CD75 783A 3FD3 AC9E
 sub  2048R/2EB0DF19 2018-10-03
-```
+`}</Terminal>
 
 If your version of gpg doesn't display fingerprints anymore, try instead:
-```
+
+<Terminal shell title="Import the public key">{`
 gpg --import --import-options show-only RPM-GPG-KEY-xcpng
-```
+`}</Terminal>
+
 with expected output:
 ```
 pub   rsa2048 2018-10-03 [SC]
@@ -163,24 +164,23 @@ you can also check that the fingerprint stored in our GitHub repository is the s
 (and in case you think someone might have altered the above link, check that the repository does actually belong to the XCP-ng project).
 
 Now import the key with `gpg`:
-```
+
+<Terminal shell title="Import the public key">{`
 gpg --import RPM-GPG-KEY-xcpng
-```
+`}</Terminal>
 
 #### Check a downloaded file
 The signature for `somefile` is stored in `somefile.asc`. Download both, then:
-```
-gpg --verify somefile.asc somefile
-```
 
-Expected output:
-```
+<Terminal title="Check a downloaded file">{`
+gpg --verify somefile.asc somefile
 # gpg: Signature made Wed 10 Oct 2018 12:50:06 PM CEST using RSA key ID 3FD3AC9E
 # gpg: Good signature from "XCP-ng Key (XCP-ng Official Signing Key) <security@xcp-ng.org>"
 # gpg: WARNING: This key is not certified with a trusted signature!
 # gpg:          There is no indication that the signature belongs to the owner.
 # Primary key fingerprint: 34AC 2EB6 8248 FED6 D076  838A CD75 783A 3FD3 AC9E
-```
+`}</Terminal>
+
 Only the date should change depending on the date of signature. **`Good Signature`** is what tells us that the verification is successful. The warning is also expected because the signing key itself is not signed and we've not setup a list of trusted sources on the computer, so there's no way for gpg to tell if the key is to be trusted or not.
 
 #### Check an ISO image
@@ -189,14 +189,16 @@ In this example we will first check the authenticity of the SHA256SUMS file, the
 First: import the GPG key if not done already (see above).
 
 Verify the authenticity of the `SHA256SUMS` file.
-```
+
+<Terminal shell title="Check an ISO image">{`
 gpg --verify SHA256SUMS.asc SHA256SUMS
-```
+`}</Terminal>
 
 Now that we trust the authenticity of the `SHA256SUMS` file, let's check the integrity of the `.iso` file.
-```
+
+<Terminal shell title="Check an ISO image">{`
 LC_ALL=C sha256sum -c SHA256SUMS 2>&1 | grep OK
-```
+`}</Terminal>
 
 It should display:
 ```
@@ -210,21 +212,24 @@ This is exactly the same as for the `.iso` file above: we provided a `SHA256SUMS
 First: import the GPG key if not done already. You can follow the steps above, but if you are on an XCP-ng 7.6 or newer, you can take a shortcut because the key file is already on your system: `gpg --import /etc/pki/rpm-gpg/RPM-GPG-KEY-xcpng`
 
 Example with `xcp-ng-7.6.repo`:
-```
+
+<Terminal shell title="Check a repository (.repo) file">{`
 wget https://updates.xcp-ng.org/7/xcp-ng-7.6.repo -O xcp-ng-7.6.repo
 wget https://updates.xcp-ng.org/7/SHA256SUMS -O SHA256SUMS
 wget https://updates.xcp-ng.org/7/SHA256SUMS.asc -O SHA256SUMS.asc
-```
+`}</Terminal>
 
 Verify the authenticity of the `SHA256SUMS` file.
-```
+
+<Terminal shell title="Check a repository (.repo) file">{`
 gpg --verify SHA256SUMS.asc SHA256SUMS
-```
+`}</Terminal>
 
 Now that we trust the authenticity of the `SHA256SUMS` file, let's check the integrity of the `.repo` file.
-```
+
+<Terminal shell title="Check a repository (.repo) file">{`
 LC_ALL=C sha256sum -c SHA256SUMS 2>&1 | grep OK
-```
+`}</Terminal>
 
 It should display:
 ```

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -14,7 +14,7 @@ The goal of this document is to give you a hint of what's next. However, since a
 
 If you have any suggestion, feel free to ask on our [community forum](https://xcp-ng.org/forum/category/1/feedback-and-requests).
 
-## 🏗️ In tech preview
+## 🏗️ In tech preview {#in-tech-preview}
 
 _Technology that is here, but not officially released for production usage._
 
@@ -25,7 +25,7 @@ _Technology that is here, but not officially released for production usage._
 * SPDK-based `blkif` backend (platform)
 * SMAPIv3 evolution (storage)
 
-## 👷 In progress
+## 👷 In progress {#in-progress}
 
 _Things we started to work on, but are not usable or visible yet._
 
@@ -40,14 +40,14 @@ _Things we started to work on, but are not usable or visible yet._
 
 * LACP support during install (platform)
 
-## 🥼 Spec/Design/PoC
+## 🥼 Spec/Design/PoC {#specdesignpoc}
 
 _Features that are being discussed or designed, but not even partly coded._
 
 * [xenopsd-ng](https://github.com/xcp-ng/xenopsd-ng) (Xen)
 * Virtio support (platform)
 
-## 🏁 Done
+## 🏁 Done {#done}
 
 * SMAPIv3 full ZFS driver
 * Faster Xen Motion (compression in `xenops`?)
@@ -79,7 +79,7 @@ _Features that are being discussed or designed, but not even partly coded._
 * Upgrade detection and upgrade with updater plugin (2018)
 * Extra package repo (2018)
 
-## 🗃️ Backlog
+## 🗃️ Backlog {#backlog}
 
 _This is a kind of wish list, without any priorities, where we try to put some ideas._
 

--- a/docs/project/security.md
+++ b/docs/project/security.md
@@ -6,7 +6,7 @@ We are using Xen as our core hypervisor engine, which is a huge collaboration pr
 
 Because XCP-ng is made of a lot of various components, we are relying on multiple sources to improve the security and fixing flaws.
 
-## 🐼 Xen Project security
+## 🐼 Xen Project security {#xen-project-security}
 
 XCP-ng project is member of the Xen Predisclosure list since 2018, which is including a lot of huge cloud players, but also companies working in critical IT security, industries and so on. The whole list is public and [available here](https://xenproject.org/developers/security-policy/#organizations-on-the-pre-disclosure-list), where you can see our name.
 
@@ -36,12 +36,12 @@ XSAs are "Xen Security Advisory". They are -in general- linked to a CVE. You can
 ![Xen Fu Panda, sitting, with a straw hat and a bamboo stick.](../../assets/img/xenpanda.png)
 </div>
 
-## 🚀 Platform security
+## 🚀 Platform security {#platform-security}
 
 XCP-ng code base is close to Citrix Hypervisor, and for that reason, we are integrating Citrix security patches very quickly into XCP-ng. We are also posting very often updates and explanation on each security patches available. You can see this list at this place: [https://xcp-ng.org/blog/tag/security/](https://xcp-ng.org/blog/tag/security/)
 
 However, it's more and more plausible that flaws might be discovered first on XCP-ng instead of Citrix Hypervisor. In that case, please see below.
 
-## 🔒 Report a security flaw
+## 🔒 Report a security flaw {#report-a-security-flaw}
 
 To ensure an efficient security process for XCP-ng, we are open to security reports with our dedicated email: security at this domain name.

--- a/docs/releases/release-8-1.md
+++ b/docs/releases/release-8-1.md
@@ -8,11 +8,11 @@ sidebar_class_name: hidden
 XCP-ng 8.1 is EOL (End Of Life) since 2021. Please check the [currently supported release(s)](releases.md).
 :::
 
-**XCP-ng 8.1** is a [standard release](../#-standard-release). [Download the installation ISO](https://mirrors.xcp-ng.org/isos/8.1/xcp-ng-8.1.0-2.iso?https=1).
+**XCP-ng 8.1** is a [standard release](../#standard-release). [Download the installation ISO](https://mirrors.xcp-ng.org/isos/8.1/xcp-ng-8.1.0-2.iso?https=1).
 
 SHA256 checksums, GPG signatures and net-install ISO are available [here](http://mirrors.xcp-ng.org/isos/8.1/).
 
-## Release information
+## ℹ️ Release information {#release-information}
 
 * Released on 2020-03-31.
 * Based on Citrix Hypervisor 8.1.
@@ -20,10 +20,10 @@ SHA256 checksums, GPG signatures and net-install ISO are available [here](http:/
 * [Xen 4.13](https://wiki.xenproject.org/wiki/Xen_Project_4.13_Feature_List).
 * Kernel 4.19, with patches. Latest kernel hotfix from CH 8.1 at the date of release included in the release.
 
-## Install
+## 💿 Install {#install}
 See [Installation](../../installation/install-xcp-ng).
 
-## Upgrade from previous releases
+## ⬆️ Upgrade from previous releases {#upgrade-from-previous-releases}
 
 Since XCP-ng 8.1.0 is a minor release, both upgrade methods are supported:
 * From the installation ISO
@@ -31,7 +31,7 @@ Since XCP-ng 8.1.0 is a minor release, both upgrade methods are supported:
 
 Refer to the [Upgrade Howto](../../installation/upgrade).
 
-## What changed since 8.0
+## ✨ What changed since 8.0 {#what-changed-since-80}
 
 ### Highlight from Citrix Hypervisor changes
 
@@ -79,7 +79,7 @@ For more information and use cases, you can check [this Devblog](https://xen-orc
 
 Our installer now offers two new installation options. In legacy boot mode, access them with F2 when offered the choice. In UEFI mode, see the added boot menu entries.
 * First new option: boot the installer with a 2G RAM limit instead of the 8G default. This is a workaround for installation issues on hardware with Ryzen CPUs. Though those are Desktop-class CPUs and not supported officially in the HCL, we tried to make it easier to workaround the infamous "installer crashes on Ryzen" issue.
-* Second new option: boot the installer with our [alternate kernel](../../installation/hardware#-alternate-kernel) (kernel-alt). That kernel, built and maintained by @r1 for the team, is based on the main kernel, with all upstream kernel.org patches from the LTS 4.19 branch applied.It should be very stable by construction **but it receives less testing**. That option is there for cases when the main kernel and drivers have issues, so that you can quickly test if kernel.org patches have fixed it already. It will also install the alternate kernel in addition to the main kernel as a convenience. **If kernel-alt fixes issues for you, the most important thing to do is to tell us so that we may fix the main kernel!**
+* Second new option: boot the installer with our [alternate kernel](../../installation/hardware#alternate-kernel) (kernel-alt). That kernel, built and maintained by @r1 for the team, is based on the main kernel, with all upstream kernel.org patches from the LTS 4.19 branch applied.It should be very stable by construction **but it receives less testing**. That option is there for cases when the main kernel and drivers have issues, so that you can quickly test if kernel.org patches have fixed it already. It will also install the alternate kernel in addition to the main kernel as a convenience. **If kernel-alt fixes issues for you, the most important thing to do is to tell us so that we may fix the main kernel!**
 
 ### New leaf coalesce logic with dynamic limits
 
@@ -90,7 +90,7 @@ Those interested in the patches, see [this commit](https://github.com/xcp-ng-rpm
 ### Changes regarding our specific packages
 
 * ZFS updated to 0.8.3.
-* [Alternate kernel](../../installation/hardware#-alternate-kernel) updated to version 4.19.108. Installing it now automatically adds a new boot entry in grub's configuration, to make testing easier. Default entry remains that of the main kernel.
+* [Alternate kernel](../../installation/hardware#alternate-kernel) updated to version 4.19.108. Installing it now automatically adds a new boot entry in grub's configuration, to make testing easier. Default entry remains that of the main kernel.
 * `netdata-ui` still available from our repositories and also as a feature in Xen Orchestra.
   * r1 contributed a fix to netdata project to bring support for Xen 4.13
   * stormi made netdata cache be RAM-only to workaround an upstream bug that could make the disk cache grow forever
@@ -107,7 +107,7 @@ However we have updated the [documentation about the guest tools](../../../vms),
 
 * Fixed netxtreme drivers (`bnx2x` module) that crashed with some models.
 
-## Misc
+## ⛑️ Misc {#misc}
 
 ### Announcement about our former experimental ext4 SR driver
 
@@ -154,7 +154,7 @@ See "Destroy and re-create a local SR" below.
     * Example: `xe sr-create type=ext name-label="Local EXT storage" host-uuid=c9800783-5202-4ccb-87fd-ff8ced6c935f device-config:device=/dev/sdb`
 * When you have handled all the servers of the pool, then for each host, if you had installed the `sm-additional-drivers` package, remove it (unless you also have XFS SRs): `yum remove sm-additional-drivers xfsprogs`.
 
-## Known issues
+## 🐞 Known issues {#known-issues}
 
 ### Host unreachable - NVIDIA GPU
 

--- a/docs/releases/release-8-2.md
+++ b/docs/releases/release-8-2.md
@@ -15,10 +15,10 @@ XCP-ng 8.2 is an [LTS Release](../#xcp-ng-release-history). [Download the instal
 SHA256 checksums, GPG signatures and net-install ISO are available [here](https://xcp-ng.org/#easy-to-install).
 
 :::info
-LTS means **Long Term Support**: more information in [this section](../#-lts-releases).
+LTS means **Long Term Support**: more information in [this section](../#lts-releases).
 :::
 
-## Release information
+## ℹ️ Release information {#release-information}
 
 * Released on 2020-11-18
 * Based on Citrix Hypervisor 8.2
@@ -27,11 +27,11 @@ LTS means **Long Term Support**: more information in [this section](../#-lts-rel
 * Kernel 4.19 + patches
 * Supported until 2025-09-16 (The initial EOL date was 2025-06-05, and we extended it to provide more time to upgrade to XCP-ng 8.3 LTS)
 
-## Install
+## 💿 Install {#install}
 
 See [Installation](../../../installation/install-xcp-ng).
 
-## Upgrade from previous releases
+## ⬆️ Upgrade from previous releases {#upgrade-from-previous-releases}
 
 Despite being an LTS, you can upgrade from previous releases. Both upgrade methods are supported:
 * From the installation ISO
@@ -39,7 +39,7 @@ Despite being an LTS, you can upgrade from previous releases. Both upgrade metho
 
 Refer to the [Upgrade Howto](../../../installation/upgrade).
 
-## What changed since 8.1
+## ✨ What changed since 8.1 {#what-changed-since-81}
 
 ### Highlight from Citrix Hypervisor changes
 
@@ -110,7 +110,7 @@ Not really a change from XCP-ng 8.1, but rather a change from Citrix Hypervisor 
 ### Other changes
 
 * We replaced Citrix's `gpumon` package, not built by us, by a mock build of `gpumon` sources, without the proprietary nvidia developer kit. For you as users, this changes nothing. For us, it means getting rid of a package that was not built by the XCP-ng build system.
-* [Alternate kernel](../../installation/hardware#-alternate-kernel) updated to version 4.19.142.
+* [Alternate kernel](../../installation/hardware#alternate-kernel) updated to version 4.19.142.
 * Intel's `e1000e` driver updated to version 3.8.4 in order to support more devices.
 * Cisco's `enic` and `fnic` drivers updated to offer better device support and compatibility.
 * `rsyslog` (logging daemon) synced from latest CentOS 7.8 security and bugfix update because several memory leaks have been patched in it.
@@ -123,7 +123,7 @@ Not really a change from XCP-ng 8.1, but rather a change from Citrix Hypervisor 
 * `zfs` updated to 0.8.5
 * `glusterfs` 8.1 added to the XCP-ng repositories
 * New [additional driver package](../../management/additional-packages): `r8125-module`, for the `r8125` Realtek device driver.
-* [Alternate driver package](../../installation/hardware#-alternate-drivers) `intel-igb-alt` updated to version 5.4.6.
+* [Alternate driver package](../../installation/hardware#alternate-drivers) `intel-igb-alt` updated to version 5.4.6.
 
 ### Misc
 
@@ -132,7 +132,7 @@ Not really a change from XCP-ng 8.1, but rather a change from Citrix Hypervisor 
 The community-maintained XCP-ng Center client is [now available for download](https://github.com/xcp-ng/xenadmin/releases/tag/v20.04.01.33). However, it is not a recommended client to use because it was modified for 8.2 support without any specific QA or validation. Keep in mind that the officially supported clients - all fully Open Source - are [documented on this page](../../management).
 
 :::note
-Although we host XCP-ng Center on our GitHub organisation and authorized its contributors to use the XCP-ng logo, we remind our users that - as documented [in the official docs](../../management#-local-management) and on its [download page](https://github.com/xcp-ng/xenadmin/releases) - **XCP-ng Center is not officially supported by the XCP-ng project**.
+Although we host XCP-ng Center on our GitHub organisation and authorized its contributors to use the XCP-ng logo, we remind our users that - as documented [in the official docs](../../management#local-management) and on its [download page](https://github.com/xcp-ng/xenadmin/releases) - **XCP-ng Center is not officially supported by the XCP-ng project**.
 :::
 
 #### Transition to the new ZFS SR driver
@@ -161,7 +161,7 @@ Plans are laid out for simpler installation and maintenance of Windows guest too
 
 Using the Windows guest tools is [documented here](/vms#windows-guest-tools).
 
-## Update: what's new in XCP-ng 8.2.1
+## 🆕 Update: what's new in XCP-ng 8.2.1 {#update-whats-new-in-xcp-ng-821}
 
 XCP-ng 8.2.1 was released as a maintenance update for XCP-ng 8.2 LTS, which has its own version number because it also comes with updated installation images.
 
@@ -171,7 +171,7 @@ The update brought a few enhancements such as [Guest Secure Boot](../../guides/g
 
 They are detailed in the [Release announcement for XCP-ng 8.2.1](https://xcp-ng.org/blog/2022/02/28/xcp-ng-8-2-1-update/).
 
-## Known issues
+## 🐞 Known issues {#known-issues}
 
 ### `yum update` from within a VNC console
 

--- a/docs/releases/release-8-3.md
+++ b/docs/releases/release-8-3.md
@@ -5,15 +5,15 @@ sidebar_position: 1
 # XCP-ng 8.3 LTS
 
 
-XCP-ng 8.3 is an [LTS Release](../#-lts-releases). [Download the installation ISO](https://mirrors.xcp-ng.org/isos/8.3/xcp-ng-8.3.0-20250606.2.iso?https=1).
+XCP-ng 8.3 is an [LTS Release](../#lts-releases). [Download the installation ISO](https://mirrors.xcp-ng.org/isos/8.3/xcp-ng-8.3.0-20250606.2.iso?https=1).
 
 SHA256 checksums, GPG signatures, and the net-install ISO are available [here](https://xcp-ng.org/#easy-to-install).
 
 :::info
-LTS means **Long Term Support**: more information in [this section](../#-lts-releases).
+LTS means **Long Term Support**: more information in [this section](../#lts-releases).
 :::
 
-## Structure of the document
+## 🗺️ Structure of the document {#structure-of-the-document}
 
 * [Release information](#release-information)
 * [What's new](#whats-new)
@@ -22,7 +22,7 @@ LTS means **Long Term Support**: more information in [this section](../#-lts-rel
 * [Attention points](#attention-points) - Highly recommended read before upgrading.
 * [Known issues](#known-issues)
 
-## Release information
+## ℹ️ Release information {#release-information}
 
 For this release, the product lifecycle has changed:
 * A longer preview phase, enabling broad user feedback, now ended.
@@ -38,11 +38,11 @@ Key details:
 * LTS since 2025-06-16.
 * Supported until 2028-11-30.
 
-## Install
+## 💿 Install {#install}
 
 See [Installation](../../../installation/install-xcp-ng).
 
-## Upgrade from previous releases
+## ⬆️ Upgrade from previous releases {#upgrade-from-previous-releases}
 
 Upgrading to XCP-ng 8.3 is possible from:
 - An up-to-date XCP-ng 8.2.1 (recommended)
@@ -62,7 +62,7 @@ Refer to the [Upgrade How-to](../../../installation/upgrade) for the exact upgra
 Users who installed a prerelease of XCP-ng 8.3 must upgrade to the final 8.3.0 version using the installation ISO image. The only exception is for users who installed XCP-ng 8.3 RC2 or have already upgraded to RC2 using the installation ISO image. These users can simply [update their system](../../management/updates) without needing the ISO image.
 :::
 
-## What's new
+## ✨ What's new {#whats-new}
 
 XCP-ng 8.3 is the result of years of development on XCP-ng, XenServer, and common open-source foundations such as the Xen Project.
 
@@ -227,9 +227,10 @@ Now it's simpler:
 To enhance security, it is now possible to close TCP port 80 on the management interface. By default, port 80 remains open for specific clients that may still require it, but all internal connections now utilize HTTPS. Previously, VM migration occurred over port 80, but this has been updated.
 
 To close port 80, run the following command:
-```
+
+<Terminal shell title="root@xcp-ng-host — Restricted use of port 80 [XS]">{`
 xe pool-param-set uuid=<pool-uuid> https-only=true
-```
+`}</Terminal>
 
 ### Improvements in the installer
 
@@ -346,13 +347,13 @@ We've also invested heavily in test automation to improve coverage. Nevertheless
 
 [Additional packages](../../management/additional-packages) are packages made available by the XCP-ng team directly in our RPM repositories, for easy installation and update on XCP-ng hosts.
 
-- [Alternate kernel](../../installation/hardware#-alternate-kernel) updated to version 4.19.316 (as of XCP-ng 8.3 release).
-- New [alternate driver packages](../../installation/hardware#-alternate-drivers): `intel-i40e-alt`, `intel-ice-alt`, `tg3-module-alt`, and `mlx4-modules-alt`. Various other alternate driver packages were also updated. See [XCP-ng Drivers](https://github.com/xcp-ng/xcp/wiki/Drivers).
+- [Alternate kernel](../../installation/hardware#alternate-kernel) updated to version 4.19.316 (as of XCP-ng 8.3 release).
+- New [alternate driver packages](../../installation/hardware#alternate-drivers): `intel-i40e-alt`, `intel-ice-alt`, `tg3-module-alt`, and `mlx4-modules-alt`. Various other alternate driver packages were also updated. See [XCP-ng Drivers](https://github.com/xcp-ng/xcp/wiki/Drivers).
 - `zfs` updated to version 2.1.15. ⚠️ Existing ZFS pools may need to be upgraded using `zpool upgrade`. Check ZFS documentation.
 - `netdata` updated to version 1.44.3.
 - `lsscsi` added to the XCP-ng repositories.
 
-## Status of XOSTOR in XCP-ng 8.3
+## 🗄️ Status of XOSTOR in XCP-ng 8.3 {#status-of-xostor-in-xcp-ng-83}
 
 As of the initial release, XOSTOR (our hyperconverged storage solution based on LINSTOR) was available in XCP-ng 8.3 but was still considered **beta**.
 
@@ -360,7 +361,7 @@ Since 2025-06-16, XOSTOR is officially supported on XCP-ng 8.3, as long as it is
 
 A [specific upgrade process](../../xostor/#upgrade) is available for pools running XCP-ng 8.2.1 with XOSTOR.
 
-## Deprecations and removals
+## 🗑️ Deprecations and removals {#deprecations-and-removals}
 
 ### PV virtualization mode
 
@@ -437,7 +438,7 @@ So here it's not really a removal. XenServer replaced the component used for Act
 
 We deleted the old, unsupported since XCP-ng 8.1, experimental EXT4 driver, superseded by the regular EXT driver (which also uses `ext4`). We're talking about an old experimental driver that you never used unless you installed the experimental packages in the XCP-ng 7.x era, so this removal is painless for the vast majority of XCP-ng users, if not all!
 
-## Attention points
+## ⚠️ Attention points {#attention-points}
 
 Important changes or adjustments that may affect how you use the product. Be sure to review these to avoid unexpected behavior.
 
@@ -488,7 +489,7 @@ You will also need to disable Secure Boot in the VM settings if it was enforced.
 
 See [Active Directory in XCP-ng](#active-directory-in-xcp-ng).
 
-## Known issues
+## 🐞 Known issues {#known-issues}
 
 ### IPv6-related issues
 

--- a/docs/releases/releases.md
+++ b/docs/releases/releases.md
@@ -1,6 +1,6 @@
 # Releases
 
-## XCP-ng Release History
+## 📜 XCP-ng Release History {#xcp-ng-release-history}
 
 | Version                   | Released   | Status               | Support until                                | Release notes                        |
 | ---                       | ---        | ---                  | ---                                          | ---                                  |
@@ -14,7 +14,7 @@
 
 (*) Support for XCP-ng 8.2 LTS was extended for a short period to ensure a three-month gap between the official LTS release of XCP-ng 8.3 and the end of support for XCP-ng 8.2 LTS.
 
-## 🟢 LTS Releases
+## 🟢 LTS Releases {#lts-releases}
 
 *Latest LTS: [XCP-ng 8.3](release-8-3.md)*
 
@@ -47,7 +47,7 @@ gantt
     XCP-ng 8.2 LTS         :2024-08-30, 1y
 ```
 
-## 🟡 Standard Release
+## 🟡 Standard Release {#standard-release}
 
 *Latest: [XCP-ng 8.3](release-8-3.md) (somehow)*
 
@@ -59,7 +59,7 @@ Using the standard release is recommended if:
 
 Standard releases are supported until the next release, plus a few additional months to allow time for transitioning. Check the support dates [in the table above](#xcp-ng-release-history).
 
-If you prefer a more conservative approach, consider choosing our [LTS release](#-lts-releases).
+If you prefer a more conservative approach, consider choosing our [LTS release](#lts-releases).
 
 :::note
 XCP-ng 8.3 is special, as it started as a standard release, then became as announced a LTS release in June 2025.
@@ -68,7 +68,7 @@ XCP-ng 9.0 might follow the same path.
 :::
 
 
-## 🔴 Pre Releases
+## 🔴 Pre Releases {#pre-releases}
 
 Using a pre-release is relevant only for testing purposes. Check [the `Release` tag on our blog](https://xcp-ng.org/blog/tag/release/) for (pre-)release announcements.
 

--- a/docs/storage/manage-srs.md
+++ b/docs/storage/manage-srs.md
@@ -1,0 +1,245 @@
+---
+sidebar_position: 2
+---
+
+# SR and VDI management
+
+Everyday operations on storage repositories (SRs) and virtual disks (VDIs): renaming, detaching, reattaching, growing, moving disks between SRs and reclaiming space.
+
+:::tip
+All of these operations are available from [Xen Orchestra](../management/manage-at-scale/xo-web-ui.md) with a few clicks (SR view and VM → Disks tab). The `xe` commands are given for scripting, troubleshooting, or when you work directly on a host.
+:::
+
+## 🎓 Quick recap of the objects {#quick-recap-of-the-objects}
+
+* **SR** (Storage Repository): where virtual disks live.
+* **VDI** (Virtual Disk Image): one virtual disk.
+* **PBD** (Physical Block Device): the *connection* between one host and one SR: how the host accesses the storage.
+* **VBD** (Virtual Block Device): the *connection* between a VDI and a VM.
+
+<Schema label="Storage object model · PBDs connect hosts to SRs, VBDs connect VDIs to VMs" legend={[["#4a90e2", "host side"], ["#56c288", "VM side"]]} maxWidth="680px">
+<svg viewBox="0 0 620 240" role="img" aria-label="Two hosts each connect to the shared SR through their own PBD; inside the SR live VDIs, and each VDI is attached to a VM through a VBD">
+  <g fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.28)">
+    <rect x="20" y="24" width="130" height="50" rx="8"/>
+    <rect x="20" y="160" width="130" height="50" rx="8"/>
+    <rect x="240" y="20" width="180" height="200" rx="8"/>
+    <rect x="470" y="24" width="130" height="50" rx="8"/>
+    <rect x="470" y="160" width="130" height="50" rx="8"/>
+  </g>
+  <g fontSize="12.5" fill="#c6d2e1" textAnchor="middle">
+    <text x="85" y="53">host 1</text>
+    <text x="85" y="189">host 2</text>
+    <text x="535" y="49">VM A</text>
+    <text x="535" y="185">VM B</text>
+  </g>
+  <text x="330" y="44" fontSize="13" fill="#c6d2e1" textAnchor="middle">SR</text>
+  <text x="330" y="60" fontSize="10" fill="#7a8699" textAnchor="middle">storage repository</text>
+  <g fill="rgba(86,194,136,0.14)" stroke="#56c288" strokeOpacity="0.8">
+    <rect x="262" y="76" width="136" height="34" rx="5"/>
+    <rect x="262" y="120" width="136" height="34" rx="5"/>
+    <rect x="262" y="164" width="136" height="34" rx="5"/>
+  </g>
+  <g fontSize="11" fill="#56c288" textAnchor="middle">
+    <text x="330" y="97">VDI · system disk A</text>
+    <text x="330" y="141">VDI · data disk A</text>
+    <text x="330" y="185">VDI · system disk B</text>
+  </g>
+  <g stroke="#4a90e2" strokeWidth="1.6" fill="none">
+    <path d="M150 49 C 190 49, 200 90, 238 100"/>
+    <path d="M150 185 C 190 185, 200 160, 238 150"/>
+  </g>
+  <g fontSize="10.5" fill="#4a90e2">
+    <text x="168" y="52">PBD</text>
+    <text x="168" y="196">PBD</text>
+  </g>
+  <g stroke="#56c288" strokeWidth="1.6" fill="none">
+    <path d="M398 93 C 430 93, 440 49, 468 49"/>
+    <path d="M398 137 C 430 137, 445 60, 468 55"/>
+    <path d="M398 181 C 430 181, 440 185, 468 185"/>
+  </g>
+  <g fontSize="10.5" fill="#56c288">
+    <text x="428" y="80">VBD</text>
+    <text x="430" y="130">VBD</text>
+    <text x="428" y="200">VBD</text>
+  </g>
+</svg>
+</Schema>
+
+More details in the [storage overview](storage.md) and in the [architecture page](../project/architecture.md#storage).
+
+## 📇 SR operations {#sr-operations}
+
+### Rename an SR
+
+<Terminal shell title="root@xcp-ng-host — Rename an SR">{`
+xe sr-param-set uuid=<sr-uuid> name-label="New name"
+`}</Terminal>
+
+### Choose the default SR
+
+The default SR of a pool is where new disks land when no SR is explicitly chosen (and where suspend/crash dump data goes):
+
+<Terminal shell title="root@xcp-ng-host — Choose the default SR">{`
+xe pool-param-set uuid=<pool-uuid> default-SR=<sr-uuid>
+`}</Terminal>
+
+### Rescan an SR
+
+A scan refreshes XAPI's view of the SR contents (e.g. after copying a VHD/QCOW2 file into a file-based SR, or to trigger garbage collection):
+
+<Terminal shell title="root@xcp-ng-host — Rescan an SR">{`
+xe sr-scan uuid=<sr-uuid>
+`}</Terminal>
+
+### Detach an SR (keep the data)
+
+Detaching unplugs the SR from the hosts without touching its contents. VMs using it must be shut down first.
+
+<Terminal shell title="root@xcp-ng-host — Detach an SR (keep the data)">{`
+xe pbd-list sr-uuid=<sr-uuid>            # one PBD per host
+xe pbd-unplug uuid=<pbd-uuid>            # repeat for each PBD
+xe sr-forget uuid=<sr-uuid>              # remove the SR from the pool database
+`}</Terminal>
+
+`sr-forget` only removes the SR *record*; the data stays on the storage and the SR can be reattached later, here or on another pool.
+
+### Reattach a forgotten SR
+
+Reintroduce the SR under its original UUID, then recreate a PBD per host with the right `device-config` for your storage type, and plug them:
+
+<Terminal shell title="root@xcp-ng-host — Reattach a forgotten SR">{`
+xe sr-introduce uuid=<original-sr-uuid> type=nfs name-label="My NFS SR" content-type=user
+xe pbd-create host-uuid=<host-uuid> sr-uuid=<original-sr-uuid> device-config:server=<ip> device-config:serverpath=<path>
+xe pbd-plug uuid=<pbd-uuid>
+`}</Terminal>
+
+The `device-config` keys depend on the SR type (`server`/`serverpath` for NFS, `target`/`targetIQN`/`SCSIid` for iSCSI…). If you're not sure about the values, look at an existing PBD of the same kind with `xe pbd-param-list`, or probe the storage with `xe sr-probe`. The same PBD destroy/recreate logic is used to [modify an existing SR connection](storage.md#how-to-modify-an-existing-sr-connection).
+
+### Destroy an SR
+
+:::warning
+`sr-destroy` **erases the SR contents** on the storage side (formats the disk/LUN). If you only want to disconnect the storage, use the detach procedure above instead.
+:::
+
+<Terminal shell title="root@xcp-ng-host — Destroy an SR">{`
+xe pbd-unplug uuid=<pbd-uuid>            # for each PBD
+xe sr-destroy uuid=<sr-uuid>
+`}</Terminal>
+
+### Grow a block-based SR after enlarging the LUN
+
+For iSCSI/HBA SRs, when you enlarge the LUN on the storage array side:
+
+1. Rescan the sessions on each host, e.g. `iscsiadm -m session --rescan` (with [multipathing](multipathing.md), also run `multipathd resize map <map>` so the multipath device picks up the new size).
+2. Run `xe sr-scan uuid=<sr-uuid>`: the SR grows to use the new space.
+
+This is done live, with no impact on running VMs.
+
+### Discover what the storage offers (probe)
+
+Before creating an SR, `sr-probe` asks the storage what's available, using the same `device-config` keys as `sr-create`. Xen Orchestra does this for you in the New SR wizard.
+
+<Terminal shell title="root@xcp-ng-host — Discover what the storage offers…">{`
+# List the IQNs of an iSCSI target, then the LUNs behind one
+xe sr-probe type=lvmoiscsi device-config:target=<ip>
+xe sr-probe type=lvmoiscsi device-config:target=<ip> device-config:targetIQN=<iqn>
+
+# List the exports of an NFS server
+xe sr-probe type=nfs device-config:server=<ip>
+`}</Terminal>
+
+The command answers in XML, listing what to feed into the next step (or into `sr-introduce` when [reattaching](#reattach-a-forgotten-sr)).
+
+## 💾 VDI operations {#vdi-operations}
+
+### Find your disks
+
+<Terminal shell title="root@xcp-ng-host — Find your disks">{`
+xe vm-disk-list vm=<vm-name-label>       # disks of one VM
+xe vdi-list sr-uuid=<sr-uuid>            # all disks on an SR
+`}</Terminal>
+
+### Create and attach a new disk to a VM
+
+From Xen Orchestra: VM → **Disks** → **New disk**. With `xe`:
+
+<Terminal shell title="root@xcp-ng-host — Create and attach a new disk to…">{`
+xe vdi-create sr-uuid=<sr-uuid> name-label="data disk" virtual-size=50GiB
+xe vbd-create vm-uuid=<vm-uuid> vdi-uuid=<vdi-uuid> device=1
+xe vbd-plug uuid=<vbd-uuid>              # hot-plug into a running VM
+`}</Terminal>
+
+### Grow a disk
+
+Disks can only be **grown**, never shrunk (see the [shrink guide](../guides/shrink_virtual_drive.md) for the copy-based workaround). From Xen Orchestra, edit the disk size in the VM's Disks tab; with `xe`:
+
+<Terminal shell title="root@xcp-ng-host — Grow a disk">{`
+xe vdi-resize uuid=<vdi-uuid> disk-size=100GiB
+`}</Terminal>
+
+Afterwards, enlarge the partition and filesystem *inside* the guest: the VM only sees a bigger disk, not a bigger filesystem.
+
+:::info
+Maximum VDI size is 2 TiB with the VHD format. Starting with XCP-ng 8.3 and the QCOW2 format, much larger disks are possible: see the [QCOW2 FAQ](qcow2_faq.md).
+:::
+
+### Move a disk to another SR
+
+* **VM halted** ("cold" migration): from Xen Orchestra, VM → Disks → migrate the VDI to another SR; works between any SR types.
+* **VM running** (live storage migration): also from the Disks tab of the running VM, or:
+
+<Terminal shell title="root@xcp-ng-host — Move a disk to another SR">{`
+xe vdi-pool-migrate uuid=<vdi-uuid> sr-uuid=<destination-sr-uuid>
+`}</Terminal>
+
+Things to know about live VDI migration:
+
+* The whole disk is copied while the VM runs, so it takes time and I/O bandwidth; the destination needs enough free space.
+* Avoid running it at the same time as a backup job on the same VM.
+* Moving a disk collapses its snapshot chain on the destination; leftover space on the source is reclaimed by the [coalesce process](storage.md#coalesce).
+
+This is also the building block of cross-pool VM migration with storage: see [VM migration](../vms/vm-migration.md).
+
+### Export / import a single disk
+
+Individual VDIs can be exported to a file and reimported (handy to move a data disk around or to keep a raw copy). From Xen Orchestra, use the disk's export button. With `xe`:
+
+<Terminal shell title="root@xcp-ng-host — Export / import a single disk">{`
+xe vdi-export uuid=<vdi-uuid> filename=disk.vhd format=vhd
+xe vdi-import uuid=<destination-vdi-uuid> filename=disk.vhd format=vhd
+`}</Terminal>
+
+(For `vdi-import`, create the destination VDI first, at least as big as the source.)
+
+## 🧹 Reclaim space {#reclaim-space}
+
+Deleting VMs, disks and snapshots frees space:
+
+* On **LVM-based SRs** (local LVM, iSCSI, HBA), the space is freed immediately at the SR level when the deletion and subsequent [coalesce](storage.md#coalesce) complete. To also tell the **storage array** that the blocks are free (thin-provisioned arrays), trigger a TRIM/UNMAP pass: in Xen Orchestra, SR view → advanced → **Reclaim space**, or:
+
+<Terminal shell title="root@xcp-ng-host — Reclaim space">{`
+xe host-call-plugin host-uuid=<host-uuid> plugin=trim fn=do_trim args:sr_uuid=<sr-uuid>
+`}</Terminal>
+
+* On **file-based SRs** (local EXT/XFS, NFS…), disk files are sparse: space returns to the filesystem once deletion and coalesce are done.
+
+If space doesn't come back after deleting snapshots, the coalesce process probably hasn't finished (or is stuck): see the [coalesce section](storage.md#coalesce) to check its status.
+
+## ⚙️ Disk I/O tuning {#disk-io-tuning}
+
+The dom0 I/O scheduler used for an SR's physical devices can be changed if you have a specific workload profile (default is fine for most cases):
+
+<Terminal shell title="root@xcp-ng-host — Disk I/O tuning">{`
+xe sr-param-set uuid=<sr-uuid> other-config:scheduler=noop
+`}</Terminal>
+
+Replug the SR's PBDs (or reboot) for the change to take effect. `noop` is generally the best choice on flash storage and smart arrays.
+
+Individual disks can also be prioritized against each other (only meaningful on local storage, with a scheduler that honors priorities):
+
+<Terminal shell title="root@xcp-ng-host — Disk I/O tuning">{`
+xe vbd-param-set uuid=<vbd-uuid> qos_algorithm-type=ionice
+xe vbd-param-set uuid=<vbd-uuid> qos_algorithm-params:sched=be qos_algorithm-params:class=2
+`}</Terminal>
+
+`sched` accepts `rt` (real-time), `be` (best-effort) or `idle`; `class` ranks 0 (highest) to 7 within `rt`/`be`. Replug the VBD to apply.

--- a/docs/storage/multipathing.md
+++ b/docs/storage/multipathing.md
@@ -1,18 +1,22 @@
 ---
-sidebar_position: 1
+sidebar_position: 3
 ---
 
 # Multipathing
 
 How to properly setup a new SR with multipathing on Xen Orchestra and XCP-ng.
 
+Multipathing uses several independent network or SAN paths between each host and the storage unit. It is the recommended setup for iSCSI and Fibre Channel SRs: a path failure (NIC, cable, switch, controller) doesn't interrupt storage traffic, and total throughput can be higher.
+
+What requires care is *when* you enable it, not whether you should:
+
 :::warning
-Do not attempt to enable multipathing on a production pool with existing and active iSCSI and/or HBA and/or FC SRs.
+Do not attempt to enable multipathing on a production pool with existing and active iSCSI and/or HBA and/or FC SRs: the device topology changes when multipathing takes over, which must not happen under active I/O. Enable it **before** creating these SRs.
 
 You can activate it on the "fly", per XCP-ng host (Advanced tab), but it is recommended to do so with XCP-ng hosts that have no VMs running.
 :::
 
-## iSCSI
+## 🌐 iSCSI {#iscsi}
 
 ### Requirements
 * Two different network interfaces.
@@ -21,9 +25,7 @@ You can activate it on the "fly", per XCP-ng host (Advanced tab), but it is reco
 * iSCSI target ports are operating in portal mode.
 
 :::info
-If the storage vendor recommends using Jumbo Frames, you will need to implement them.
-
-Since each architecture is unique, feel free to check with the storage vendor if it’s possible to stay with an MTU of 1500 (e.g., using storage dedicated PIF at 10Gb/s or 25Gb/s).
+Keep the default MTU (1500) on your storage networks. Non-standard MTUs are a frequent source of hard-to-diagnose storage issues, for little to no gain on modern networks: see [MTUs](../networking/networking.md#mtus).
 :::
 
 :::warning
@@ -43,94 +45,61 @@ This could have an impact on expected performance.
 | 🟢 | 422 | 10.42.2.0/24 | 10.42.2.11 | 10.42.2.101 | 10.42.2.102 |
 
 #### Target architecture diagram
-```mermaid
----
-config:
-  look: normal
-  theme: default
----
-flowchart LR
-  classDef blueNode fill:#A7C8F0,stroke:#2C6693,color:#000000;
-  classDef greenNode fill:#A8E6A2,stroke:#3E8E41,color:#000000;
-  classDef grayNode fill:#D6D6D6,stroke:#8C8C8C,color:#000000;
 
-  subgraph server[XCP-ng host]
-    direction LR
-    subgraph Card1[Network cards]
-        direction RL
-        card1pif1[pif1]
-        card1pif2[pif2]
-        card2pif1[pif4]
-        card2pif2[pif3]
-    end
-  end
-  subgraph Switch 2
-    vlan422[vlan422]:::greenNode
-  end
-  subgraph Switch 1
-    vlan421[vlan421]:::blueNode
-  end
-  subgraph storage[Storage unit]
-  direction LR
-    subgraph ctrl2[Controller 2]
-        direction RL
-        ctrl2-port1[port1]
-        ctrl2-port2[port2]
-    end
-    subgraph ctrl1[Controller 1]
-        direction RL
-        ctrl1-port1[port1]
-        ctrl1-port2[port2]
-    end
-    lun1@{ shape: lin-cyl, label: "LUN" }
-
-  end
-
-  card1-pif1-ip([10.42.1.11/24]):::blueNode
-  card1-pif2-ip([other networks]):::grayNode
-  card2-pif2-ip([10.42.2.11/24]):::greenNode
-  card2-pif1-ip([other networks]):::grayNode
-  ctrl1-port1-ip([10.42.1.101/24]):::blueNode
-  ctrl1-port2-ip([10.42.2.101/24]):::greenNode
-  ctrl2-port1-ip([10.42.1.102/24]):::blueNode
-  ctrl2-port2-ip([10.42.2.102/24]):::greenNode
-
-  card1pif1<-->card1-pif1-ip
-  card1-pif1-ip<-->vlan421
-  vlan421<-->ctrl1-port1-ip
-  ctrl1-port1-ip<-->ctrl1-port1
-  vlan421<-->ctrl2-port1-ip
-  ctrl2-port1-ip<-->ctrl2-port1
-
-  card2pif2<-->card2-pif2-ip
-  card2-pif2-ip<-->vlan422
-  vlan422<-->ctrl1-port2-ip
-  ctrl1-port2-ip<-->ctrl1-port2
-  vlan422<-->ctrl2-port2-ip
-  ctrl2-port2-ip<-->ctrl2-port2
-
-  card1pif2<-->card1-pif2-ip
-  card2pif1<-->card2-pif1-ip
-  ctrl1 <----> lun1
-  ctrl2 <----> lun1
-
-linkStyle 0 stroke:#4A90E2,stroke-width:2px;
-linkStyle 1 stroke:#4A90E2,stroke-width:2px;
-linkStyle 2 stroke:#4A90E2,stroke-width:2px;
-linkStyle 3 stroke:#4A90E2,stroke-width:2px;
-linkStyle 4 stroke:#4A90E2,stroke-width:2px;
-linkStyle 5 stroke:#4A90E2,stroke-width:2px;
-
-linkStyle 6 stroke:#5CB85C,stroke-width:2px;
-linkStyle 7 stroke:#5CB85C,stroke-width:2px;
-linkStyle 8 stroke:#5CB85C,stroke-width:2px;
-linkStyle 9 stroke:#5CB85C,stroke-width:2px;
-linkStyle 10 stroke:#5CB85C,stroke-width:2px;
-linkStyle 11 stroke:#5CB85C,stroke-width:2px;
-
-linkStyle 12 stroke:#8C8C8C,stroke-width:2px;
-linkStyle 13 stroke:#8C8C8C,stroke-width:2px;
-```
+<Schema label="iSCSI multipathing · two independent paths from host to storage" legend={[["#4a90e2", "path A · VLAN 421"], ["#56c288", "path B · VLAN 422"]]} maxWidth="560px">
+<svg viewBox="0 0 560 445" role="img" aria-label="An XCP-ng host with two NICs on top; each NIC goes through its own switch and VLAN; each switch reaches one port on each of the two storage controllers; the LUN sits below both controllers">
+  <g fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.28)">
+    <rect x="160" y="16" width="240" height="104" rx="8"/>
+    <rect x="60" y="180" width="180" height="52" rx="8"/>
+    <rect x="320" y="180" width="180" height="52" rx="8"/>
+    <rect x="50" y="290" width="460" height="140" rx="8"/>
+  </g>
+  <text x="280" y="40" fontSize="14" fill="#c6d2e1" textAnchor="middle">XCP-ng host</text>
+  <rect x="175" y="52" width="100" height="44" rx="5" fill="rgba(74,144,226,0.14)" stroke="#4a90e2" strokeOpacity="0.85"/>
+  <text x="225" y="70" fontSize="12" fill="#4a90e2" textAnchor="middle">pif1</text>
+  <text x="225" y="86" fontSize="9" fill="#7a8699" textAnchor="middle">10.42.1.11/24</text>
+  <rect x="285" y="52" width="100" height="44" rx="5" fill="rgba(86,194,136,0.14)" stroke="#56c288" strokeOpacity="0.85"/>
+  <text x="335" y="70" fontSize="12" fill="#56c288" textAnchor="middle">pif2</text>
+  <text x="335" y="86" fontSize="9" fill="#7a8699" textAnchor="middle">10.42.2.11/24</text>
+  <text x="150" y="210" fontSize="13" fill="#c6d2e1" textAnchor="middle">Switch 1</text>
+  <text x="150" y="226" fontSize="11" fill="#4a90e2" textAnchor="middle">VLAN 421 · 10.42.1.0/24</text>
+  <text x="410" y="210" fontSize="13" fill="#c6d2e1" textAnchor="middle">Switch 2</text>
+  <text x="410" y="226" fontSize="11" fill="#56c288" textAnchor="middle">VLAN 422 · 10.42.2.0/24</text>
+  <text x="66" y="420" fontSize="13" fill="#c6d2e1">Storage unit</text>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)">
+    <rect x="70" y="326" width="200" height="56" rx="6"/>
+    <rect x="290" y="326" width="200" height="56" rx="6"/>
+  </g>
+  <circle cx="120" cy="326" r="7" fill="rgba(74,144,226,0.25)" stroke="#4a90e2"/>
+  <circle cx="220" cy="326" r="7" fill="rgba(86,194,136,0.25)" stroke="#56c288"/>
+  <circle cx="340" cy="326" r="7" fill="rgba(74,144,226,0.25)" stroke="#4a90e2"/>
+  <circle cx="440" cy="326" r="7" fill="rgba(86,194,136,0.25)" stroke="#56c288"/>
+  <g fontSize="9.5" fill="#7a8699" textAnchor="middle">
+    <text x="120" y="348">.1.101</text>
+    <text x="220" y="348">.2.101</text>
+    <text x="340" y="348">.1.102</text>
+    <text x="440" y="348">.2.102</text>
+  </g>
+  <text x="170" y="372" fontSize="12" fill="#c6d2e1" textAnchor="middle">Controller 1</text>
+  <text x="390" y="372" fontSize="12" fill="#c6d2e1" textAnchor="middle">Controller 2</text>
+  <rect x="230" y="394" width="100" height="28" rx="12" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)"/>
+  <text x="280" y="412" fontSize="12" fill="#c6d2e1" textAnchor="middle">LUN</text>
+  <g stroke="rgba(255,255,255,0.35)" strokeWidth="1.4">
+    <line x1="170" y1="382" x2="230" y2="397"/>
+    <line x1="390" y1="382" x2="330" y2="397"/>
+  </g>
+  <g stroke="#4a90e2" strokeWidth="1.6" fill="none">
+    <path d="M225 96 C 225 130, 170 145, 152 178"/>
+    <path d="M150 232 C 150 265, 130 290, 120 319"/>
+    <path d="M150 232 C 160 270, 300 280, 338 319"/>
+  </g>
+  <g stroke="#56c288" strokeWidth="1.6" fill="none">
+    <path d="M335 96 C 335 130, 390 145, 408 178"/>
+    <path d="M410 232 C 410 265, 430 290, 440 319"/>
+    <path d="M410 232 C 400 270, 260 280, 222 319"/>
+  </g>
+</svg>
+</Schema>
 
 ### Operating procedure
 
@@ -186,9 +155,9 @@ If this is not the case:
 #### 3. Configure the SR
 Proceed with the iSCSI SR configuration as indicated in the [storage documentation](../../storage/#iscsi).
 
-## Fibre Channel (HBA)
+## 🧵 Fibre Channel (HBA) {#fibre-channel-hba}
 ### Requirements
-* Check that the Fibre Channel cards model(s) is supported via the [HCL](../../installation/hardware/#-hardware-compatibility-list-hcl).
+* Check that the Fibre Channel cards model(s) is supported via the [HCL](../../installation/hardware/#hardware-compatibility-list-hcl).
 * Two different Fibre Channel ports.
 * Two different SAN switches.
 * Multiple targets per LUN on your storage unit.
@@ -200,63 +169,54 @@ Make sure not to mix Fibre Channel speeds.
 
 ### Target architecture
 #### Target architecture diagram
-```mermaid
----
-config:
-  look: normal
-  theme: default
----
-flowchart LR
-  classDef blueNode fill:#A7C8F0,stroke:#2C6693,color:#000000;
-  classDef greenNode fill:#A8E6A2,stroke:#3E8E41,color:#000000;
-  classDef grayNode fill:#D6D6D6,stroke:#8C8C8C,color:#000000;
 
-  subgraph server[XCP-ng host]
-    direction LR
-    subgraph Card1[Fibre Channel]
-        direction RL
-        card1port1[port1]
-        card1port2[port2]
-    end
-  end
-
-  subgraph storage[Storage unit]
-  direction LR
-    subgraph ctrl2[Controller 2]
-        direction RL
-        ctrl2-port1[port1]
-        ctrl2-port2[port2]
-    end
-    subgraph ctrl1[Controller 1]
-        direction RL
-        ctrl1-port1[port1]
-        ctrl1-port2[port2]
-    end
-    lun1@{ shape: lin-cyl, label: "LUN" }
-
-  end
-
-  vlan421[SAN Switch 1]:::blueNode
-  vlan422[SAN Switch 2]:::greenNode
-
-  card1port1<---->vlan421
-  vlan421<---->ctrl1-port1
-  vlan421<---->ctrl2-port1
-
-  card1port2<---->vlan422
-  vlan422<---->ctrl1-port2
-  vlan422<---->ctrl2-port2
-
-  ctrl1 <----> lun1
-  ctrl2 <----> lun1
-
-linkStyle 0 stroke:#4A90E2,stroke-width:2px;
-linkStyle 1 stroke:#4A90E2,stroke-width:2px;
-linkStyle 2 stroke:#4A90E2,stroke-width:2px;
-linkStyle 3 stroke:#5CB85C,stroke-width:2px;
-linkStyle 4 stroke:#5CB85C,stroke-width:2px;
-linkStyle 5 stroke:#5CB85C,stroke-width:2px;
-```
+<Schema label="Fibre Channel multipathing · two independent fabrics from host to storage" legend={[["#4a90e2", "fabric A"], ["#56c288", "fabric B"]]} maxWidth="560px">
+<svg viewBox="0 0 560 420" role="img" aria-label="An XCP-ng host with two Fibre Channel ports on top; each port goes through its own SAN switch; each switch reaches one port on each of the two storage controllers; the LUN sits below both controllers">
+  <g fill="rgba(255,255,255,0.04)" stroke="rgba(255,255,255,0.28)">
+    <rect x="160" y="16" width="240" height="96" rx="8"/>
+    <rect x="60" y="160" width="180" height="48" rx="8"/>
+    <rect x="320" y="160" width="180" height="48" rx="8"/>
+    <rect x="50" y="266" width="460" height="140" rx="8"/>
+  </g>
+  <text x="280" y="40" fontSize="14" fill="#c6d2e1" textAnchor="middle">XCP-ng host</text>
+  <text x="280" y="56" fontSize="10" fill="#7a8699" textAnchor="middle">Fibre Channel HBA</text>
+  <rect x="180" y="66" width="90" height="30" rx="5" fill="rgba(74,144,226,0.14)" stroke="#4a90e2" strokeOpacity="0.85"/>
+  <text x="225" y="85" fontSize="12" fill="#4a90e2" textAnchor="middle">port 1</text>
+  <rect x="290" y="66" width="90" height="30" rx="5" fill="rgba(86,194,136,0.14)" stroke="#56c288" strokeOpacity="0.85"/>
+  <text x="335" y="85" fontSize="12" fill="#56c288" textAnchor="middle">port 2</text>
+  <text x="150" y="181" fontSize="13" fill="#c6d2e1" textAnchor="middle">SAN switch 1</text>
+  <text x="150" y="198" fontSize="11" fill="#4a90e2" textAnchor="middle">fabric A</text>
+  <text x="410" y="181" fontSize="13" fill="#c6d2e1" textAnchor="middle">SAN switch 2</text>
+  <text x="410" y="198" fontSize="11" fill="#56c288" textAnchor="middle">fabric B</text>
+  <text x="66" y="396" fontSize="13" fill="#c6d2e1">Storage unit</text>
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)">
+    <rect x="70" y="302" width="200" height="56" rx="6"/>
+    <rect x="290" y="302" width="200" height="56" rx="6"/>
+  </g>
+  <circle cx="120" cy="302" r="7" fill="rgba(74,144,226,0.25)" stroke="#4a90e2"/>
+  <circle cx="220" cy="302" r="7" fill="rgba(86,194,136,0.25)" stroke="#56c288"/>
+  <circle cx="340" cy="302" r="7" fill="rgba(74,144,226,0.25)" stroke="#4a90e2"/>
+  <circle cx="440" cy="302" r="7" fill="rgba(86,194,136,0.25)" stroke="#56c288"/>
+  <text x="170" y="344" fontSize="12" fill="#c6d2e1" textAnchor="middle">Controller 1</text>
+  <text x="390" y="344" fontSize="12" fill="#c6d2e1" textAnchor="middle">Controller 2</text>
+  <rect x="230" y="370" width="100" height="28" rx="12" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)"/>
+  <text x="280" y="388" fontSize="12" fill="#c6d2e1" textAnchor="middle">LUN</text>
+  <g stroke="rgba(255,255,255,0.35)" strokeWidth="1.4">
+    <line x1="170" y1="358" x2="230" y2="373"/>
+    <line x1="390" y1="358" x2="330" y2="373"/>
+  </g>
+  <g stroke="#4a90e2" strokeWidth="1.6" fill="none">
+    <path d="M225 96 C 225 125, 170 130, 152 158"/>
+    <path d="M150 208 C 150 240, 130 268, 120 295"/>
+    <path d="M150 208 C 160 246, 300 258, 338 295"/>
+  </g>
+  <g stroke="#56c288" strokeWidth="1.6" fill="none">
+    <path d="M335 96 C 335 125, 390 130, 408 158"/>
+    <path d="M410 208 C 410 240, 430 268, 440 295"/>
+    <path d="M410 208 C 400 246, 260 258, 222 295"/>
+  </g>
+</svg>
+</Schema>
 ### Operating procedure
 
 #### 1. Prepare XCP-ng hosts
@@ -312,7 +272,7 @@ If this is not the case:
 Proceed with the HBA SR configuration as indicated in the [storage documentation](../../storage/#hba).
 
 
-## Maintenance operations
+## 🔧 Maintenance operations {#maintenance-operations}
 ### Add a new XCP-ng host to an existing multipathing pool
 
 :::warning
@@ -323,7 +283,7 @@ Do not add the new XCP-ng host to the pool without completing these steps.
 2. Ensure that the iSCSI PIF configuration is completed if you are using iSCSI.
 3. Add the new XCP-ng host to the pool.
 
-## Troubleshooting
+## 🧑‍⚕️ Troubleshooting {#troubleshooting}
 
 ### Verify multipathing
 You can use the command ```multipath -ll``` to check if multipathing is active.
@@ -356,16 +316,15 @@ tcp: [4] 10.42.2.102:3260,2 iqn.2024-02.com.acme:ultrasan.lun01 (non-flash)
 In this example, we have four iSCSI sessions with one LUN.
 :::
 
-#### iSCSI: Verify Jumbo Frame configuration
-To check the Jumbo Frames configuration, connect to a XCP-ng host and try pinging all IP addresses involved in your iSCSI storage (target and initiator) using this command.
+#### iSCSI: verify MTU consistency
+An MTU mismatch between the host, the switches and the storage unit causes erratic storage behavior. To check for one, connect to a XCP-ng host and ping all IP addresses involved in your iSCSI storage (target and initiator) with a full-size, non-fragmentable packet:
 
-```
-ping -M do -s 8972 <REMOTE_IP_ADDRESS>
-```
+<Terminal shell title="iSCSI: verify MTU consistency">{`
+ping -M do -s 1472 <REMOTE_IP_ADDRESS>
+`}</Terminal>
+
+(1472 is for the standard MTU of 1500: packet size minus the 28 bytes of IP and ICMP headers. If your network uses another MTU, subtract 28 from it.)
+
 :::warning
-If you get an error, usually ```ping: sendmsg: Message too long```, your MTU settings are incorrect, and you need to fix your network configuration.
-:::
-
-:::tip
-If your storage vendor allows it, feel free to use "1500" for MTU.
+If you get an error, usually ```ping: sendmsg: Message too long```, your MTU settings are inconsistent along the path, and you need to fix your network configuration.
 :::

--- a/docs/storage/qcow2_faq.md
+++ b/docs/storage/qcow2_faq.md
@@ -1,14 +1,14 @@
 ---
-sidebar_position: 2
+sidebar_position: 4
 ---
 
 # QCOW2 FAQ
 
-## What’s QCOW2?
+## 🎓 What’s QCOW2? {#whats-qcow2}
 
 QCOW2 is the name of a virtual disk image format coming from the open source QEMU project. Contrarily to the VHD disk image format, historically used by XCP-ng, QCOW2 is not limited to 2 TiB per disk.
 
-## Quick summary
+## ⚡ Quick summary {#quick-summary}
 
 For those who will only read this.
 
@@ -18,13 +18,13 @@ For those who will only read this.
 - Not needed to create a new SR to create QCOW2 disks. A SR can have QCOW2 and VHD co-existing.
 - VHD stays the default for now, a QCOW2 disk will automatically be created when asking for the creation of a VDI bigger than 2040GiB.
 
-## Glossary
+## 📚 Glossary {#glossary}
 
 - VDI: Virtual Disk Image. This is a VM’s disk, seen from the hypervisor.
 - SR: Storage Repository. Storage space managed by XCP-ng to store VDIs.
 - image format: there exist several formats to store a VM disk’s data. VHD, QCOW2 and VMDK are all such image formats. Historically, XCP-ng only supported the VHD image format (as well as raw data, which means no image format). It now supports a new image format in addition to VHD: QCOW2.
 
-## About image formats
+## 🖼️ About image formats {#about-image-formats}
 
 Before entering the FAQ itself, let's talk about image formats.
 
@@ -45,22 +45,22 @@ You can also add the parameter at the SR creation on the command line with `xe`.
 
 Example:
 
-```
+<Terminal shell title="root@xcp-ng-host — Configure a new SR's…">{`
 xe sr-create name-label="test-lvmsr" type=lvm device-config:device=/dev/nvme1n1 device-config:preferred-image-formats=qcow2
-```
+`}</Terminal>
 
 ### Configure an existing SR's preferred-image-formats
 
 As said above, by default, an existing SR has `vhd,qcow2` as its preferred image formats. This is our recommended default at the moment.
 
-To tell an existing SR that it must prefer the `qcow2` image format for new disks, it is necessary to unplug, destroy, recreate and re-plug its PBD with the added parameter in the device-config: https://docs.xcp-ng.org/storage/#-how-to-modify-an-existing-sr-connection
+To tell an existing SR that it must prefer the `qcow2` image format for new disks, it is necessary to unplug, destroy, recreate and re-plug its PBD with the added parameter in the device-config: https://docs.xcp-ng.org/storage/#how-to-modify-an-existing-sr-connection
 
 In order to unplug the PBD, any VMs with a VDI on the SR will have to be stopped, or the VDI moved temporarily to another SR.
 
 This operation will not affect the contents of the SR. The PDB object represents the connection to the SR, not its contents.
 
 
-## FAQ
+## ❓ FAQ {#faq}
 
 Now let's enter the FAQ itself.
 
@@ -100,24 +100,27 @@ This only works on SR types which support QCOW2.
 
 Alternatively, you can specify the image format on the command line:
 
-```
+<Terminal shell title="root@xcp-ng-host — How to create a QCOW2 VDI">{`
 xe vdi-create sr-uuid=<SR UUID> virtual-size=5TiB name-label="My QCOW2 VDI" sm-config:image-format=qcow2
-```
+`}</Terminal>
 
 ### How to know the image format used by a VDI
 
 To know what format a VDI is in, we added a key in the VDI `sm-config` for storage drivers compatible with the QCOW2 feature, called `image-format`.
 A VDI `sm-config` is data from the storage layer in the XAPI, it's used to share information directly with the storage implementation.
 You can read it using `xe` with:
-```
+
+<Terminal shell title="root@xcp-ng-host — How to know the image format…">{`
 xe vdi-param-get uuid=<VDI UUID> param-name=sm-config param-key=image-format
-```
+`}</Terminal>
 
 The command output will tell you if the information is not available:
-```
-# xe vdi-param-get uuid=a1d1188a-5e46-499c-a2fa-4a9d79362480  param-name=sm-config param-key=image-format
+
+<Terminal title="root@xcp-ng-host — How to know the image format…">{`
+xe vdi-param-get uuid=a1d1188a-5e46-499c-a2fa-4a9d79362480  param-name=sm-config param-key=image-format
 Error: Key image-format not found in map
-```
+`}</Terminal>
+
 The information may not be available for multiple reasons:
 - the driver does not advertise the image format
 - the version of the storage stack does not include the feature
@@ -133,9 +136,10 @@ Yes, you can by setting the `preferred-image-formats` parameter to `qcow2` (and 
 You can do so directly in the SR creation form of Xen Orchestra.
 
 Here's also a command line example:
-```
+
+<Terminal shell title="root@xcp-ng-host — Can you create a SR which only…">{`
 xe sr-create name-label="test-lvmsr" type=lvm device-config:device=/dev/nvme1n1 device-config:preferred-image-formats=qcow2
-```
+`}</Terminal>
 
 ### Can I create QCOW2 disks smaller than 2 TiB?
 
@@ -186,11 +190,11 @@ For thick allocated disks, you need the space for the base copy, the snapshot an
 
 Yes, on File based SR, you can create a QCOW2 with a different cluster size with the command:
 
-```bash
+<Terminal shell title="Can we change the QCOW2 cluster size?">{`
 cd /var/run/sr-mount/<SR UUID>/
 qemu-img create -f qcow2 -o cluster_size=2M $(uuidgen).qcow2 10G
 xe sr-scan uuid=<SR UUID> # to introduce it in the XAPI
-```
+`}</Terminal>
 
 The `qemu-img` command will print the name, the VDI is `<VDI UUI>.qcow2` from the output.
 

--- a/docs/storage/storage.md
+++ b/docs/storage/storage.md
@@ -1,10 +1,16 @@
 ---
-"position": 4
+sidebar_position: 1
 ---
 
 # Storage in XCP-ng
 
-Storage in XCP-ng is quite a large topic. This section is dedicated to it. Keywords are:
+Storage in XCP-ng is quite a large topic. This section is dedicated to it.
+
+:::tip
+Looking for day-2 operations (detach/reattach an SR, resize or move virtual disks, reclaim space)? See [SR and VDI management](manage-srs.md).
+:::
+
+Keywords are:
 
 * SR: Storage Repository, the place for your VM disks (VDI SR)
 * VDI: a virtual disk
@@ -16,7 +22,7 @@ Please take into consideration, that Xen API (XAPI) via their storage module (`S
 We encourage people to use file based SR (local ext, NFS, XOSTOR…) because it's easier to deal with. If you want to know more, read the rest.
 :::
 
-## 📑 Storage types
+## 📑 Storage types {#storage-types}
 
 There are two types of storage:
 
@@ -149,15 +155,15 @@ As XCP-ng will handle everything for you, be aware that the device or partition 
 * If you want to attach an existing SR to your pool, don't create a new local SR over it, else your virtual disks will be deleted. Instead, use the `xe sr-introduce` command. Further explanation can be found in the official XenServer documentation: https://support.citrix.com/external/article?articleUrl=CTX121896-how-to-introduce-a-local-storage-repository-in-xenserver
 :::
 
-In [Xen Orchestra](../management#%EF%B8%8F-manage-at-scale):
+In [Xen Orchestra](../management#manage-at-scale):
 
 ![Adding a new local ext SR in XO.](https://xcp-ng.org/assets/img/screenshots/createSRlocal.png)
 
 Via `xe` CLI for a local EXT SR (where `sdaX` is a partition, but it can be the entire device e.g. `sdc`):
 
-```
+<Terminal shell title="root@xcp-ng-host — Local">{`
 xe sr-create host-uuid=<host UUID> type=ext content-type=user name-label="Local Ext" device-config:device=/dev/sdaX
-```
+`}</Terminal>
 
 In addition to the two main, rock-solid, local storages (EXT and LVM), XCP-ng offers storage drivers for other types of local storage (ZFS, XFS, etc.).
 
@@ -194,9 +200,10 @@ Local, thin-provisioned. Not recommended.
 The `file` storage driver allows you to use any local directory as storage. 
 
 Example:
-```
+
+<Terminal shell title="root@xcp-ng-host — File">{`
 xe sr-create host-uuid=<host UUID> type=file content-type=user name-label="Local File SR" device-config:location=/path/to/storage
-```
+`}</Terminal>
 
 Avoid using it with mountpoints for remote storage: if for some reason the filesystem is not mounted when the SR is scanned for virtual disks, the `file` driver will believe that the SR is empty and drop all VDI metadata for that storage.
 
@@ -224,19 +231,19 @@ Then either reboot or run `modprobe -v zfs` to load the kernel module.
 
 Due to the variety of parameters of ZFS, the SR driver does not automate everything. You need to create your ZFS pool and volumes yourself, e.g. on partition `sda4`:
 
-```
+<Terminal shell title="ZFS">{`
 zpool create -o ashift=12 -m /mnt/zfs tank /dev/sda4
-```
+`}</Terminal>
 
-```
- zfs create tank/zfssr
-```
+<Terminal shell title="ZFS">{`
+zfs create tank/zfssr
+`}</Terminal>
 
 Now you can create the SR on top of it:
 
-```
+<Terminal shell title="root@xcp-ng-host — ZFS">{`
 xe sr-create host-uuid=<HOST_UUID> type=zfs content-type=user name-label=LocalZFS device-config:location=/mnt/zfs/zfssr
-```
+`}</Terminal>
 
 :::tip
 Please report any problems (performance or otherwise) you might encounter with ZFS. [Our forum](https://xcp-ng.org/forum) is here for that!
@@ -267,9 +274,9 @@ zpool iostat -v 1
 
 To get the list of supported parameters, you can execute:
 
-```
+<Terminal shell title="ZFS module parameters">{`
 man zfs-module-parameters
-```
+`}</Terminal>
 
 It's possible to write/read parameters on the fly. For example:
 
@@ -308,9 +315,9 @@ Works in the same way as the Local EXT storage driver: you hand it a device and 
 
 Via `xe` CLI for a local XFS SR (where `sdaX` is a partition, but it can be the entire device e.g. `sdc`):
 
-```
+<Terminal shell title="root@xcp-ng-host — XFS">{`
 xe sr-create host-uuid=<host UUID> type=xfs content-type=user name-label="Local XFS" device-config:device=/dev/sdaX
-```
+`}</Terminal>
 
 ### Glusterfs
 
@@ -326,9 +333,9 @@ Shared, thin-provisioned storage. Available since XCP-ng 8.2.
 
 You can use this driver to connect to an existing [Gluster storage](https://docs.gluster.org/en/latest/) volume and configure it as a shared SR for all your hosts in the pool. For example, a Gluster storage with 3 nodes (`192.168.1.11`, `192.168.1.12` and `192.168.1.13`) and a volume name called `glustervolume` will be thin provisioned with the command:
 
-```
+<Terminal shell title="root@xcp-ng-host — Glusterfs">{`
 xe sr-create content-type=user type=glusterfs name-label=GlusterSharedStorage shared=true device-config:server=192.168.1.11:/glustervolume device-config:backupservers=192.168.1.12:192.168.1.13
-```
+`}</Terminal>
 
 ### CephFS
 
@@ -347,8 +354,8 @@ Error parameters: , The SR is not available [opterr=ceph is not installed],
 
 Since most of the Centos repositories have been deprecated, you need to add the Vault repository before installing.
 
-```
-# nano /etc/yum.repos.d/CentOS-Vault.repo
+<Terminal title="CephFS">{`
+nano /etc/yum.repos.d/CentOS-Vault.repo
 
 # Vault
 [Vault-base]
@@ -371,10 +378,11 @@ baseurl=http://vault.centos.org/centos/$releasever/extras/$basearch/
 enabled=0
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever
-```
+`}</Terminal>
+
 After that follow installation steps
 
-```
+<Terminal shell title="root@xcp-ng-host — Vault">{`
 yum install centos-release-ceph-nautilus --enablerepo=Vault-extras
 yum-config-manager --disable centos-nfs-ganesha28 centos-ceph-nautilus
 # Fix the repo file so that it points at vault.centos.org
@@ -383,18 +391,20 @@ sed -i -e 's/#baseurl=/baseurl=/' /etc/yum.repos.d/CentOS-Ceph-Nautilus.repo
 sed -i -e 's/mirror\.centos\.org/vault.centos.org/' /etc/yum.repos.d/CentOS-Ceph-Nautilus.repo
 # install
 yum install ceph-common --enablerepo=centos-ceph-nautilus,Vault-base
-```
+`}</Terminal>
 
 Create `/etc/ceph/admin.secret` with your access secret for CephFS.
-```
-# cat /etc/ceph/admin.secret
+
+<Terminal title="install">{`
+cat /etc/ceph/admin.secret
 AQBX21dfVMJtBhAA2qthmLyp7Wxz+T5YgoxzeQ==
-```
+`}</Terminal>
 
 Now you can create the SR where `server` is your mon ip.
-```
-# xe sr-create type=cephfs name-label=ceph device-config:server=172.16.10.10 device-config:serverpath=/xcpsr device-config:options=name=admin,secretfile=/etc/ceph/admin.secret
-```
+
+<Terminal shell title="root@xcp-ng-host — cat /etc/ceph/admin.secret">{`
+xe sr-create type=cephfs name-label=ceph device-config:server=172.16.10.10 device-config:serverpath=/xcpsr device-config:options=name=admin,secretfile=/etc/ceph/admin.secret
+`}</Terminal>
 
 :::tip
 * For `serverpath` it would be good idea to use an empty folder from the CephFS instead of `/`.
@@ -416,11 +426,13 @@ SR driver was contributed directly by MooseFS Development Team.
 :::
 
 Installation steps
-```
+
+<Terminal shell title="MooseFS">{`
 curl "https://ppa.moosefs.com/RPM-GPG-KEY-MooseFS" > /etc/pki/rpm-gpg/RPM-GPG-KEY-MooseFS
 curl "http://ppa.moosefs.com/MooseFS-3-el7.repo" > /etc/yum.repos.d/MooseFS.repo
 yum install moosefs-client
-```
+`}</Terminal>
+
 :::tip
 - By default, the `moosefs` storage driver is not enabled and must be whitelisted in XAPI's configuration.
 - The list of accepted storage drivers is defined in `/etc/xapi.conf` but we must *never* modify this file directly. Instead, copy the `sm-plugins` definition from it, add `moosefs` to the line, and write the resulting line to a new `/etc/xapi.conf.d/99-enable-moosefs.conf` file.
@@ -428,10 +440,11 @@ yum install moosefs-client
 :::
 
 Now when the MooseFS client is installed you can connect to an existing [MooseFS cluster](https://moosefs.com/support/#documentation) and create a shared SR for all hosts in the pool.
-```
 
-# xe sr-create type=moosefs name-label=MooseFS-SR content-type=user shared=True device-config:masterhost=mfsmaster.host.name device-config:masterport=9421 device-config:rootpath=/xcp-ng
-```
+<Terminal shell title="root@xcp-ng-host — MooseFS">{`
+
+xe sr-create type=moosefs name-label=MooseFS-SR content-type=user shared=True device-config:masterhost=mfsmaster.host.name device-config:masterport=9421 device-config:rootpath=/xcp-ng
+`}</Terminal>
 
 Basically, to connect the driver to our cluster we have to know two parameters:
 - masterhost - MooseFS master host name or IP, default mfsmaster
@@ -455,17 +468,17 @@ For a Fibre Channel multipath configuration, please follow [these steps](../../s
 
 You can add a Host Bus Adapter (HBA) storage device with `xe`:
 
-```
+<Terminal shell title="root@xcp-ng-host — HBA">{`
 xe sr-create content-type=user shared=true type=lvmohba name-label=MyHBAStorage device-config:SCSIid=<the SCSI id>
-```
+`}</Terminal>
 
 This is great for passing through full hardware disks, such as an entire hard disk.
 
 If you have a problem with the SCSIid, you can use this alternative, carefully selecting the right drive, and checking it's visible on all hosts with the same name:
 
-```
+<Terminal shell title="root@xcp-ng-host — HBA">{`
 xe sr-create content-type=user shared=true type=lvmohba name-label=MyHBAStorage device-config:device=/dev/<HBA drive>
-```
+`}</Terminal>
 
 ### Ceph iSCSI gateway
 
@@ -494,8 +507,8 @@ Known issue: this SR is not allowed to be used for HA state metadata due to LVM 
 
 Since most of the Centos repositories have been deprecated, you need to add the Vault repository before installing.
 
-```
-# nano /etc/yum.repos.d/CentOS-Vault.repo
+<Terminal title="Ceph RBD">{`
+nano /etc/yum.repos.d/CentOS-Vault.repo
 
 # Vault
 [Vault-base]
@@ -518,10 +531,11 @@ baseurl=http://vault.centos.org/centos/$releasever/extras/$basearch/
 enabled=0
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever
-```
+`}</Terminal>
+
 After that follow installation steps
 
-```
+<Terminal shell title="root@xcp-ng-host — Vault">{`
 yum install centos-release-ceph-nautilus --enablerepo=Vault-extras
 yum-config-manager --disable centos-nfs-ganesha28 centos-ceph-nautilus
 # Fix the repo file so that it points at vault.centos.org
@@ -530,32 +544,32 @@ sed -i -e 's/#baseurl=/baseurl=/' /etc/yum.repos.d/CentOS-Ceph-Nautilus.repo
 sed -i -e 's/mirror\.centos\.org/vault.centos.org/' /etc/yum.repos.d/CentOS-Ceph-Nautilus.repo
 # install
 yum install ceph-common --enablerepo=centos-ceph-nautilus,Vault-base
-```
+`}</Terminal>
 
 Create `/etc/ceph/keyring` with your access secret for Ceph.
 
-```
-# cat /etc/ceph/keyring 
+<Terminal title="install">{`
+cat /etc/ceph/keyring
 [client.admin]
 key = YOUR-SECRET-KEY
-```
+`}</Terminal>
 
 Create `/etc/ceph/ceph.conf` as your matching setup.
 
-```
-# cat /etc/ceph/ceph.conf 
+<Terminal title="cat /etc/ceph/keyring">{`
+cat /etc/ceph/ceph.conf
 [global]
 mon_host = mon-ip-1:6789,mon-ip-2:6789,mon-ip-3:6789
 
 [client.admin]
 keyring = /etc/ceph/keyring
-```
+`}</Terminal>
 
 Create the RBD image.
 
-```
+<Terminal shell title="install">{`
 rbd create --size 300G --image-feature layering pool/xen1
-```
+`}</Terminal>
 
 Mount the RBD image on your host.
 
@@ -566,17 +580,17 @@ rbd map pool/xen1
 
 To automatically mount the RBD image, you can configure the `/etc/rbdmap` ( see [RBDMap documentation ](https://docs.ceph.com/en/reef/man/8/rbdmap/) ) as follows:
 
-```
+<Terminal title="Map it to all xen hosts in your pool">{`
 cat /etc/ceph/rbdmap
 # RbdDevice		Parameters
 pool/xen1
-```
+`}</Terminal>
 
 And then, enable the `rbdmap` service to mount automatically the image at boot.
 
-```
+<Terminal shell title="RbdDevice		Parameters">{`
 systemctl enable --now rbdmap
-```
+`}</Terminal>
 
 The CEPH RBD SR is built on top of an LVM Block device (your RBD image). You need to adapt the LVM configuration in order to be able to detect the newly created LVM VG created by XCP-NG.
 
@@ -600,10 +614,11 @@ This configuration must be re-applied after each [XCP-NG Upgrade](/installation/
 :::
 
 Create the CephRBD SR.
-```
+
+<Terminal shell title="root@xcp-ng-host — RbdDevice		Parameters">{`
 # create a shared LVM
 xe sr-create name-label='CEPH' shared=true device-config:device=/dev/rbd/rbd/xen1 type=lvm content-type=user
-```
+`}</Terminal>
 
 You will probably want to configure ceph further so that the block device is mapped on reboot.
 
@@ -621,14 +636,14 @@ Largeblock SR is a workaround for 4KiB disks not working on VDI creation with no
 
 To create a LargeBlock SR, the same parameters needed for a EXT SR are needed with the SR type changed to `largeblock`.
 
-```
+<Terminal shell title="root@xcp-ng-host — LargeBlock SR">{`
 xe sr-create host-uuid=<host UUID> type=largeblock content-type=user name-label="Local largeblock" device-config:device=/dev/sdaX
-```
+`}</Terminal>
 
 The largeblock SR creates a translation layer to align the device on 512 sector size using a loop device and creates a EXT SR on this emulated device.
 It's needed to work around an issue with VHD alignment that creates an error on VHD creation on the native 4KiB device.
 
-## 💿 ISO SR
+## 💿 ISO SR {#iso-sr}
 
 You might be wondering how to upload an ISO. Unlike other solutions, you need to create a dedicated "space" for these, a specific ISO SR. To create an ISO SR, you have 2 possibilities:
 - Shared: A shared ISO SR is on a VM or on a dedicated storage server. It's accessible with an IP address, like 192.168.1.100 via SMB or NFS.
@@ -686,7 +701,7 @@ That's it!
 Don't forget to rescan your SR after adding, changing, or deleting ISO files. Rescan is done automatically every 10 minutes otherwise.
 :::
 
-## 📡 Storage API
+## 📡 Storage API {#storage-api}
 
 Current storage stack on XCP-ng is called `SMAPIv1`. The VHD format is used, which has a maximum file size limitation of 2TiB. This means that when using this format your VM disk can't be larger than 2TiB.
 
@@ -705,9 +720,9 @@ Alternatively, you can decide to use a disk without 2TiB limitation, thanks to R
 
 To create a large VDI on a file based SR, it's trivial, for example:
 
-```
+<Terminal shell title="root@xcp-ng-host — Using RAW format">{`
 xe vdi-create type=user sm-config:type=raw virtual-size=5TiB sr-uuid=<SR_UUID> name-label=test
-```
+`}</Terminal>
 
 On a block based storage, it's a bit more complicated:
 
@@ -725,7 +740,7 @@ You won't be able to live migrate storage on this disk or snapshot it anymore. O
 
 Also, the storage API is far more agnostic and the code is better. So what's the catch? Problem is there's no Open Source implementation of `SMAPIv3`, also the current API state isn't really complete (doesn't support a lot of features). However, XCP-ng team is working on it too, because it's clearly the future!
 
-## 🪄 Coalesce
+## 🪄 Coalesce {#coalesce}
 
 Coalesce process is an operation happening in your hosts as soon a snapshot is removed.
 
@@ -762,7 +777,7 @@ But more than that, Xen Orchestra is also able to show you uncoalesced disk in t
 
 More about this exclusive feature on [https://xen-orchestra.com/blog/xenserver-coalesce-detection-in-xen-orchestra/](https://xen-orchestra.com/blog/xenserver-coalesce-detection-in-xen-orchestra/)
 
-## 🦮 How to modify an existing SR connection
+## 🦮 How to modify an existing SR connection {#how-to-modify-an-existing-sr-connection}
 
 The link between a host and an SR is called the `PBD`. A PBD basically stores **how** to access a storage repository (like the path to the drive or to an NFS share).
 

--- a/docs/troubleshooting/_category_.json
+++ b/docs/troubleshooting/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "Troubleshooting",
-    "position": 10
+    "position": 11
 }

--- a/docs/troubleshooting/advanced.md
+++ b/docs/troubleshooting/advanced.md
@@ -1,0 +1,70 @@
+# Advanced host troubleshooting
+
+Techniques for the hard cases: a host that doesn't boot, kernel or hypervisor crashes, and getting diagnostics out of a machine you can barely reach. For everyday issues, start with the [3-Step-Guide](troubleshooting.md) and the [log files page](log-files.md).
+
+## 🧵 Serial console access {#serial-console-access}
+
+When the network is down or the host hangs at boot, a serial console is often the only way in. Most servers expose it through the BMC (Serial-over-LAN with iDRAC, iLO, IPMI `ipmitool sol activate`...), which makes it usable remotely.
+
+To make XCP-ng talk on the first serial port, run these on the host and reboot:
+
+<Terminal shell title="root@xcp-ng-host — Serial console access">{`
+/opt/xensource/libexec/xen-cmdline --set-xen "com1=115200,8n1 console=com1,vga"
+/opt/xensource/libexec/xen-cmdline --set-dom0 "console=hvc0 console=tty0"
+`}</Terminal>
+
+* The first line makes the Xen hypervisor output its messages on serial (and keeps VGA).
+* The second makes the dom0 kernel and login prompt available there too (`hvc0` is the Xen virtual console, bridged to serial by the hypervisor).
+
+To get a login prompt on it, enable the getty once:
+
+<Terminal shell title="Serial console access">{`
+systemctl enable --now serial-getty@hvc0.service
+`}</Terminal>
+
+`xen-cmdline` edits the boot configuration for both BIOS and UEFI installs, so you don't have to touch `grub.cfg` by hand.
+
+## ⚙️ Xen boot options {#xen-boot-options}
+
+The same `xen-cmdline` tool manages the hypervisor's boot parameters:
+
+<Terminal shell title="root@xcp-ng-host — Xen boot options">{`
+/opt/xensource/libexec/xen-cmdline --list-xen
+/opt/xensource/libexec/xen-cmdline --set-xen "loglvl=all guest_loglvl=all"
+/opt/xensource/libexec/xen-cmdline --delete-xen loglvl
+`}</Terminal>
+
+Raising `loglvl`/`guest_loglvl` to `all` is the classic first step when chasing hypervisor-level problems: it makes `xl dmesg` much more talkative. Only add options you understand (or that support/developers asked for): a wrong hypervisor parameter can make the host unbootable, which is exactly what the serial console above is for.
+
+## 🔍 Reading the hypervisor state {#reading-the-hypervisor-state}
+
+* `xl dmesg`: the Xen hypervisor's own log ring (distinct from dom0's `dmesg`). Hardware issues, IOMMU errors and guest faults often show up only here.
+* `xl info`: hypervisor version, memory, capabilities.
+* **Debug keys**: Xen can dump internal state on demand into `xl dmesg`:
+
+<Terminal shell title="root@xcp-ng-host — Reading the hypervisor state">{`
+xl debug-keys q     # dump domain and vCPU states
+xl debug-keys m     # dump memory information
+xl debug-keys h     # list all available keys in xl dmesg
+`}</Terminal>
+
+## 💥 Host crashes and crash dumps {#host-crashes-and-crash-dumps}
+
+If the host crashes at the kernel or hypervisor level, a crash dump is saved in `/var/crash` at the following reboot (see [kernel crash logs](log-files.md#kernel-crash-logs)). List them also via XAPI:
+
+<Terminal shell title="root@xcp-ng-host — Host crashes and crash dumps">{`
+xe host-crashdump-list
+`}</Terminal>
+
+When reporting such a crash (forum or support), provide the crash dump contents along with a [status report](log-files.md#produce-a-status-report). Crash dumps live on the boot disk: don't let them accumulate, `xe host-crashdump-destroy uuid=<uuid>` cleans them up once analyzed.
+
+## 🥾 When the host doesn't boot {#when-the-host-doesnt-boot}
+
+1. At the boot menu, try the **fallback entries** (previous kernel version) if an update or driver change preceded the failure. See also [after upgrade troubleshooting](after-upgrade.md).
+2. Watch the boot on the serial console (above) or the BMC's remote screen: the last messages usually name the culprit (storage driver, network driver...).
+3. You can boot the [installation ISO](installation-upgrade.md) and use its shell for repairs: your root filesystem can be mounted from there (the installer's rescue capabilities are also usable over [remote access during installation](installation-upgrade.md#getting-remote-access-to-host-during-installation)).
+4. For RAID-related boot failures, see [software RAID issues](storage/disk-failure-software-RAID.md).
+
+## 🆘 Produce a status report {#produce-a-status-report}
+
+When asking for help, generate a status report archive containing logs and configuration: see [the procedure](log-files.md#produce-a-status-report). Mention exactly what you changed last: most "impossible" host issues follow a recent change.

--- a/docs/troubleshooting/after-upgrade.md
+++ b/docs/troubleshooting/after-upgrade.md
@@ -1,6 +1,6 @@
 # After Upgrade
 
-## 🔧 The Server stays in Maintenance Mode
+## 🔧 The Server stays in Maintenance Mode {#the-server-stays-in-maintenance-mode}
 
 ### Causes and Solutions
 * You enabled the maintenance mode and forgot about it.
@@ -14,7 +14,7 @@
 
 ***
 
-## 🙅 Some of my VMs do not start
+## 🙅 Some of my VMs do not start {#some-of-my-vms-do-not-start}
 
 With the following error: "This operation cannot be performed because the specified virtual disk could not be found."
 
@@ -26,7 +26,7 @@ Eject the ISO on those VMs.
 
 ***
 
-## 💔 Missing scripts/tools after upgrade
+## 💔 Missing scripts/tools after upgrade {#missing-scriptstools-after-upgrade}
 
 ### Cause
 
@@ -39,7 +39,7 @@ To access the backup (with all your tools and modifications) just mount the back
 
 ***
 
-## 🐛 After upgrading my XCP-ng host is unstable, network card freezes, kernel errors, etc.
+## 🐛 After upgrading my XCP-ng host is unstable, network card freezes, kernel errors, etc. {#after-upgrading-my-xcp-ng-host-is-unstable-network-card-freezes-kernel-errors-etc}
 
 ### Causes and Solutions
 

--- a/docs/troubleshooting/common-problems.md
+++ b/docs/troubleshooting/common-problems.md
@@ -4,7 +4,7 @@ Here is a list of common problems.
 
 ---
 
-## Blank screen (on a Linux VM)
+## 🖥️ Blank screen (on a Linux VM) {#blank-screen-on-a-linux-vm}
 
 ### Cause
 
@@ -32,7 +32,7 @@ Blacklist the problematic driver ([source](https://xcp-ng.org/forum/post/1707)):
 
 ---
 
-## Initrd is missing after an update
+## 🧬 Initrd is missing after an update {#initrd-is-missing-after-an-update}
 
 ### Cause
 
@@ -52,7 +52,7 @@ Here is an example of `dracut` command on a 8.3 host: `dracut -f /boot/initrd-4.
 
 ---
 
-## VM not in expected power state
+## 🔌 VM not in expected power state {#vm-not-in-expected-power-state}
 
 ### Cause
 
@@ -64,7 +64,7 @@ Restart toolstack on CLI with the command `xe-toolstack-restart`. This just rest
 
 ---
 
-## Host and Pool have incompatible Licenses
+## 🪪 Host and Pool have incompatible Licenses {#host-and-pool-have-incompatible-licenses}
 
 ### Cause
 
@@ -76,7 +76,7 @@ To solve this, simply get your pool "coherent" and do not mix products. Ensure a
 
 ---
 
-## Rebooting hangs the server
+## 🔄 Rebooting hangs the server {#rebooting-hangs-the-server}
 
 ### Cause
 
@@ -92,7 +92,7 @@ Try these steps:
 
 ---
 
-## Server loses time on 14th gen Dell hardware
+## ⏰ Server loses time on 14th gen Dell hardware {#server-loses-time-on-14th-gen-dell-hardware}
 
 ### Cause
 
@@ -100,14 +100,14 @@ Losing time can be related to the system trying to keep listening to the hardwar
 
 ### Solution
 
-```
+<Terminal title="Solution">{`
 echo "xen" > /sys/devices/system/clocksource/clocksource0/current_clocksource
   printf '%s\n\t%s\n%s\n' 'if test -f /sys/devices/system/clocksource/clocksource0/current_clocksource; then' 'echo xen > /sys/devices/system/clocksource/clocksource0/current_clocksource' 'fi' >> /etc/rc.local
-```
+`}</Terminal>
 
 ---
 
-## Async Tasks/Commands Hang or Execute Extremely Slowly
+## 🐌 Async Tasks/Commands Hang or Execute Extremely Slowly {#async-taskscommands-hang-or-execute-extremely-slowly}
 
 ### Cause
 
@@ -123,7 +123,7 @@ This symptom can be caused by a variety of issues including RAID degradation, ag
 
 ---
 
-## TCP Offload checksum errors
+## 🌐 TCP Offload checksum errors {#tcp-offload-checksum-errors}
 
 ### Cause
 
@@ -156,7 +156,7 @@ The PIF UUID can be found by executing:
 
 ---
 
-## TCP Segmentation Offload (TSO) decreasing performances
+## 🐢 TCP Segmentation Offload (TSO) decreasing performances {#tcp-segmentation-offload-tso-decreasing-performances}
 
 ### Cause
 
@@ -174,16 +174,16 @@ In some cases, at least observed on XCP-ng 8.2.1 with Intel I219-V NICs, having 
 If running the unplug/plug commands through ssh, make sure you're not doing so over the network that will be unplugged. Ideally it is recommended to do such changes through your machine IPMI interface or on via physical access
 :::
 
-```
-# xe pif-unplug uuid=$PIFUUID
-# xe pif-plug uuid=$PIFUUID
-```
+<Terminal shell title="root@xcp-ng-host — Solution">{`
+xe pif-unplug uuid=$PIFUUID
+xe pif-plug uuid=$PIFUUID
+`}</Terminal>
 
 :::tip
 If working on a pool, you can set this for all the PIFs of the pool from a single host as `xe pif-list` will show all the PIFs of the pool. You can then do a "Rolling Pool Reboot" in XO from your pool page, in the advanced tab.
 :::
 
-## Reset XCP-ng root password
+## 🔑 Reset XCP-ng root password {#reset-xcp-ng-root-password}
 
 ### Cause
 
@@ -193,15 +193,15 @@ The root credentials of a pool are believed to be compromised and need to be cha
 
 To change the password of all hosts in a pool, SSH into the coordinator host and create a file. Write the password as its contents, then run:
 
-```bash
+<Terminal shell title="root@xcp-ng-host — Solution">{`
 xe user-password-change new="$(< /path/to/password_file)"
-```
+`}</Terminal>
 
 After the password has been set, please place a copy somewhere safe and delete the password file.
 
 ---
 
-## XenStore related issues
+## 🗄️ XenStore related issues {#xenstore-related-issues}
 
 ### Cause
 
@@ -215,7 +215,7 @@ The `XENSTORED_TRACE` being enabled might give useful information.
 
 ---
 
-## Ubuntu 18.04 boot issue
+## 🥾 Ubuntu 18.04 boot issue {#ubuntu-1804-boot-issue}
 
 ### Cause
 
@@ -233,7 +233,7 @@ Alternatively, in a fresh Ubuntu 18.04 install, you can switch to UEFI and you w
 
 ---
 
-## Missing templates when creating a new VM
+## 📋 Missing templates when creating a new VM {#missing-templates-when-creating-a-new-vm}
 
 ### Cause
 
@@ -242,23 +242,24 @@ In specific conditions, the global template generation can fail. If you attempt 
 ### Solution
 
 Simply go to the console of your XCP-NG host and enter the following command:
-```
+
+<Terminal shell title="Solution">{`
 /usr/bin/create-guest-templates
-```
+`}</Terminal>
 
 This should recreate all the templates.
 
 ---
 
-## The updater plugin is busy
+## ♻️ The updater plugin is busy {#the-updater-plugin-is-busy}
 
 ### Cause
 
 The message `The updater plugin is busy (current operation: check_update)` means that the plugin crashed will doing an update. The lock was then active, and it was left that way. You can probably see that by doing:
 
-```
+<Terminal shell title="Cause">{`
 cat /var/lib/xcp-ng-xapi-plugins/updater.py.lock
-```
+`}</Terminal>
 
 It should be empty, but if you have the bug, you got `check_update`.
 
@@ -269,7 +270,7 @@ Remove `/var/lib/xcp-ng-xapi-plugins/updater.py.lock` and that should fix it.
 
 ---
 
-## Unable to live migrate VDI between SRs
+## 🚚 Unable to live migrate VDI between SRs {#unable-to-live-migrate-vdi-between-srs}
 
 ### Cause
 
@@ -284,9 +285,11 @@ Xenops_interface.Xenopsd_error([S(Internal_error);S(Sys_error(\"Connection reset
 ### Solution
 
 To fix this, create the file with the following command:
-```
+
+<Terminal shell title="root@xcp-ng-host — Solution">{`
 xe host-refresh-server-certificate host=<host name>
-```
+`}</Terminal>
+
 This will create the correct file on the host.
 You will need to run the command on all hosts of the pool.
 
@@ -294,7 +297,7 @@ To know more about certificates in XAPI, check out the [XAPI documentation](http
 
 ---
 
-## Installation hanging at "Select Keymap"
+## ⌨️ Installation hanging at "Select Keymap" {#installation-hanging-at-select-keymap}
 
 ### Issue
 

--- a/docs/troubleshooting/installation-upgrade.md
+++ b/docs/troubleshooting/installation-upgrade.md
@@ -2,7 +2,7 @@
 
 Upgrade here designates an upgrade using the installation ISO
 
-## If the installer starts booting up then crashes or hangs
+## 💥 If the installer starts booting up then crashes or hangs {#if-the-installer-starts-booting-up-then-crashes-or-hangs}
 
 * First of all check the integrity of the ISO image you downloaded, using the provided checksum
 * Try the other boot options
@@ -19,7 +19,7 @@ Upgrade here designates an upgrade using the installation ISO
 
 If any of the above allows to work around your issue, please let us know ([github issues](https://github.com/xcp-ng/xcp/issues)). We can't fix issues we aren't aware of.
 
-## During installation or upgrade
+## 🚧 During installation or upgrade {#during-installation-or-upgrade}
 
 You can reach a shell with ALT+F2 (or ALT+RIGHT) and a logs console with ALT+F3 (or ALT+RIGHT twice).
 
@@ -57,7 +57,7 @@ You can specify an interface name such as `eth1` instead of `all` if necessary, 
 
 The ssh server will be available once the network is up. If you are unsure which DHCP address was obtained, you can use the shell console as described above to look it up using `ip a`. You can then connect as `root` using the password you provided on the commandline.
 
-## The installer reports "No Disks" but the machine has a drive
+## 💽 The installer reports "No Disks" but the machine has a drive {#the-installer-reports-no-disks-but-the-machine-has-a-drive}
 
 **Cause**
 
@@ -86,7 +86,7 @@ Reach a shell with `ALT` + `F2` (see [During installation or upgrade](#during-in
 The fix above applies only when the cause is the RAID/RST controller mode. A drive can also be hidden by a storage controller whose driver is missing from the install ISO (for example some MegaRAID or `mpi3mr` adapters). That is a different problem with a different fix: load a driver disk at install time, or use an updated installer that includes the driver. A BIOS change does not help there.
 :::
 
-## The ISO installer does not offer to upgrade the existing install (XCP-ng or XenServer)
+## 🙅 The ISO installer does not offer to upgrade the existing install (XCP-ng or XenServer) {#the-iso-installer-does-not-offer-to-upgrade-the-existing-install-xcp-ng-or-xenserver}
 
 :::note
 This section details how to deal with the most frequent causes for the installer not detecting your current installation. There can be other, rarer cases which are not detailed here.  In all cases the detailed reason for an inability to upgrade will always be possible to find in the installer log file. See [During installation or upgrade](#during-installation-or-upgrade) to access the log file.
@@ -170,12 +170,12 @@ Probe of /dev/nvme0n1 found boot=(True, '/dev/nvme0n1p4') root=(1, '/dev/nvme0n1
 
 The `/etc/xensource-inventory` file is critical to the upgrade process. This is one of the cases where the log will exhibit "A problem occurred whilst scanning for existing installations:" followed by more details.
 
-## Installation logs
+## 📜 Installation logs {#installation-logs}
 
 On the installed system, installer logs are kept in `/var/log/installer/`.
 
 The main log file is `/var/log/installer/install-log`.
 
-## Debugging the installer
+## 🐛 Debugging the installer {#debugging-the-installer}
 
 You can [build your own installer](../../project/development-process/ISO-modification).

--- a/docs/troubleshooting/log-files.md
+++ b/docs/troubleshooting/log-files.md
@@ -2,25 +2,25 @@
 
 On a XCP-ng host, like in most Linux/UNIX systems, the logs are located in `/var/log`. XCP-ng does not use `journald` for logs, so everything is in `/var/log` directly.
 
-## General log
+## 📜 General log {#general-log}
 
 `/var/log/daemon.log`
 
 Output of various running daemons involved in XCP-ng's tasks. Examples: output of `xenopsd` which handles the communication with the VMs, of executables involved in live migration and storage motion, and more...
 
-## XAPI's log
+## 📡 XAPI's log {#xapis-log}
 
 `/var/log/xensource.log`
 
 Contains the output of the XAPI toolstack.
 
-## Storage related (eg. coalescing snapshots)
+## 💽 Storage related (eg. coalescing snapshots) {#storage-related-eg-coalescing-snapshots}
 
 `/var/log/SMlog`
 
 Contains the output of the storage manager.
 
-## Kernel messages
+## 🐧 Kernel messages {#kernel-messages}
 
 For hardware related issues or system crashes.
 
@@ -28,34 +28,34 @@ For hardware related issues or system crashes.
 
 All kernel logs since last boot: type `dmesg`.
 
-## Kernel crash logs
+## 💥 Kernel crash logs {#kernel-crash-logs}
 
 In case of a host crash, if it is kernel-related, you should find logs in `/var/crash`
 
-## Produce a status report
+## 📋 Produce a status report {#produce-a-status-report}
 
 To help someone else identify an issue or reproduce a bug, you can generate a full status report containing all log files, details about your configuration and more.
 
-```
+<Terminal shell title="root@xcp-ng-host — Produce a status report">{`
 xen-bugtool --yestoall
-```
+`}</Terminal>
 
 Then upload the resulting archive somewhere. It may contain sensitive information about your setup, so it may be better to upload it to a private area and give the link only to those you trust to analyze it.
 
 
-## XCP-ng Center
+## 🪟 XCP-ng Center {#xcp-ng-center}
 
 You can display the log files via menu `Help` -> `View XCP-ng Center Log Files`.
 
 The log files are located in `C:\Users\<user>\AppData\Roaming\XCP-ng\XCP-ng Center\logs`.
 
-## Windows VM
+## 🖥️ Windows VM {#windows-vm}
 
 ### (PV-)Driver install log
 `C:\Windows\INF\setupapi.dev.log`
 
 
-## Useful data for debugging
+## 🔍 Useful data for debugging {#useful-data-for-debugging}
 
 ### DMAR/IVRS ACPI tables
 

--- a/docs/troubleshooting/storage/disk-failure-software-RAID.md
+++ b/docs/troubleshooting/storage/disk-failure-software-RAID.md
@@ -6,7 +6,7 @@ title: 'Software RAID issues'
 
 This page regroups the common issues you might deal with regarding software RAID.
 
-## ⏏️ Disk replacement with software RAID
+## ⏏️ Disk replacement with software RAID {#disk-replacement-with-software-raid}
 
 If XCP-ng has been installed with a *software RAID 1 full disk mirror* method, a disk failure can be fixed with a disk replacement. Here's how:
 
@@ -17,9 +17,11 @@ Boot to the XCP-ng installer ISO in shell mode.
 ### Once booted into your XCP-ng install or the ISO
 
 Enter the following commands:
-```
+
+<Terminal shell title="Once booted into your XCP-ng install or the ISO">{`
 cat /proc/mdstat
-```
+`}</Terminal>
+
 This will return a similar output:
 ```
 Personalities : [raid1]
@@ -33,9 +35,11 @@ unused devices: <none>
 ### Remove damaged disk
 
 Let's assume we want to remove `nvme0n1`:
-```
+
+<Terminal shell title="Remove damaged disk">{`
 mdadm --manage /dev/md127 --fail /dev/nvme0n1
-```
+`}</Terminal>
+
 Now `mdstat` shows `nvme0n1` as *failed*:
 ```
 Personalities : [raid1]
@@ -45,9 +49,11 @@ md127 : active raid1 nvme0n2[3] nvme0n1[2](F)
 unused devices: <none>
 ```
 Now we can remove the disk from the raid:
-```
+
+<Terminal shell title="Remove damaged disk">{`
 mdadm --manage /dev/md127 --remove /dev/nvme0n1
-```
+`}</Terminal>
+
 The disk is removed from `mdstat`:
 ```
 Personalities : [raid1]
@@ -61,9 +67,11 @@ The disk is successfully removed.
 ### Add a new/replacement disk to the RAID
 
 Now we can add a replacement disk. Shutdown your host, install the disk on your system, then boot it to your XCP-ng install or the installer ISO once more. Now add the disk to the RAID:
-```
+
+<Terminal shell title="Add a new/replacement disk to the RAID">{`
 mdadm --manage /dev/md127 --add /dev/nvme0n1
-```
+`}</Terminal>
+
 `mdstat` shows that disk `nvme0n1` is in the RAID and is synchronizing with `nvme0n2`:
 ```
 Personalities : [raid1]

--- a/docs/troubleshooting/storage/iscsi-troubleshooting.md
+++ b/docs/troubleshooting/storage/iscsi-troubleshooting.md
@@ -2,48 +2,55 @@
 
 This page is dedicated to common issues you might have with iSCSI.
 
-## 🎓 Basic iSCSI commands
+## 🎓 Basic iSCSI commands {#basic-iscsi-commands}
 
 Discover available targets from a discovery portal:
-```sh
+
+<Terminal shell title="root@xcp-ng-host — Basic iSCSI commands">{`
 iscsiadm -m discovery -t sendtargets -p <IP_address>
-```
+`}</Terminal>
 
 Log into a specific target:
-```sh
+
+<Terminal shell title="root@xcp-ng-host — Basic iSCSI commands">{`
 iscsiadm -m node -T targetname -p <IP_address> -l
-```
+`}</Terminal>
 
 Log into all targets:
-```sh
+
+<Terminal shell title="root@xcp-ng-host — Basic iSCSI commands">{`
 iscsiadm -m node -l
-```
+`}</Terminal>
 
 Display a list of all current sessions logged in:
-```sh
+
+<Terminal shell title="root@xcp-ng-host — Basic iSCSI commands">{`
 iscsiadm -m session
-```
+`}</Terminal>
 
 Log out of all targets:
-```sh
+
+<Terminal shell title="root@xcp-ng-host — Basic iSCSI commands">{`
 iscsiadm -m node -u
-```
+`}</Terminal>
 
 Display information about a target:
-```sh
+
+<Terminal shell title="root@xcp-ng-host — Basic iSCSI commands">{`
 iscsiadm -m node -T targetname -p <IP_address>
-```
+`}</Terminal>
 
 Rescan a volume after expanding a LUN:
-```sh
-iscsiadm -m node -p <IP_address> --rescan
-```
 
-## 💓 iSCSI in storage-cluster environment
+<Terminal shell title="root@xcp-ng-host — Basic iSCSI commands">{`
+iscsiadm -m node -p <IP_address> --rescan
+`}</Terminal>
+
+## 💓 iSCSI in storage-cluster environment {#iscsi-in-storage-cluster-environment}
 
 This apply to setup using DRBD/Corosync/Pacemaker.
 
-#### iSCSI reconnect after reboot fails permanently ( Unsupported SCSI Opcode )
+### iSCSI reconnect after reboot fails permanently (Unsupported SCSI Opcode)
 
 The problem is that in a storage-cluster environment every time the node changes or pacemaker start /stop /restart iSCSI resources the "iSCSI SN" for a lun are new generated and differs from that before.
 Xen uses the "iSCSI SN" as an identifier, so you have to ensure that "iSCSI SN" is the same on all cluster nodes.
@@ -65,7 +72,7 @@ kernel: [11219.642772] iSCSI/iqn.2018-12.com.example.server:33init: Unsupported 
 
 ```
 
-### Solution
+#### Solution
 
 The trick is to extend the Lio iSCSI lun configuration in pacemaker with a hard coded iscsi_sn (scsi_sn=d27dab3f-c8bf-4385-8f7e-a4772673939d) and `lio_iblock`, so that every node uses the same.
 

--- a/docs/troubleshooting/troubleshooting-ha.md
+++ b/docs/troubleshooting/troubleshooting-ha.md
@@ -8,7 +8,7 @@ To know more on high availability in general and how to set it up with XCP-ng, s
 
 ---
 
-## My host rebooted. Why did it reboot?
+## 🔄 My host rebooted. Why did it reboot? {#my-host-rebooted-why-did-it-reboot}
 
 If a host configured for high availability reboots unexpectedly, it might have: 
 
@@ -17,7 +17,7 @@ If a host configured for high availability reboots unexpectedly, it might have:
 
 Check the host's logs to verify if any of these events happened, in particular `/var/log/xha.log`.
 
-## I can't reach my host!
+## 🚨 I can't reach my host! {#i-cant-reach-my-host}
 
 ### Disabling HA
 
@@ -25,10 +25,10 @@ If a host becomes unreachable, a first step is to disable HA on your environment
 
 To do this, run the following commands:
 
-```
+<Terminal title="root@xcp-ng-host — Disabling HA">{`
 xe host-emergency-ha-disable force=true
 xe-toolstack-restart
-```
+`}</Terminal>
 
 Your host will reboot with high availability disabled. This will let you:
 
@@ -41,20 +41,20 @@ If a host cannot connect to the pool coordinator, you might want to turn it into
 
 To make your host reboot as a pool coordinator, run:
 
-```
+<Terminal shell title="root@xcp-ng-host — Changing pool coordinators">{`
 xe pool-emergency-transition-to-master uuid=<host uuid>
-```
+`}</Terminal>
 
 To tell your host the location of your pool coordinator, run:
 
-```
+<Terminal shell title="root@xcp-ng-host — Changing pool coordinators">{`
 xe pool-emergency-reset-master master-address=<new pool coordinator hostname>
-```
+`}</Terminal>
 
 ### Re-enabling HA
 
 Once your issue has been sorted out **and** if you still need HA, then feel free to enable HA again. To do this, run the following command on your pool:
 
-```
+<Terminal shell title="root@xcp-ng-host — Re-enabling HA">{`
 xe pool-ha-enable heartbeat-sr-uuid=<sr uuid>
-```
+`}</Terminal>

--- a/docs/troubleshooting/troubleshooting.md
+++ b/docs/troubleshooting/troubleshooting.md
@@ -2,7 +2,7 @@
 
 If you have a problem or a question on XCP-ng, there's 2 options: community support (mostly on [XCP-ng Forum](https://xcp-ng.org/forum)) or [pro support](https://xcp-ng.com).
 
-## The 3-Step-Guide
+## 🪜 The 3-Step-Guide {#the-3-step-guide}
 Here is our handy **3-Step-Guide**:
 
 1. Check the [logs](log-files). Check your settings. Check all the articlesbelow here. If you already did, proceed to Step 2.

--- a/docs/troubleshooting/windows-pv-tools.md
+++ b/docs/troubleshooting/windows-pv-tools.md
@@ -2,7 +2,7 @@
 
 Common issues and topics related to Windows Guest Tools.
 
-## Low storage performance on Windows
+## 🐌 Low storage performance on Windows {#low-storage-performance-on-windows}
 
 ### Cause
 
@@ -20,7 +20,7 @@ Consult your motherboard manual for details; for example, on Dell systems with i
 </div>
 
 
-## Windows fails to boot (hangs, `INACCESSIBLE_BOOT_DEVICE`)
+## 🥾 Windows fails to boot (hangs, `INACCESSIBLE_BOOT_DEVICE`) {#windows-fails-to-boot-hangs-inaccessible_boot_device}
 
 In some situations (failed uninstallation, major Windows version upgrades), Xen PV drivers (whether Citrix or XCP-ng) may cause Windows to fail to start (hanging at boot, BSOD with Stop code `INACCESSIBLE_BOOT_DEVICE`).
 The XenBootFix utility included with XCP-ng Windows Guest Tools 9.0 and above helps you disable any active Xen PV drivers and get your system to a bootable state before running XenClean.
@@ -54,7 +54,7 @@ Below is a procedure for using XenBootFix to recover a non-booting VM:
 7. Type `exit` to close Command Prompt. If using Windows RE, choose **Continue** to boot into Windows. Windows should now start normally.
 8. **You must immediately run XenClean from within Windows to remove the remaining Xen drivers**. See instructions above.
 
-## Connecting to guests using serial console
+## 🧵 Connecting to guests using serial console {#connecting-to-guests-using-serial-console}
 
 In some situations, you might want to expose a VM's serial console to network for troubleshooting purposes (e.g. Windows kernel debugging).
 You can use the following procedure:
@@ -73,7 +73,7 @@ You can use the following procedure:
   Connect using [WinDbg](https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/) using the `Attach to kernel` option with a connection string: `com:ipport=7001,port=<host IP>`
 * To undo the changes and remove the serial setting, use `xe vm-param-remove uuid=<uuid> param-name=platform param-key=hvm_serial`
 
-## BSOD 0x3B (SYSTEM_SERVICE_EXCEPTION) or 0x7E (SYSTEM_THREAD_EXCEPTION_NOT_HANDLED) on newer Intel CPUs
+## 💙 BSOD 0x3B (SYSTEM_SERVICE_EXCEPTION) or 0x7E (SYSTEM_THREAD_EXCEPTION_NOT_HANDLED) on newer Intel CPUs {#bsod-0x3b-system_service_exception-or-0x7e-system_thread_exception_not_handled-on-newer-intel-cpus}
 
 ### Cause
 
@@ -84,11 +84,11 @@ Xen's support of this CPU feature is incomplete, which causes Windows to crash w
 
 Stop the VM, run the following command on the host then restart the VM:
 
-```
+<Terminal shell title="root@xcp-ng-host — Workaround">{`
 xe vm-param-add uuid=<VM's UUID> param-name=platform msr-relaxed=true
-```
+`}</Terminal>
 
-## BSOD 0x109 (CRITICAL_STRUCTURE_CORRUPTION) after migrating VMs on Intel platforms
+## 💥 BSOD 0x109 (CRITICAL_STRUCTURE_CORRUPTION) after migrating VMs on Intel platforms {#bsod-0x109-critical_structure_corruption-after-migrating-vms-on-intel-platforms}
 
 ### Cause
 
@@ -110,7 +110,7 @@ Focus on the following settings (naming depends on BIOS vendor):
 - Power and thermal controls
 - Event counters
 
-## Windows fails to boot after updating
+## ♻️ Windows fails to boot after updating {#windows-fails-to-boot-after-updating}
 
 ### Cause
 
@@ -126,7 +126,7 @@ bcdboot C:\Windows
 
 After exiting to Windows, your system should boot successfully.
 
-## Windows Server 2019 crashes on AMD Zen without BSOD
+## 🤐 Windows Server 2019 crashes on AMD Zen without BSOD {#windows-server-2019-crashes-on-amd-zen-without-bsod}
 
 First, try disabling Viridian from Xen Orchestra. Note that this value may reset itself after reboot.
 
@@ -134,7 +134,7 @@ If this fixes the problem, remove the Registry value `Enabled` at `HKLM\SYSTEM\C
 
 You can now enable Viridian again for better VM performance.
 
-## Data drives showing as removable in Windows
+## 💾 Data drives showing as removable in Windows {#data-drives-showing-as-removable-in-windows}
 
 Follow the instructions in the Citrix KB entry [CTX583997: In XenServer, fixed data drives show as removable data drives to BitLocker](https://support.citrix.com/s/article/CTX583997-in-xenserver-fixed-data-drives-show-as-removable-data-drives-to-bitlocker).
 
@@ -147,11 +147,11 @@ HKLM\System\CurrentControlSet\Services\XenBus\Parameters\VBD\AllowPdoEject = 0
 
 Next, set each VBD's property to non-unpluggable:
 
-```
+<Terminal shell title="root@xcp-ng-host — Data drives showing as removable…">{`
 xe vbd-param-set uuid=<vbd-uuid> unpluggable=false
-```
+`}</Terminal>
 
-## XenServer VM Tools not upgrading drivers after installation
+## 🚫 XenServer VM Tools not upgrading drivers after installation {#xenserver-vm-tools-not-upgrading-drivers-after-installation}
 
 This can be due to the "Manage Citrix PV drivers via Windows Update" feature being enabled on that VM.
 
@@ -159,7 +159,7 @@ If this feature is enabled, XenServer VM Tools will automatically uncheck the "I
 
 Make sure to either check this checkbox, specify `ALLOWDRIVERINSTALL=YES` on the Msiexec command line (if installing via command line) or install driver updates via Windows Update.
 
-## XenServer drivers not receiving updates via Windows Update
+## 🔄 XenServer drivers not receiving updates via Windows Update {#xenserver-drivers-not-receiving-updates-via-windows-update}
 
 ### Cause
 
@@ -191,7 +191,7 @@ See the [XenClean guide](/vms/#fully-removing-xen-pv-drivers-with-xenclean) for 
 You will need to reinstall the management agent.
 :::
 
-## Malfunctioning XenServer PV drivers
+## 🩺 Malfunctioning XenServer PV drivers {#malfunctioning-xenserver-pv-drivers}
 
 ### Symptoms
 
@@ -213,7 +213,7 @@ XenServer drivers require multiple reboots after an update.
 Reboot your VMs manually, or set the [Autoreboot Registry value](https://support.citrix.com/external/article/CTX292687/setting-automatic-reboots-when-updating.html) to force the VM to automatically reboot after a driver update.
 You can also disable automatic updating of XenServer drivers and update them during a dedicated maintenance window.
 
-## Windows Server 2025 hangs randomly with 0% CPU
+## 🧊 Windows Server 2025 hangs randomly with 0% CPU {#windows-server-2025-hangs-randomly-with-0-cpu}
 
 ### Cause
 
@@ -229,7 +229,7 @@ bcdedit /deletevalue "{current}" useplatformclock
 bcdedit /deletevalue "{current}" useplatformtick
 ```
 
-## How to gather kernel memory dumps for in-depth troubleshooting
+## 🧠 How to gather kernel memory dumps for in-depth troubleshooting {#how-to-gather-kernel-memory-dumps-for-in-depth-troubleshooting}
 
 In situations where your VM stops responding, we may need to gather kernel memory dumps to help troubleshoot the situation.
 Follow this procedure to configure and gather a memory dump:
@@ -238,14 +238,18 @@ Follow this procedure to configure and gather a memory dump:
 - In the **System failure - Write debugging information** setting, select **Automatic memory dump** or **Kernel memory dump**.
   ![Advanced system settings - Startup and Recovery - Write debugging information configured to Automatic memory dump.](../assets/img/winpv-memory-dump.png)
 - When the system locks up, retrieve your VM's domain ID from its host:
-```
+
+<Terminal shell title="root@xcp-ng-host — How to gather kernel memory…">{`
 xe vm-param-get uuid=<vm-uuid> param-name=resident-on
 xe vm-param-get uuid=<vm-uuid> param-name=dom-id
-```
+`}</Terminal>
+
 - Make note of the domain ID displayed in the previous step.
 - Log in to the host where the VM is running via SSH. Use the following command to force the VM to crash:
-```
+
+<Terminal shell title="root@xcp-ng-host — How to gather kernel memory…">{`
 xl trigger <domid> nmi
-```
+`}</Terminal>
+
 - Your VM will crash and generate a dump file. The default location is `C:\Windows\MEMORY.DMP`.
 - Provide the requested memory dump to customer support. The dump can be compressed in a ZIP file to reduce its size.

--- a/docs/troubleshooting/xapi/leftover-VBDs.md
+++ b/docs/troubleshooting/xapi/leftover-VBDs.md
@@ -8,13 +8,13 @@ Thus, VMs that were reverted to their snapshots between `xapi-26.1.4-3.3` and `x
 
 Running the [detector script](https://github.com/xcp-ng/xcp/blob/master/scripts/xapi_leaked_vbds.py) will produce a list of possibly-affected VBDs (if there is no output, this means no affected VBDs were found), for example:
 
-```
-# ./xapi_leaked_vbds.py
+<Terminal title="console">{`
+./xapi_leaked_vbds.py
 VM e2678368-596d-1b6e-7211-9ee45f60dec1 ("Alpine") has
 VBDs that are not present in the snapshot it was reverted to
 (303ead66-9515-b1c8-0dc5-d33b7644b161 "Alpine_snapshot1"):
 xvdb (ca8610d2-76e3-6c54-4378-ee599619b4bb))
-```
+`}</Terminal>
 
 It's up to the user to deal with such VBDs (after determining if they were indeed affected) by, for example, detaching them from the VM.
 

--- a/docs/troubleshooting/xapi/snapshot-of.md
+++ b/docs/troubleshooting/xapi/snapshot-of.md
@@ -9,22 +9,24 @@ A fix for this long-standing issue is being developed for several storage backen
 :::danger
 The script temporarily disables HA and stops xapi to apply the changes to the database. This means that the pool is not running operations like handling backups, migrating, starting or stopping VMs, and HA is disabled during the operation. To check for issues in the pool without stopping xapi and rewriting the database, the `dry-run` option can be used:
 
-```
-# ./snapshot-fixer.py dry-run
+<Terminal title="console">{`
+./snapshot-fixer.py dry-run
 INFO:root:Regenerating database...
 INFO:root:The VDI 38dd4f0e-6d0e-46e1-bb1a-980ec3d3efd2 has OpaqueRef:3664c45a-2943-52b6-529b-693e8275130b as its "snapshot_of" value, changing to null.
-```
+`}</Terminal>
+
 :::
 
 The script needs to be run on the master host of the affected pool:
-```
-# ./snapshot-fixer.py rewrite
+
+<Terminal title="/snapshot-fixer.py dry-run">{`
+./snapshot-fixer.py rewrite
 INFO:root:Check HA...
 INFO:root:Shutting down xapi...
 INFO:root:Regenerating database...
 INFO:root:The VDI 38dd4f0e-6d0e-46e1-bb1a-980ec3d3efd2 has OpaqueRef:3664c45a-2943-52b6-529b-693e8275130b as its "snapshot_of" value, changing to null.
 INFO:root:Writing database to /var/lib/xcp/state.db
 INFO:root:Starting up xapi...
-```
+`}</Terminal>
 
 In unlikely case the script corrupts the database, the script provides the `restore-backup` option to restore the database from the backup (which is automatically generated on every script invocation).

--- a/docs/vms/advanced.md
+++ b/docs/vms/advanced.md
@@ -1,0 +1,79 @@
+---
+sidebar_position: 7
+---
+
+# Advanced VM settings
+
+Less common VM-level settings and behaviors: boot options, vTPM, time handling.
+
+## 🥾 Boot options {#boot-options}
+
+### Boot device order
+
+The virtual firmware tries boot devices in the order given by the `order` boot parameter, a string of `c` (disk), `d` (CD/DVD), `n` (network/PXE):
+
+<Terminal shell title="root@xcp-ng-host — Boot device order">{`
+xe vm-param-set uuid=<vm-uuid> HVM-boot-params:order=dc
+`}</Terminal>
+
+Xen Orchestra exposes this in the VM's **Advanced** tab (boot order). To install a VM from the network, set `n` first and boot it: the VM's virtual NIC does PXE like a physical machine.
+
+### BIOS vs UEFI firmware
+
+The firmware type (BIOS or UEFI) is chosen at VM creation, from the template or the creation form. Switching an **installed** guest between BIOS and UEFI is not supported: the guest OS bootloader setup differs. Create the VM with the right firmware from the start; UEFI is the default for modern guests and required for [Secure Boot](../guides/guest-UEFI-Secure-Boot.md) and Windows 11.
+
+To check a VM's firmware from the CLI:
+
+<Terminal shell title="root@xcp-ng-host — BIOS vs UEFI firmware">{`
+xe vm-param-get uuid=<vm-uuid> param-name=HVM-boot-params
+xe vm-param-get uuid=<vm-uuid> param-name=platform param-key=device-model
+`}</Terminal>
+
+See also [how to check UEFI/Secure Boot status](../guides/guest-UEFI-Secure-Boot.md#misc).
+
+## 🔐 vTPM {#vtpm}
+
+Starting with XCP-ng 8.3, VMs can have a **virtual TPM 2.0**, required for Windows 11 and Windows Server 2025, and usable by Linux guests too.
+
+* From Xen Orchestra: the Windows 11 template enables it automatically; you can also toggle "vTPM" in the VM creation form or in the VM's Advanced tab (VM halted).
+* With `xe`, on a halted VM:
+
+<Terminal shell title="root@xcp-ng-host — vTPM">{`
+xe vtpm-create vm-uuid=<vm-uuid>
+`}</Terminal>
+
+Notes:
+
+* The vTPM state is stored with the pool metadata, not on a disk: it follows the VM in exports and backups made by Xen Orchestra.
+* If the guest uses the TPM for disk encryption (e.g. BitLocker), **keep your recovery keys safe**: losing the vTPM state means the guest can't unseal its keys.
+* Suspending or checkpointing (RAM snapshot) a vTPM-equipped VM is not supported.
+
+## ⏰ Time in VMs {#time-in-vms}
+
+Guests get their initial clock from the host, then keep time themselves. Recommendations:
+
+* Keep the **hosts** correctly synchronized first: see [NTP configuration](../management/hosts-pools.md#time-synchronization-ntp).
+* Run an NTP client **in each guest** (chrony, systemd-timesyncd, Windows Time). Time drifts after live migrations, suspend/resume or snapshots revert are then corrected automatically.
+* **Windows** stores local time in the RTC by default. XCP-ng exposes a UTC clock, so either keep Windows' own time service active (default, recommended) or make Windows use UTC. If a Windows VM shows a fixed offset after boot, check the timezone settings in the guest.
+
+## 🚫 Blocking operations on a VM {#blocking-operations-on-a-vm}
+
+Any XAPI operation can be administratively blocked per VM (deletion, but also start, shutdown, migration…):
+
+<Terminal shell title="root@xcp-ng-host — Blocking operations on a VM">{`
+xe vm-param-set uuid=<vm-uuid> blocked-operations:migrate_send=true
+`}</Terminal>
+
+See [protecting a VM against accidental deletion](vm-lifecycle.md#protect-a-vm-against-accidental-deletion) for the most common use.
+
+## 🧠 VM memory {#vm-memory}
+
+A VM's memory is defined by four values: static min/max (the hard bounds, changed only while the VM is halted) and dynamic min/max (the range the VM can be ballooned within, at runtime). When dynamic min = dynamic max, the VM simply owns that amount: this is the recommended setup for predictable performance, and the [caution about Dynamic Memory Control](vms.md#dynamic-memory) explains why.
+
+<Terminal shell title="root@xcp-ng-host — VM memory">{`
+xe vm-param-list uuid=<vm-uuid> | grep memory      # current values
+xe vm-memory-limits-set vm=<vm> static-min=2GiB dynamic-min=8GiB dynamic-max=8GiB static-max=8GiB
+xe vm-memory-set vm=<vm> memory=8GiB               # shortcut: all four to the same value
+`}</Terminal>
+
+Xen Orchestra exposes the same in the VM's Advanced tab ("VM limits"). Remember that the host also needs memory for dom0 and the Xen overhead: see the [dom0 memory guide](../guides/dom0-memory.md).

--- a/docs/vms/import-export.md
+++ b/docs/vms/import-export.md
@@ -1,0 +1,66 @@
+---
+sidebar_position: 6
+---
+
+# Import and export VMs
+
+Moving VMs in and out of XCP-ng as files: full VMs (XVA, OVA) or individual disks (VHD, VMDK…).
+
+:::tip
+Coming from VMware, Hyper-V, KVM or another hypervisor? There's a dedicated page: [migrate to XCP-ng](../installation/migrate-to-xcp-ng.md), including XO's V2V tool for live VMware conversions.
+:::
+
+## 📦 Formats {#formats}
+
+* **XVA**: the native format. A single streamable file containing the VM's metadata *and* its disks. Best fidelity (everything is preserved), best performance, and works between any XCP-ng/XAPI-based hosts. Use it whenever both sides are XCP-ng.
+* **OVA/OVF**: the interchange format, when the other side is *not* XCP-ng. An OVA is an archive with the disks and a hardware description; interpretation varies between vendors, so expect to double-check VM settings after import.
+* **Disk images** (VHD, VMDK, raw): import/export a single disk rather than a whole VM. Attach the imported disk to a VM you create yourself.
+
+## 📥 Import {#import}
+
+### XVA
+
+From Xen Orchestra: **New** → **Import**, pick the file. With `xe`:
+
+<Terminal shell title="root@xcp-ng-host — XVA">{`
+xe vm-import filename=my-vm.xva sr-uuid=<destination-sr-uuid>
+`}</Terminal>
+
+Add `preserve=true` to keep the original MAC addresses (beware of duplicates if the original VM still runs somewhere!).
+
+### OVA
+
+From Xen Orchestra: **New** → **Import** accepts `.ova` files directly, shows the parsed hardware description and lets you adjust it before creating the VM. After import, install the [guest tools](vms.md#guest-tools) and check boot mode, NICs and disks.
+
+### Single disks
+
+From Xen Orchestra: **New** → **Import** → **Disk** imports a VHD or VMDK file into an SR of your choice; then attach it to a VM ([how](../storage/manage-srs.md#create-and-attach-a-new-disk-to-a-vm)). With `xe`, see [vdi-import](../storage/manage-srs.md#export--import-a-single-disk).
+
+## 📤 Export {#export}
+
+### XVA
+
+From Xen Orchestra: VM → **Export** (with optional compression; zstd is a good default: much smaller files for a modest CPU cost). With `xe`:
+
+<Terminal shell title="root@xcp-ng-host — XVA">{`
+xe vm-export vm="my-vm" filename=my-vm.xva
+`}</Terminal>
+
+The VM should be halted; to export a *running* VM's state, take a [snapshot](snapshots.md) and export that instead:
+
+<Terminal shell title="root@xcp-ng-host — XVA">{`
+xe snapshot-export-to-template snapshot-uuid=<snapshot-uuid> filename=my-vm.xva
+`}</Terminal>
+
+### OVA
+
+From Xen Orchestra: VM → **Export** and choose the OVA format. Use it only when the destination isn't XCP-ng.
+
+### Single disks
+
+From Xen Orchestra, each disk in the VM's Disks tab has an export button (VHD). See also [exporting VDIs with xe](../storage/manage-srs.md#export--import-a-single-disk).
+
+## 🔁 Not what you're looking for? {#not-what-youre-looking-for}
+
+* Moving a VM between two **connected** pools? Use [live migration](vm-migration.md), no intermediate file needed.
+* Recurring exports for safety? That's a backup job. See [backup](../management/backup.md): Xen Orchestra does scheduled full/delta backups, replication and more.

--- a/docs/vms/snapshots.md
+++ b/docs/vms/snapshots.md
@@ -1,0 +1,102 @@
+---
+sidebar_position: 4
+---
+
+# Snapshots
+
+A snapshot captures the state of a VM at a point in time: its disks, and optionally its RAM. Snapshots are the base of quick rollbacks ("let me try this upgrade…") and of delta backups.
+
+:::warning
+Snapshots are **not backups**: they live on the same SR as the VM. If the storage is lost, snapshots are lost with it. For real backups (full, delta, replicated, off-site…), use [Xen Orchestra backup](../management/backup.md).
+:::
+
+## 🎓 How they work {#how-they-work}
+
+XCP-ng disks are copy-on-write: taking a snapshot freezes the current disk state as a read-only parent, and the VM continues writing into a new child disk. This makes snapshot creation almost instant, but it has consequences:
+
+<Schema label="A disk chain after two snapshots · the VM writes only into the active leaf" legend={[["#7a8699", "read-only parents"], ["#56c288", "active disk"]]} maxWidth="640px">
+<svg viewBox="0 0 600 170" role="img" aria-label="A chain of disks: the base image, then snapshot 1, then snapshot 2, then the active disk receiving the VM's writes; each links to its parent">
+  <g fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.28)">
+    <rect x="20" y="60" width="120" height="46" rx="8"/>
+    <rect x="170" y="60" width="120" height="46" rx="8"/>
+    <rect x="320" y="60" width="120" height="46" rx="8"/>
+  </g>
+  <rect x="470" y="60" width="110" height="46" rx="8" fill="rgba(86,194,136,0.14)" stroke="#56c288" strokeOpacity="0.85"/>
+  <g fontSize="12" fill="#c6d2e1" textAnchor="middle">
+    <text x="80" y="80">base disk</text>
+    <text x="230" y="80">snapshot 1</text>
+    <text x="380" y="80">snapshot 2</text>
+  </g>
+  <text x="525" y="80" fontSize="12" fill="#56c288" textAnchor="middle">active disk</text>
+  <g fontSize="10" fill="#7a8699" textAnchor="middle">
+    <text x="80" y="96">full data</text>
+    <text x="230" y="96">changes only</text>
+    <text x="380" y="96">changes only</text>
+    <text x="525" y="96">new writes</text>
+  </g>
+  <g stroke="#7a8699" strokeWidth="1.5" fill="none">
+    <path d="M170 83 L 148 83 M148 83 l 8 -4 v 8 z"/>
+    <path d="M320 83 L 298 83 M298 83 l 8 -4 v 8 z"/>
+    <path d="M470 83 L 448 83 M448 83 l 8 -4 v 8 z"/>
+  </g>
+  <text x="240" y="53" fontSize="10.5" fill="#7a8699" textAnchor="middle">reads fall through the chain until the data is found</text>
+  <path d="M525 30 C 525 40, 525 48, 525 58" stroke="#56c288" strokeWidth="1.6" fill="none"/>
+  <text x="525" y="22" fontSize="11" fill="#56c288" textAnchor="middle">VM writes</text>
+  <text x="300" y="150" fontSize="10.5" fill="#7a8699" textAnchor="middle">deleting a snapshot merges its changes into its neighbor (coalesce) before space returns</text>
+</svg>
+</Schema>
+
+* Each snapshot extends the disk chain; a long chain slightly degrades I/O performance.
+* Snapshots consume space on the SR (on thick-provisioned SRs like LVM/iSCSI/HBA, a snapshot can reserve up to the full disk size).
+* Deleting a snapshot doesn't free space immediately: the [coalesce process](../storage/storage.md#coalesce) has to merge the chain in the background first.
+
+## 📸 Take a snapshot {#take-a-snapshot}
+
+Two flavors:
+
+* **Disk-only snapshot**: captures the disks. Works on a running or halted VM.
+* **Snapshot with RAM** (also called *checkpoint*): additionally saves the VM's memory. Reverting resumes the VM exactly where it was, running. Requires working [guest tools](vms.md#guest-tools) and takes longer.
+
+From Xen Orchestra: VM → **Snapshots** tab → new snapshot (with an option to also snapshot the RAM). With `xe`:
+
+<Terminal shell title="root@xcp-ng-host — Take a snapshot">{`
+xe vm-snapshot vm="my-vm" new-name-label="before-upgrade"
+xe vm-checkpoint vm="my-vm" new-name-label="before-upgrade-with-ram"
+`}</Terminal>
+
+:::tip
+In Xen Orchestra you can exclude specific disks from snapshots (and backups) by naming convention: putting `[NOSNAP]` (snapshots) or `[NOBAK]` (backups and their snapshots) in the disk's name. Very useful for large scratch/data disks. On XCP-ng 8.3, disk exclusion is supported natively by the snapshot API, which XO uses.
+:::
+
+## ⏪ Revert to a snapshot {#revert-to-a-snapshot}
+
+Reverting replaces the VM's current state with the snapshot's state. **Everything written since the snapshot is lost.**
+
+From Xen Orchestra: Snapshots tab → revert. With `xe`:
+
+<Terminal shell title="root@xcp-ng-host — Revert to a snapshot">{`
+xe snapshot-list snapshot-of=<vm-uuid>
+xe snapshot-revert snapshot-uuid=<snapshot-uuid>
+`}</Terminal>
+
+After reverting, the VM is halted (or suspended for a RAM snapshot; resume it to continue exactly where it was). The snapshot itself survives the revert, so you can revert again later.
+
+## 🗑️ Delete a snapshot {#delete-a-snapshot}
+
+From Xen Orchestra: Snapshots tab → delete. With `xe`:
+
+<Terminal shell title="root@xcp-ng-host — Delete a snapshot">{`
+xe snapshot-uninstall snapshot-uuid=<snapshot-uuid>
+`}</Terminal>
+
+Space is reclaimed asynchronously by the [coalesce process](../storage/storage.md#coalesce): expect a delay (and storage I/O activity) before the SR usage drops. If space never comes back, check that coalesce isn't stuck.
+
+## 🔁 Scheduled (rolling) snapshots {#scheduled-rolling-snapshots}
+
+Use Xen Orchestra's **Rolling Snapshot** backup jobs: take a snapshot of selected VMs on a schedule and keep the N most recent ones. This gives you automatic short-term rollback points at near-zero cost. See the [XO backup documentation](https://docs.xen-orchestra.com/xo5/rolling_snapshots) for details, and remember the warning above: schedule real backups too.
+
+## 🧰 Other things you can do with a snapshot {#other-things-you-can-do-with-a-snapshot}
+
+* [Create a template](templates.md#create-a-custom-template) from it (golden image without stopping the source VM).
+* Create a full VM from it: `xe snapshot-copy snapshot-uuid=<uuid> new-name-label="restored-vm"` (or from Xen Orchestra, "create VM from snapshot").
+* Export it as an XVA file: `xe snapshot-export-to-template snapshot-uuid=<uuid> filename=snap.xva` (see [import and export](import-export.md)).

--- a/docs/vms/templates.md
+++ b/docs/vms/templates.md
@@ -1,0 +1,83 @@
+---
+sidebar_position: 3
+---
+
+# Templates
+
+Templates are the blueprint VMs are created from: they define the virtual hardware (firmware type, devices, memory defaults…) and, optionally, pre-installed disk content.
+
+## 🎓 Two kinds of templates {#two-kinds-of-templates}
+
+* **Built-in templates**: shipped with XCP-ng, one per supported guest OS family. They contain **no disk content**: they only carry the right virtual hardware settings and optimizations for that OS (device model, boot mode, memory defaults…). You install the OS yourself from an ISO or network. Always create a VM from the template matching its OS: this is what guarantees the best defaults.
+* **Custom templates**: created by you from an existing VM or snapshot. They include the **disks' content**, so new VMs start as exact copies. This is the classic "golden image" workflow.
+
+List available templates:
+
+<Terminal shell title="root@xcp-ng-host — Two kinds of templates">{`
+xe template-list params=name-label
+`}</Terminal>
+
+:::tip
+If built-in templates are missing (e.g. after an incomplete upgrade), see [this troubleshooting entry](../troubleshooting/common-problems.md#missing-templates-when-creating-a-new-vm).
+:::
+
+## 📸 Create a custom template {#create-a-custom-template}
+
+### From a VM
+
+Halt the VM, then in Xen Orchestra use **Convert to template** (VM advanced tab). With `xe`, converting is a one-way flag flip:
+
+<Terminal shell title="root@xcp-ng-host — From a VM">{`
+xe vm-param-set uuid=<vm-uuid> is-a-template=true
+`}</Terminal>
+
+If you want to keep the original VM, clone it first and convert the clone.
+
+### From a snapshot
+
+A [snapshot](snapshots.md) of a running VM can become a template without ever stopping the source VM: in Xen Orchestra, snapshot list → **create template from snapshot**, or:
+
+<Terminal shell title="root@xcp-ng-host — From a snapshot">{`
+xe snapshot-export-to-template snapshot-uuid=<snapshot-uuid> filename=my-template.xva
+xe vm-import filename=my-template.xva preserve=true
+`}</Terminal>
+
+## 🧼 Prepare the source before templating {#prepare-the-source-before-templating}
+
+New VMs created from a custom template are clones: anything unique to the source machine gets duplicated. Before converting a source VM into a template:
+
+* **Linux**: clear `/etc/machine-id`, remove SSH host keys (they'll regenerate at boot with most distros), remove static network configuration, clean logs and package caches. Even better, install `cloud-init` so each new VM configures its hostname, users and network at first boot. Xen Orchestra has first-class cloud-init support (see [cloud features](../management/cloud.md)).
+* **Windows**: run `sysprep /generalize` so each clone gets its own machine identity.
+
+A full worked example (cloud image → prepared VM → template → new VMs) is in the [Ubuntu custom templates guide](../guides/create-use-custom-xcpng-ubuntu-templates.md).
+
+## 🚀 Create VMs from a template {#create-vms-from-a-template}
+
+From Xen Orchestra: **New** → **VM** and pick your template: custom templates appear alongside built-in ones. With `xe`:
+
+<Terminal shell title="root@xcp-ng-host — Create VMs from a template">{`
+xe vm-install template="my-golden-image" new-name-label="new-vm" sr-uuid=<sr-uuid>
+`}</Terminal>
+
+For repeated or automated deployments, drive this with [Terraform/OpenTofu, Packer or Ansible](../management/infrastructure-as-code.md).
+
+## 📦 Move templates around {#move-templates-around}
+
+Templates export and import like VMs, in XVA format, which is handy to copy a golden image to another pool:
+
+<Terminal shell title="root@xcp-ng-host — Move templates around">{`
+xe template-export template-uuid=<template-uuid> filename=my-template.xva
+xe vm-import filename=my-template.xva preserve=true
+`}</Terminal>
+
+Or from Xen Orchestra, export/import from the template's view (see [import and export](import-export.md)).
+
+## 🗑️ Delete a custom template {#delete-a-custom-template}
+
+In Xen Orchestra, from the templates list (Home → VMs → templates filter). With `xe`:
+
+<Terminal shell title="root@xcp-ng-host — Delete a custom template">{`
+xe template-uninstall template-uuid=<template-uuid>
+`}</Terminal>
+
+This also removes the template's disks (after confirmation).

--- a/docs/vms/vm-lifecycle.md
+++ b/docs/vms/vm-lifecycle.md
@@ -1,0 +1,120 @@
+---
+sidebar_position: 2
+---
+
+# Create and manage VMs
+
+Creating, cloning and deleting virtual machines on XCP-ng.
+
+:::tip
+The most comfortable way to create and manage VMs is [Xen Orchestra](../management/manage-at-scale/xo-web-ui.md) (or [XO Lite](../management/manage-locally/xo-lite.md) directly from your host, for simple cases). The `xe` commands below are useful for scripting and automation. See also [infrastructure as code](../management/infrastructure-as-code.md) for Terraform/OpenTofu, Packer and Ansible.
+:::
+
+## 🏗️ Create a VM {#create-a-vm}
+
+### From a template + ISO
+
+The usual workflow: pick the [template](templates.md) matching the guest OS, give the VM resources, attach an installation ISO, install the OS, then install the [guest tools](vms.md#guest-tools).
+
+From Xen Orchestra: **New** → **VM**, pick the pool, template, name, CPU/RAM, disks and network, select the ISO, and create. ISOs come from an [ISO SR](../storage/storage.md#iso-sr).
+
+With `xe`:
+
+<Terminal shell title="root@xcp-ng-host — From a template + ISO">{`
+# Find the right template
+xe template-list params=name-label | grep -i debian
+
+# Create the VM from it
+xe vm-install template="Debian Bookworm 12" new-name-label="my-vm"
+
+# Attach the install ISO and a network interface
+xe vm-cd-add vm="my-vm" cd-name="debian-12.iso" device=3
+xe vif-create vm-uuid=<vm-uuid> network-uuid=<network-uuid> device=0
+
+# Start it and install the OS through the console
+xe vm-start vm="my-vm"
+`}</Terminal>
+
+`vm-install` creates the disks defined by the template on the default SR; add `sr-uuid=` to choose another one.
+
+### From a cloud image
+
+For cloud-ready images (Ubuntu cloud images, Debian genericcloud…), import the image as a disk and configure it at first boot with cloud-init: see the [custom templates guide](../guides/create-use-custom-xcpng-ubuntu-templates.md) and Xen Orchestra's cloud-init support in the [cloud features page](../management/cloud.md).
+
+### By cloning
+
+See [clone or copy](#clone-or-copy-a-vm) below: cloning an installed and prepared VM (or a [template](templates.md) made from it) is the fastest way to mass-produce VMs.
+
+### By importing
+
+Import an existing VM (XVA, OVA, or disks from another hypervisor): see [import and export](import-export.md) and [migrate to XCP-ng](../installation/migrate-to-xcp-ng.md).
+
+## 🐑 Clone or copy a VM {#clone-or-copy-a-vm}
+
+Two different operations:
+
+* **Clone** (`xe vm-clone`): near-instant on SRs supporting copy-on-write: the clone shares its base disk with the original ("fast clone" in Xen Orchestra). Ideal to spin up many VMs from one source on the same SR.
+* **Copy** (`xe vm-copy`): full independent copy of the disks, optionally to a **different SR**. Slower, but the result doesn't share anything with the source ("full copy" in Xen Orchestra).
+
+<Terminal shell title="root@xcp-ng-host — Clone or copy a VM">{`
+xe vm-clone vm="my-vm" new-name-label="my-vm-clone"
+xe vm-copy vm="my-vm" new-name-label="my-vm-copy" sr-uuid=<destination-sr-uuid>
+`}</Terminal>
+
+The source VM must be halted (or use a [snapshot](snapshots.md) of a running VM as the source).
+
+:::warning
+Clones inherit everything from the source, including hostname, SSH host keys, and machine IDs. For anything you plan to clone repeatedly, prepare the source first (for Linux: reset `/etc/machine-id`, SSH host keys, static IPs; for Windows: use `sysprep`). Details in the [templates page](templates.md).
+:::
+
+## ⚡ Start, stop, reboot {#start-stop-reboot}
+
+From Xen Orchestra or XO Lite, use the VM's action buttons. With `xe`:
+
+<Terminal shell title="root@xcp-ng-host — Start, stop, reboot">{`
+xe vm-start vm="my-vm"
+xe vm-shutdown vm="my-vm"            # clean shutdown, needs guest tools
+xe vm-reboot vm="my-vm"
+xe vm-shutdown vm="my-vm" force=true # hard power-off, last resort
+`}</Terminal>
+
+A clean shutdown/reboot requires working [guest tools](vms.md#guest-tools) in the VM. You can also suspend a VM to disk (`xe vm-suspend` / `xe vm-resume`): its memory is written to the default SR and the VM stops consuming RAM.
+
+To start VMs automatically when the host boots, see the [autostart guide](../guides/autostart-vm.md). To choose *which host* a VM should preferably run on, set its affinity host (`xe vm-param-set uuid=<vm-uuid> affinity=<host-uuid>`). See [VM load balancing](../management/vm-load-balancing.md) for dynamic placement.
+
+## 🛡️ Protect a VM against accidental deletion {#protect-a-vm-against-accidental-deletion}
+
+You can block specific operations on any VM, including deletion:
+
+<Terminal shell title="root@xcp-ng-host — Protect a VM against accidental…">{`
+xe vm-param-set uuid=<vm-uuid> blocked-operations:destroy=true
+`}</Terminal>
+
+Anyone (or any script) trying to delete the VM will get an error until the block is removed:
+
+<Terminal shell title="root@xcp-ng-host — Protect a VM against accidental…">{`
+xe vm-param-remove uuid=<vm-uuid> param-name=blocked-operations param-key=destroy
+`}</Terminal>
+
+## 🧺 VM groups with a start order (vApps) {#vapps}
+
+XAPI can group VMs into an *appliance* (also called vApp): a set of VMs started together, in a defined order, with delays between them. Typical use: bring a database up before the application servers. The group is also what [HA](../management/ha.md) and DR tooling can recover as a unit.
+
+<Terminal shell title="root@xcp-ng-host — VM groups with a start order…">{`
+xe appliance-create name-label="my-app"
+xe vm-param-set uuid=<vm-uuid> appliance=<appliance-uuid> start-order=1 start-delay=30
+xe appliance-start uuid=<appliance-uuid>
+`}</Terminal>
+
+See the [appliance commands](../appendix/cli_reference.md#appliance-commands) in the CLI reference.
+
+## 🗑️ Delete a VM {#delete-a-vm}
+
+From Xen Orchestra, deleting a VM lets you choose whether to also remove its disks and snapshots. With `xe`:
+
+<Terminal shell title="root@xcp-ng-host — Delete a VM">{`
+xe vm-uninstall vm="my-vm"           # deletes the VM and the disks marked for destruction
+xe vm-destroy uuid=<vm-uuid>         # deletes the VM record only, leaves the disks
+`}</Terminal>
+
+A VM must be halted before deletion. Remember that its snapshots are separate objects: list them with `xe snapshot-list snapshot-of=<vm-uuid>` and clean them up too, or the space won't be freed (see [snapshots](snapshots.md)).

--- a/docs/vms/vm-migration.md
+++ b/docs/vms/vm-migration.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 5
+---
+
+# VM migration
+
+Moving VMs between hosts, SRs and pools, live when possible.
+
+## 🎓 The different migration types {#the-different-migration-types}
+
+* **Live migration** (same pool, shared storage): only the VM's memory and execution state move to another host. Takes seconds to minutes, no service interruption beyond a sub-second switchover.
+* **Live migration with storage** ("storage motion"): additionally copies the VM's disks: between SRs, between hosts using only local storage, or **between pools**. Much longer (the whole disk is streamed), still without stopping the VM.
+* **Warm migration**: a Xen Orchestra feature for cases where live migration isn't possible (very different source and destination versions, CPU incompatibility…): the VM is replicated while running, then briefly suspended and switched over. See [migrating from older releases](../installation/upgrade.md#migrate-vms-from-older-xenserverxcp-ng).
+* **Cold migration**: the VM is halted; only disks move. Most robust, works across anything. See [moving disks](../storage/manage-srs.md#move-a-disk-to-another-sr) and [export/import](import-export.md).
+
+## ✅ Requirements and limitations {#requirements-and-limitations}
+
+* **CPU compatibility**: within a pool, [CPU leveling](../management/hosts-pools.md#heterogeneous-pools) guarantees live migration works between members. Across pools, the destination CPUs must be the same vendor and offer the features the VM currently uses (moving to a newer CPU generation usually works; the reverse may not).
+* **Memory**: the destination host needs enough free RAM for the VM.
+* **Attached hardware**: VMs using [PCI passthrough, physical GPUs/vGPU or USB passthrough](../compute.md) cannot live migrate: the physical device can't follow. Detach first, or migrate cold.
+* **Guest tools**: strongly recommended (and required for a healthy storage motion): see [guest tools](vms.md#guest-tools).
+* For storage motion, the destination SR needs space for the **full** disk size, and the disk chain gets flattened on arrival (snapshots don't follow the VM).
+
+:::tip
+On XCP-ng 8.3, you can speed up migrations on constrained networks by enabling [migration compression](../management/hosts-pools.md#migration-compression), and choose which network migrations use (Xen Orchestra: pool advanced settings → default migration network).
+:::
+
+## 🚀 Migrate within a pool {#migrate-within-a-pool}
+
+From Xen Orchestra: VM → **Migrate** action (or drag and drop the VM onto a host in the Home view). With `xe`:
+
+<Terminal shell title="root@xcp-ng-host — Migrate within a pool">{`
+xe vm-migrate vm="my-vm" host=<destination-host> live=true
+`}</Terminal>
+
+If the disks are on local storage (or you want to change SR at the same time), add a disk mapping and XAPI performs storage motion:
+
+<Terminal shell title="root@xcp-ng-host — Migrate within a pool">{`
+xe vm-migrate vm="my-vm" host=<destination-host> vdi:<vdi-uuid>=<destination-sr-uuid> live=true
+`}</Terminal>
+
+## 🌍 Migrate to another pool {#migrate-to-another-pool}
+
+From Xen Orchestra, the same **Migrate** dialog lets you pick any connected pool as destination, with per-disk SR mapping and per-interface network mapping. With `xe`:
+
+```
+xe vm-migrate vm="my-vm" remote-master=<destination-coordinator-ip> \
+  remote-username=root remote-password=<password> \
+  host-uuid=<destination-host-uuid> \
+  vdi:<vdi-uuid>=<destination-sr-uuid> \
+  vif:<vif-uuid>=<destination-network-uuid> live=true
+```
+
+Cross-pool migration is a disk copy under the hood: plan for the transfer time, and avoid concurrent backup jobs on the same VM.
+
+## 🧑‍⚕️ When something blocks the migration {#when-something-blocks-the-migration}
+
+* `xe host-get-vms-which-prevent-evacuation uuid=<host-uuid>` explains why VMs can't leave a host (used by [maintenance mode](../management/hosts-pools.md#maintenance-mode)).
+* "Not enough memory": free RAM on the destination, or lower the VM's [dynamic memory](vms.md#dynamic-memory).
+* CPU feature errors on cross-pool moves: use warm migration (above) or a cold move.
+* See also [VDI migration caveats](../storage/manage-srs.md#move-a-disk-to-another-sr) for storage-motion specifics.

--- a/docs/vms/vms.md
+++ b/docs/vms/vms.md
@@ -1,10 +1,29 @@
 ---
+sidebar_position: 1
 toc_max_heading_level: 4
 ---
 
 # Virtual Machines (VMs)
 
-## 🛠️ Guest Tools
+This page covers guest OS support and guest tools. The other pages of this section cover the VM operations:
+
+* [Create and manage VMs](vm-lifecycle.md): create, clone, start/stop, delete
+* [Templates](templates.md) and [Snapshots](snapshots.md)
+* [VM migration](vm-migration.md) and [Import and export](import-export.md)
+* [Advanced VM settings](advanced.md): boot options, vTPM, memory, time
+* [Windows VMs](windows.md): creation, sysprep, in-place upgrades
+
+## 🧩 Supported guest operating systems {#supported-guest-operating-systems}
+
+XCP-ng can run virtually any x86 operating system that works in a Xen HVM guest, far beyond any official list. In practice, three things define how well a guest is supported:
+
+1. **A matching [template](templates.md)**: XCP-ng ships templates with the right virtual hardware defaults for all common operating systems (Windows, the major Linux families, *BSD…). For an OS with no dedicated template, start from a generic or closely related one.
+2. **Guest tools availability**: PV drivers and a management agent make the difference between "it boots" and "it runs well": see the per-OS sections below.
+3. **The OS's own lifecycle**: an OS abandoned by its vendor will not get fixed for guest-side issues.
+
+If you rely on professional support, the commercially supported guest OS list is maintained on the [Vates documentation](https://docs.vates.tech/). For everything else, the [forum](https://xcp-ng.org/forum) is full of reports about less common guests.
+
+## 🛠️ Guest Tools {#guest-tools}
 
 XCP-ng needs guest tools to be installed in the VMs in order to communicate with the guest operating system. This brings better performance and is required for various features.
 
@@ -18,7 +37,7 @@ Linux: see [Linux Guest Tools](#linux-guest-tools) \
 Windows: see [Windows Guest Tools](#windows-guest-tools) \
 FreeBSD, OpenBSD and some appliances based on them: see [*BSD Guest Tools](#bsd-guest-tools)
 
-## 🏘️ All VMs
+## 🏘️ All VMs {#all-vms}
 
 ### Dynamic Memory
 
@@ -40,53 +59,53 @@ How Secure Boot can be enabled in VMs is described in a [dedicated guide](../gui
 
 1. Connect to a XCP-ng server using SSH, then execute this command with the VM UUID to join:
 
-```
+<Terminal shell title="root@xcp-ng-host — Use a VNC client">{`
 xe vm-list params=dom-id,resident-on uuid=<VM_UUID>
-```
+`}</Terminal>
 
 For example:
 
-```
+<Terminal title="root@xcp-ng-host — Use a VNC client">{`
 xe vm-list params=dom-id,resident-on uuid=b2632c6a-8c0c-2fcc-4f1f-5b872733f58c
 resident-on ( RO)    : 888254e8-da05-4f86-ad37-979b8d6bad04
          dom-id ( RO): 2
-```
+`}</Terminal>
 
 2. Then, check you are on the host where the VM is currently running using the host UUID:
 
-```
+<Terminal title="root@xcp-ng-host — Use a VNC client">{`
 xe pif-list management=true params=IP host-uuid=888254e8-da05-4f86-ad37-979b8d6bad04
 IP ( RO)    : 172.16.210.15
-```
+`}</Terminal>
 
 If not, use this IP to create an SSH connection to the right host.
 
 3. Ensure `socat` is installed and execute this command with the DOM ID got earlier and a free TCP port:
 
-```
+<Terminal shell title="Use a VNC client">{`
 socat TCP-LISTEN:<TCP_PORT_TO_USE> UNIX-CONNECT:/var/run/xen/vnc-<DOM_ID>
-```
+`}</Terminal>
 
 What have we done? We exposed a UNIX domain socket (which allows us to connect to the VM using VNC) directly over TCP.
 
 4. Fine, now open a new shell, and on your local machine create an SSH tunnel with a free TCP port:
 
-```
+<Terminal shell title="Use a VNC client">{`
 ssh -L <LOCAL_PORT>:localhost:<REMOTE_PORT> root@<HOST_IP>
-```
+`}</Terminal>
 
 5. Finally, start the client, for example `vncviewer`:
 
-```
+<Terminal shell title="Use a VNC client">{`
 vncviewer localhost:<LOCAL_PORT>
-```
+`}</Terminal>
 
 ### Disk WWID
 
 Certain applications, such as Oracle ASM, require a unique identifier for disk drives known as a WWID (World Wide Identifier). In a Linux environment, this can be achieved by utilizing the `ID_PART_ENTRY_UUID` or `ID_PART_ENTRY_NAME` variables. These identifiers can be set in the udev rules file located at `/etc/udev/rules.d/99-asm.rules`. For detailed instructions on configuring disk devices manually for Oracle ASM using WWID, refer to [this guide](https://alexzy.blogspot.com/2018/02/configuring-disk-devices-manually-for.html).
 
 
-## 🪟 Windows VMs
+## 🪟 Windows VMs {#windows-vms}
 
 ### Windows Guest Tools
 
@@ -131,9 +150,11 @@ Before starting the VM:
 If you already started the VM with the option on, then the Citrix drivers have been installed automatically. Restart from scratch or go to [Fully removing Xen PV drivers with XenClean](#fully-removing-xen-pv-drivers-with-xenclean).
 
 Tip: you can also check the value of the parameter from the command line.
-```
+
+<Terminal shell title="root@xcp-ng-host — Prerequisite: Disable 'Manage…">{`
 xe vm-param-get param-name=has-vendor-device uuid={VM-UUID}
-```
+`}</Terminal>
+
 `True` means that it's active, `False` that it isn't. It needs to be `False`.
 
 ##### Install the XCP-ng tools
@@ -345,9 +366,9 @@ Viridian enlightenments are enabled by default on Windows VM templates included 
 
 To enable Viridian enlightenments for other non-Windows VM templates, simply run the following command:
 
-```
+<Terminal shell title="root@xcp-ng-host — Enabling Viridian extensions">{`
 xe vm-param-set uuid=<vm-uuid> platform:device_id=0002 platform:viridian=true platform:viridian_time_ref_count=true platform:viridian_reference_tsc=true platform:viridian_apic_assist=true platform:viridian_crash_ctl=true platform:viridian_stimer=true
-```
+`}</Terminal>
 
 :::warning
 Do not set the device ID on VMs with Xen PV drivers installed. Changing the device ID may cause old Xen PV drivers to fail booting.
@@ -395,19 +416,22 @@ The issue is due to a parameter value which is specific to Windows VMs and preve
 First, get the UUID of the Windows VM (visible in Xen Orchestra, or in the output of `xe vm-list`) and make sure it is powered off.
 
 Open an ssh session to the XCP-ng host of the concerned VM and enter the following command:
-```bash
-$ xe vm-param-set uuid=VM-UUID platform:device_id=0001
-```
+
+<Terminal shell title="root@xcp-ng-host — Booting a live Linux ISO on a…">{`
+xe vm-param-set uuid=VM-UUID platform:device_id=0001
+`}</Terminal>
+
 Where `VM-UUID` is the uuid of the Windows VM.
 
 You should be able to boot the VM on any Linux ISO disk.
 
 Once done with Linux, shut down the VM and restore the parameter to its original value with:
-```bash
-$ xe vm-param-set uuid=VM-UUID platform:device_id=0002
-```
 
-## 🐧 Linux VMs
+<Terminal shell title="root@xcp-ng-host — Booting a live Linux ISO on a…">{`
+xe vm-param-set uuid=VM-UUID platform:device_id=0002
+`}</Terminal>
+
+## 🐧 Linux VMs {#linux-vms}
 
 ### Linux Guest Tools
 
@@ -430,31 +454,37 @@ Distros often have policies that forbid enabling new services by default, so mos
 
 ##### CentOS and Fedora
 Enable the EPEL repository in the VM, then:
-```
+
+<Terminal shell title="root@xcp-ng-host — CentOS and Fedora">{`
 yum install xe-guest-utilities-latest
-```
+`}</Terminal>
+
 The service is not enabled by default, so enable it and start it:
-```
+
+<Terminal shell title="CentOS and Fedora">{`
 systemctl enable xe-linux-distribution
 systemctl start xe-linux-distribution
-```
+`}</Terminal>
 
 ##### Alpine
 Enable the `community` repository in `/etc/apk/repositories`, then:
-```
+
+<Terminal shell title="Alpine">{`
 apk add xe-guest-utilities
-```
+`}</Terminal>
+
 The service is not enabled by default, so enable it and start it:
-```
+
+<Terminal title="Alpine">{`
 rc-update add xe-guest-utilities
 rc-service xe-guest-utilities start
-```
+`}</Terminal>
 
 ##### Ubuntu
 
-```
+<Terminal shell title="Ubuntu">{`
 apt install xe-guest-utilities
-```
+`}</Terminal>
 
 Some older versions of Ubuntu, now EOL, may not have this package available in their repositories. Known such releases are 20.10 to 21.10. The best solution is to upgrade to a supported release. If this is really not possible, you may install the tools from the guest tools ISO.
 
@@ -467,20 +497,24 @@ Some older versions of Ubuntu, now EOL, may not have this package available in t
 For distros that are supported by the `install.sh` script (Debian, CentOS, RHEL, SLES, Ubuntu...), the process is:
 * Attach the guest tools ISO to the guest from Xen Orchestra or using `xe`.
 * Then inside the VM, as root:
-```
+
+<Terminal shell title="Supported' Linux distributions">{`
 mount /dev/cdrom /mnt
 bash /mnt/Linux/install.sh
 umount /dev/cdrom
-```
+`}</Terminal>
+
 * No need to reboot the VM even if the script asks to. That's an old message from back when it was needed to install a kernel module in addition to the management agent. We'll get rid of it at some point.
 * Eject the guest tools ISO
 
 ##### Derived Linux distributions
 
 If your Linux distribution is not recognized by the installation script but derives from one that is supported by the script, you can override the detection and force the tools to install by using:
-```
+
+<Terminal shell title="Derived Linux distributions">{`
 bash /mnt/Linux/install.sh -d $DISTRO -m $MAJOR_VERSION
-```
+`}</Terminal>
+
 Examples:
 ```
 ## derived from debian 10
@@ -500,30 +534,37 @@ For the remaining Linux distributions, mount the guest tools ISO as described ab
 ###### openSUSE Leap 15.2 with transactional-update
 
 For the xe-daemon to start it is necessary that insserv is installed on the system. To make sure that is the case run
-```
+
+<Terminal shell title="openSUSE Leap 15.2 with transactional-update">{`
 sudo transactional-uptdate pkg install insserv-compat
-```
+`}</Terminal>
+
 and as good measure reboot if they weren't already installed.
 
 To install the guest tools open up the chroot environment with
-```
+
+<Terminal shell title="openSUSE Leap 15.2 with transactional-update">{`
 sudo transactional-update shell
-```
+`}</Terminal>
+
 and mount the ISO like with every other derived distro
-```
+
+<Terminal shell title="openSUSE Leap 15.2 with transactional-update">{`
 mount /dev/cdrom /mnt
 bash /mnt/Linux/install.sh -d sles -m 15
 umount /dev/cdrom
-```
+`}</Terminal>
+
 To exit the chroot cleanly you have to kill the `xe-daemon` process that may have been automatically started. Otherwise you end up with a corrupted snapshot and transactional-update will fail.
 
 And again reboot the system to go to your newest snapshot.
 
 After the reboot enable the service and start it with
-```
+
+<Terminal shell title="openSUSE Leap 15.2 with transactional-update">{`
 systemctl enable xe-linux-distribution.service
 systemctl start xe-linux-distribution.service
-```
+`}</Terminal>
 
 #### Update the guest tools
 
@@ -545,7 +586,7 @@ The default Ubuntu installation includes a package named `linux-modules-extra` c
 
 For more details, the problem comes from `Ubuntu` kernels that don't have the `efi-framebuffer` driver compiled in. This driver should be used if the `bochs` driver isn't present and it is just not selected in the `Ubuntu` kernel build config. To be more precise, `Ubuntu` kernels try to use a driver called `simple-framebuffer` for which there seems to be an incompatibility with the way the OVMF UEFI bios initializes the VGA card, causing the distorted display.
 
-## 😈 *BSD VMs
+## 😈 *BSD VMs {#bsd-vms}
 
 ### *BSD Guest Tools
 
@@ -562,10 +603,11 @@ To communicate with the hypervisor, you need to install two [ports](https://www.
 The `install.sh` script on the guest tools ISO does not yet support FreeBSD, so there is no point in mounting the guest tools ISO on a FreeBSD VM.
 
 To manually [install xe-guest-utilities from a package](https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/pkgng-intro.html) you can run:
-```
+
+<Terminal shell title="FreeBSD Guest Tools">{`
 pkg install xen-guest-tools xe-guest-utilities
 service xenguest start
-```
+`}</Terminal>
 
 By default the `xe-daemon` will run if FreeBSD detects the Xen hypervisor at boot. If that autodetection fails for some reason, you can force it to try by putting `xenguest_enable=YES` in your `rc.conf` file: `sysrc xenguest_enable=YES`.
 

--- a/docs/vms/windows.md
+++ b/docs/vms/windows.md
@@ -1,0 +1,55 @@
+---
+sidebar_position: 8
+---
+
+# Windows VMs
+
+The Windows-specific parts of a VM's life on XCP-ng: creation choices, golden images with sysprep, in-place Windows upgrades, and where to go when something breaks. The [guest tools themselves are covered in detail here](vms.md#windows-guest-tools).
+
+## 🏗️ Creating a Windows VM {#creating-a-windows-vm}
+
+Follow the [normal VM creation workflow](vm-lifecycle.md), with these Windows-specific points:
+
+* **Pick the template matching your Windows version**: it sets the right firmware and device defaults.
+* **Windows 11 and Windows Server 2025** require UEFI with [Secure Boot](../guides/guest-UEFI-Secure-Boot.md) and a [vTPM](advanced.md#vtpm) (XCP-ng 8.3). The Windows 11 template configures this for you.
+* The firmware type (BIOS/UEFI) [cannot be changed after installation](advanced.md#bios-vs-uefi-firmware), so don't create new Windows VMs in BIOS mode unless you have a specific reason.
+* Install the [Windows guest tools](vms.md#windows-guest-tools) right after the OS installation, and read that section first: the choice between XCP-ng and XenServer tools, and the Windows Update behavior around drivers, matter.
+
+## 🧼 Golden image with sysprep {#golden-image-with-sysprep}
+
+Windows machines carry a unique identity. To build a [template](templates.md) you'll clone many VMs from:
+
+1. Install Windows, the guest tools, your applications and updates in a source VM.
+2. Generalize it with sysprep, which removes the machine-specific identity and shuts the VM down:
+
+```
+C:\Windows\System32\Sysprep\sysprep.exe /generalize /oobe /shutdown
+```
+
+3. Convert the halted VM into a [custom template](templates.md#create-a-custom-template).
+4. Each VM created from it goes through Windows' first-boot setup (OOBE) with its own identity; automate that part with an unattend file if you deploy at scale.
+
+The guest tools survive sysprep: install them before generalizing, not after cloning.
+
+## ⬆️ Upgrading Windows in place {#upgrading-windows-in-place}
+
+Upgrading the Windows version *inside* an existing VM (e.g. Windows Server 2019 to 2022) works like on physical hardware, with these precautions:
+
+1. Take a [snapshot](snapshots.md) first, so you can roll back a failed upgrade in seconds.
+2. Update the [guest tools](vms.md#windows-guest-tools) to the latest version **before** upgrading the OS, so the drivers in place are the ones best supporting the newer Windows.
+3. Run the new version's installer/upgrade from within the guest, as Microsoft documents it.
+4. After the upgrade, check in the Device Manager that the PV drivers are still active, and that the management agent reports to XAPI (the VM's IP address visible in Xen Orchestra is a good sign).
+
+:::warning
+An upgrade to **Windows 11** has hardware requirements (UEFI, Secure Boot, TPM) that a VM created in BIOS mode cannot meet, since the [firmware can't be switched](advanced.md#bios-vs-uefi-firmware) after installation. For those, create a fresh UEFI + vTPM VM and migrate the data instead.
+:::
+
+## 🖥️ Console access {#console-access}
+
+The console in Xen Orchestra/XO Lite works from the first boot, with no guest configuration. For day-to-day use, enable Remote Desktop inside the guest and connect with your usual RDP client; the XO console remains your out-of-band access when the network is down. About resolution tuning, see [managing screen resolution](vms.md#manage-screen-resolution).
+
+## 🧑‍⚕️ When Windows misbehaves {#when-windows-misbehaves}
+
+* Boot failures, BSODs, storage performance, drivers not updating: see the dedicated [Windows guest tools troubleshooting](../troubleshooting/windows-pv-tools.md) page, including [how to gather kernel memory dumps](../troubleshooting/windows-pv-tools.md#how-to-gather-kernel-memory-dumps-for-in-depth-troubleshooting) for support cases.
+* Automating PV driver updates through Group Policy: see [this guide](../guides/winpv-update.md).
+* Secure Boot issues: see the [Secure Boot guide](../guides/guest-UEFI-Secure-Boot.md#troubleshoot-guest-secure-boot-issues).

--- a/docs/xostor/_category_.json
+++ b/docs/xostor/_category_.json
@@ -1,4 +1,4 @@
 {
     "label": "XOSTOR",
-    "position": 9
+    "position": 10
 }

--- a/docs/xostor/xostor.md
+++ b/docs/xostor/xostor.md
@@ -1,7 +1,7 @@
 
 # XOSTOR documentation
 
-## LINSTOR/DRBD global documentation in the context of XCP-ng
+## 🎓 LINSTOR/DRBD global documentation in the context of XCP-ng {#linstordrbd-global-documentation-in-the-context-of-xcp-ng}
 
 ### What is LINSTOR?
 
@@ -300,9 +300,9 @@ ExecStop=/opt/xensource/libexec/safe-umount /var/lib/linstor
 RemainAfterExit=true
 ```
 
-## Howto and Questions
+## ❓ Howto and Questions {#howto-and-questions}
 
-## Installation
+## 📥 Installation {#installation}
 
 ### Prerequisites
 
@@ -323,11 +323,11 @@ Changing the replication factor after creating XOSTOR is not possible, as it can
 The maximum number of machines per pool is 7.
 :::
 
-## Update
+## ♻️ Update {#update}
 
 See this documentation: [RPU](/management/updates/#rolling-pool-update-rpu).
 
-## Upgrade
+## ⬆️ Upgrade {#upgrade}
 
 If you are reading this documentation, we assume that you want to upgrade a pool on which XOSTOR is deployed, i.e. change the version of XCP-ng, for example from 8.2 to 8.3.
 For updates that don't change the version number of XCP-ng (bugfixes, security fixes), see [the update section](#update).
@@ -337,12 +337,13 @@ For updates that don't change the version number of XCP-ng (bugfixes, security f
 - All hosts must be up to date on the version of XCP-ng you are currently using. For this refer to [the update section](#update).
 - HA must be disabled on your pool.
 - Ensure all nodes are reachable and resources are in "OK" state via XO's XOSTOR view. Alternatively, you can use the CLI:
-```
+
+<Terminal shell title="root@xcp-ng-host — 1. Prerequisites">{`
 linstor n l
 linstor r l
 linstor adv r
 linstor sp l
-```
+`}</Terminal>
 
 ### 2. XCP-ng ISO with LINSTOR support
 
@@ -361,11 +362,12 @@ From this point we can proceed to upgrade your XOSTOR-enabled pool.
 
 An upgrade can take quite a long time so we recommend disabling the auto-evict mechanism during this procedure to avoid bad behavior.
 On the host where the controller is running:
-```
-linstor controller set-property DrbdOptions/AutoEvictAllowEviction False
-```
 
-For each host of the pool (starting with the master), follow the instructions given in [this guide](../installation/upgrade/#-upgrade-via-installation-iso-recommended).
+<Terminal shell title="root@xcp-ng-host — 3. Upgrade steps">{`
+linstor controller set-property DrbdOptions/AutoEvictAllowEviction False
+`}</Terminal>
+
+For each host of the pool (starting with the master), follow the instructions given in [this guide](../installation/upgrade/#upgrade-via-installation-iso-recommended).
 :::warning
 Do not update the host following an upgrade until all hosts in the XOSTOR pool have been upgraded.
 Otherwise, it could pull more recent versions of the LINSTOR packages on the newly upgraded hosts. LINSTOR packages versions need to be aligned on the whole pool.
@@ -381,15 +383,17 @@ Cannot upgrade host with LINSTOR using a package source that does not have LINST
 If you want to make sure that everything is going well so as not to impact your production, we recommend these manual checks after each host reboot:
 
 - Ensure the host node is connected with the command below. Otherwise wait a few seconds.
-```
+
+<Terminal shell title="root@xcp-ng-host — 3. Upgrade steps">{`
 linstor n list
-```
+`}</Terminal>
 
 - Check if there is an issue with the resources:
-```
+
+<Terminal shell title="root@xcp-ng-host — 3. Upgrade steps">{`
 linstor r list
 linstor advise r # Give possible fix commands in case of problems.
-```
+`}</Terminal>
 
 - Check in XOA that the PBD of the SR of this host is connected. If not, connect it.
 
@@ -400,26 +404,29 @@ Very important: if you don't want to break the quorum or your production environ
 ### 4. After pool upgrade
 
 - If you have deactivated auto eviction as recommended, it's necessary to reactivate it. On the host where the controller resides, execute this command:
-```
+
+<Terminal shell title="root@xcp-ng-host — 4. After pool upgrade">{`
 linstor controller set-property DrbdOptions/AutoEvictAllowEviction True
-```
+`}</Terminal>
 
 If a node was evicted because the recommendation was not followed, read this [topic](#what-to-do-when-a-node-is-in-an-evicted-state).
 
 - Check the resource states with:
-```
+
+<Terminal shell title="root@xcp-ng-host — 4. After pool upgrade">{`
 linstor r list
-```
+`}</Terminal>
 
 In case of bad sync between volumes, execute on each machine:
-```
+
+<Terminal shell title="4. After pool upgrade">{`
 systemctl stop linstor-controller
 systemctl restart linstor-satellite
-```
+`}</Terminal>
 
 - In case of a bad node (missing, without storage pool or inaccessible via `linstor n l`/`linstor sp l`) due to a failed upgrade or if the documentation was not followed correctly, you can read this [documentation](#how-to-add-a-new-host-or-fix-a-badly-configured-host) to recover.
 
-## Global questions
+## 💬 Global questions {#global-questions}
 
 ### The linstor command does not work!?
 
@@ -435,14 +442,16 @@ There can only be one controller running on a pool at a time. If you get this er
 
 :::tip
 It's possible to provide the command with a comma separated list of IPs, eliminating the need to manually try each host.
-```
+
+<Terminal shell title="root@xcp-ng-host — The linstor command does not…">{`
 linstor --controllers=<IP_LIST> r list
-```
+`}</Terminal>
 
 Example on a pool with 3 machines:
-```
+
+<Terminal shell title="root@xcp-ng-host — The linstor command does not…">{`
 linstor --controllers=172.16.210.84,172.16.210.85,172.16.210.86 r list
-```
+`}</Terminal>
 
 :::
 Important: the `--controllers` parameter should always be just after the command name and before the action.
@@ -451,9 +460,10 @@ Important: the `--controllers` parameter should always be just after the command
 ### How to list LINSTOR resources and interpret this output?
 
 Command:
-```
+
+<Terminal shell title="root@xcp-ng-host — How to list LINSTOR resources…">{`
 linstor r list
-```
+`}</Terminal>
 
 Output example:
 ```
@@ -493,15 +503,17 @@ Remarks regarding special volumes:
 ### How to get a quick view of the resource status of a pool?
 
 You can use the following commands to find out the status of a pool:
-```
+
+<Terminal shell title="root@xcp-ng-host — How to get a quick view of the…">{`
 linstor n list
 linstor r list
-```
+`}</Terminal>
 
 They return the state of the nodes and resources. If nothing is written in RED, it probably means that there is no damage to the data. However, this does not mean that there are no problems elsewhere. To prevent issues from happening, you can run this command:
-```
+
+<Terminal shell title="root@xcp-ng-host — How to get a quick view of the…">{`
 linstor advise r
-```
+`}</Terminal>
 
 It returns recommendations about resources that might have problems later.
 For example, you can have an output like this:
@@ -551,17 +563,19 @@ Resource UUIDs are different from VDI UUIDs. The output of `linstor r list` give
 To better understand the mapping of UUIDs, we developed a tool called `linstor-kv-tool`.
 
 Usage:
-```
+
+<Terminal shell title="Map LINSTOR resource names to XAPI VDI UUIDs">{`
 linstor-kv-tool --dump-volumes -u <HOSTNAME> -g <SP_NAME> | grep '/volume-name":'
-```
+`}</Terminal>
 
 - `<HOSTNAME>` is the IP of the host on which the controller is running. If you are currently connected to it, you can use `localhost`.
 - `<SP_NAME>` is the LINSTOR storage pool used by the pool.
 
 To know which group to specify, you can use the command:
-```
+
+<Terminal shell title="root@xcp-ng-host — Map LINSTOR resource names to…">{`
 linstor resource-group list
-```
+`}</Terminal>
 
 Output example:
 ```
@@ -620,23 +634,26 @@ Consider the following:
 
 :::warning
 If you want to configure a new host, make sure the pool is up-to-date (see [the update section](#update)) and make sure you have the required packages on the new host by running these commands on it:
-```
+
+<Terminal shell title="root@xcp-ng-host — How to add a new host or fix a…">{`
 yum install -y xcp-ng-release-linstor
 yum install -y xcp-ng-linstor
-```
+`}</Terminal>
 
 And then restart the toolstack to detect the LINSTOR driver:
-```
+
+<Terminal shell title="How to add a new host or fix a badly configured host?">{`
 xe-toolstack-restart
-```
+`}</Terminal>
 
 If you are in a situation where you can't safely update your pool, contact [Vates Pro Support](https://vates.tech/pricing-and-support) for guidance applying to your specific situation.
 :::
 
 First ensure you have the same configuration on each PBD of your XOSTOR SR using this command. Replace `<UUID>` with the SR UUID that you use:
-```
+
+<Terminal shell title="root@xcp-ng-host — How to add a new host or fix a…">{`
 xe pbd-list sr-uuid=<UUID>
-```
+`}</Terminal>
 
 Example output where the group-name is `linstor_group/thin_device`:
 ```
@@ -662,9 +679,11 @@ uuid ( RO)                  : 1d872d5b-fb60-dbd7-58fc-555a211f18fa
 ```
 
 Then if you want to fix an incorrect group name value or even add a new host, use this command with the correct `<GROUP_NAME>` and `<HOST_UUID>`:
-```
+
+<Terminal shell title="root@xcp-ng-host — How to add a new host or fix a…">{`
 xe host-call-plugin host-uuid=<HOST_UUID> plugin=linstor-manager fn=addHost args:groupName=<GROUP_NAME>
-```
+`}</Terminal>
+
 For a short description, this command (re)creates a PBD, opens DRBD/LINSTOR ports, starts specific services and adds the node to the LINSTOR database.
 
 If you have storage devices to use on the host, a LINSTOR storage layer is not directly added to the corresponding node.
@@ -677,9 +696,10 @@ There are two simple steps:
 2. Create a SP for the host pointing to this new VG
 
 You can verify the storage state like this:
-```
+
+<Terminal shell title="root@xcp-ng-host — How to add storage on a new host?">{`
 linstor sp list
-```
+`}</Terminal>
 
 Small example:
 
@@ -700,20 +720,23 @@ A `LVM_THIN` entry is missing for `hpmc17` in this context, meaning it has no lo
 
 To add disks to the linstor SR, you will need to create a LVM volume group.
 Connect to the machine to modify and use `vgcreate` with the wanted disks to create a VG group on the host:
-```
+
+<Terminal shell title="How to add storage on a new host?">{`
 vgcreate <GROUP_NAME> <DEVICES>
-```
+`}</Terminal>
 
 In our example where we want to use `/dev/nvme0n1` with the group `linstor_group`:
-```
+
+<Terminal shell title="How to add storage on a new host?">{`
 vgcreate linstor_group /dev/nvme0n1
-```
+`}</Terminal>
 
 For `thin` additional commands are required:
-```
+
+<Terminal title="How to add storage on a new host?">{`
 lvcreate -l 100%FREE -T <GROUP_NAME>/<LV_THIN_VOLUME>
 lvchange -ay <GROUP_NAME>/<LV_THIN_VOLUME>
-```
+`}</Terminal>
 
 Most of the time and in our example, we will have:
 - `<GROUP_NAME>`: `linstor_group`.
@@ -723,32 +746,36 @@ Most of the time and in our example, we will have:
 2. Create a new storage pool attached to the node
 
 Run the corresponding command on the host where the controller is running to add the volume group in the LINSTOR database:
-```
+
+<Terminal shell title="root@xcp-ng-host — How to add storage on a new host?">{`
 # For thin:
 linstor storage-pool create lvmthin <NODE_NAME> <SP_NAME> <VG_NAME>/<LV_THIN_VOLUME>
 
 # For thick:
 linstor storage-pool create lvm <NODE_NAME> <SP_NAME> <VG_NAME>
-```
+`}</Terminal>
 
 In our example:
-```
+
+<Terminal shell title="root@xcp-ng-host — For thick:">{`
 linstor storage-pool create lvm hpmc17 xcp-sr-linstor_group_thin_device linstor_group/thin_device
-```
+`}</Terminal>
 
 ### How to use a specific network for DRBD requests?
 
 To use a specific network to handle the DRBD traffic, a new interface must be created on each host:
-```
+
+<Terminal shell title="root@xcp-ng-host — How to use a specific network…">{`
 linstor node interface create <NODE_NAME> <INTERFACE_NAME> <IP>
-```
+`}</Terminal>
 
 `<INTERFACE_NAME>` is arbitrary; you can choose any name. Then, specify an existing IP on the host you have assigned to a network / NIC in XCP-ng.
 
 To set this new interface as active, use the following:
-```
+
+<Terminal shell title="root@xcp-ng-host — How to use a specific network…">{`
 linstor node set-property <NODE_NAME> PrefNic <INTERFACE_NAME>
-```
+`}</Terminal>
 
 Repeat this command for every node.
 
@@ -783,32 +810,37 @@ systemctl restart linstor-monitor.service
 There is no easy way to do this, the trick is to create a new node and remove the old one. Here are the steps to follow:
 
 1. Create a new node:
-```
+
+<Terminal shell title="root@xcp-ng-host — On all hosts">{`
 linstor node create --node-type Combined <NODE_NAME> <IP>
-```
+`}</Terminal>
 
 2. Evacuate the old node to preserve the replication count:
-```
+
+<Terminal shell title="root@xcp-ng-host — On all hosts">{`
 linstor node evacuate <OLD_NAME>
-```
+`}</Terminal>
 
 3. Change the hostname:
-```
+
+<Terminal shell title="root@xcp-ng-host — On all hosts">{`
 xe host-set-hostname-live host-uuid=<HOST_UUID> host-name=<HOST_NAME>
-```
+`}</Terminal>
 
 4. Restart the services on each host:
-```
+
+<Terminal shell title="On all hosts">{`
 systemctl stop linstor-controller
 systemctl restart linstor-satellite
-```
+`}</Terminal>
 
 5. Make sure that the resources of the deleted node have been replicated on the remaining host and verify with `linstor r list` that all resources are up to date. Then, delete the node and create a storage pool for the new node:
-```
-linstor node delete <OLD_NAME>
-```
 
-```
+<Terminal shell title="root@xcp-ng-host — On all hosts">{`
+linstor node delete <OLD_NAME>
+`}</Terminal>
+
+<Terminal shell title="root@xcp-ng-host — On all hosts">{`
 # For thin:
 linstor storage-pool create lvmthin <NODE_NAME> <SP_NAME> <VG_NAME>
 
@@ -816,14 +848,16 @@ linstor storage-pool create lvmthin <NODE_NAME> <SP_NAME> <VG_NAME>
 linstor storage-pool create lvm <NODE_NAME> <SP_NAME> <VG_NAME>
 
 # Example:
-# linstor storage-pool create lvmthin r620-s4 xcp-sr-linstor_group_thin_device linstor_group/thin_device
-```
+linstor storage-pool create lvmthin r620-s4 xcp-sr-linstor_group_thin_device linstor_group/thin_device
+`}</Terminal>
 
 :::tip
 To verify the Storage Pool, you can use:
-```
+
+<Terminal shell title="root@xcp-ng-host — linstor storage-pool create…">{`
 linstor sp list
-```
+`}</Terminal>
+
 :::
 
 6. Recreate the diskless/diskful resources (if necessary).
@@ -840,9 +874,11 @@ Jun 22 10:50:13 r620-s3 SM: [23871] FAILED in util.pread: (rc 22) stdout: 'error
 ```
 
 The problem with this error is that it's generic and can occur in other situations. If you're not sure what you're doing, contact us on [support](https://vates.tech) or the [forum](https://xcp-ng.org/forum). Alternatively you can confirm that a resource is indeed unusable, execute this command by connecting to a host where the volume is marked `InUse`:
-```
+
+<Terminal shell title="How can I delete an unreadable or unusable resource?">{`
 vhd-util check -n <DRBD_PATH>
-```
+`}</Terminal>
+
 In this example, `<DRBD_PATH>` is `/dev/drbd/by-res/xcp-volume-83da35c4-dd18-47fb-9d2b-68bd5b92fcaa/0`
 Two cases here:
 - If the volume is marked as `InUse` in the LINSTOR database, run this command on the host that is using it.
@@ -857,9 +893,10 @@ Additionally, we assume that if you destroy a resource, you have a recent backup
 :::
 
 1. Retrieve the SR's storage pool name using this command:
-```
+
+<Terminal shell title="root@xcp-ng-host — How can I delete an unreadable…">{`
 linstor sp list
-```
+`}</Terminal>
 
 Example output where the storage pool name is `xcp-sr-linstor_group_thin_device` in the `StoragePool` column:
 ```
@@ -876,9 +913,11 @@ Example output where the storage pool name is `xcp-sr-linstor_group_thin_device`
 ```
 
 2. If you don't know what the corresponding VDI UUID for the DRBD resource is, you can deduce it via this command:
-```
+
+<Terminal shell title="How can I delete an unreadable or unusable resource?">{`
 linstor-kv-tool --dump-volumes -g <SP_NAME> | grep volume-name | grep <RES_UUID>
-```
+`}</Terminal>
+
 As a reminder, `<RES_UUID>` is the UUID used in the naming of DRBD resources after the prefix `xcp-volume-`. For example: `xcp-volume-83da35c4-dd18-47fb-9d2b-68bd5b92fcaa`. And `<SP_NAME>` is the value obtained in the previous point.
 
 :::tip
@@ -886,30 +925,34 @@ For more explanation between `RES_UUID` and `VDI_UUID` link, check out [this sec
 :::
 
 Example result by replacing `<RES_UUID>` with `83da35c4-dd18-47fb-9d2b-68bd5b92fcaa`:
-```
+
+<Terminal title="How can I delete an unreadable or unusable resource?">{`
 linstor-kv-tool --dump-volumes -g xcp-sr-linstor_group_thin_device | grep volume-name | grep 83da35c4-dd18-47fb-9d2b-68bd5b92fcaa
   "xcp/volume/6b9046a2-8ef9-47ef-baa9-a4c533ca848a/volume-name": "83da35c4-dd18-47fb-9d2b-68bd5b92fcaa",
-```
+`}</Terminal>
+
 Here, the XAPI UUID of the VDI to delete is `6b9046a2-8ef9-47ef-baa9-a4c533ca848a`.
 
 3. You can remove the VDI reference from the `kv-store` via the following command, replace `<VDI_UUID>` with the one obtained previously:
-```
+
+<Terminal shell title="How can I delete an unreadable or unusable resource?">{`
 linstor-kv-tool -g xcp-sr-linstor_group_thin_device --remove-volume <VDI_UUID>
-```
+`}</Terminal>
 
 The previous command does not delete the LINSTOR volume itself, only the kv-store reference that is used by the driver. It's necessary to manually delete the resource definition that still exists under the name `xcp-volume-<RES_UUID>`. Replace `<RES_UUID>` with the one used during the previous step:
-```
+
+<Terminal shell title="root@xcp-ng-host — How can I delete an unreadable…">{`
 linstor rd delete xcp-volume-<RES_UUID>
-```
+`}</Terminal>
 
 ### How to use a specific network for satellites?
 
 Doing this is not recommended. To guarantee a certain robustness of the pool, the best choice is to use the XAPI management interface.  
 But if you are sure of what you are doing:
 
-```
+<Terminal shell title="root@xcp-ng-host — How to use a specific network…">{`
 linstor node interface modify <NODE_NAME> <INTERFACE_NAME> --active
-```
+`}</Terminal>
 
 Documentation on Network Interface Cards management on [this page](https://linbit.com/drbd-user-guide/linstor-guide-1_0-en/#s-managing_network_interface_cards).
 
@@ -922,9 +965,10 @@ Feel free to follow steps 1 to 5 described below:
 Check the node list using `linstor node list` on the node where the controller is running.
 If there is no controller, use `drbdsetup status xcp-persistent-database` to see the state of the database on each host. In the case of split-brain, use the corresponding documentation.
 Otherwise, to change the IPs manually, open this file on a machine of the pool:
-```
+
+<Terminal shell title="1. Reset resource file config">{`
 nano /var/lib/linstor.d/xcp-persistent-database.res
-```
+`}</Terminal>
 
 You should  have a similar configuration in the file:
 ```
@@ -945,21 +989,24 @@ For each entry, modify the IPs to use the XAPI management interface of each host
 Save and repeat this modification on each host.
 
 Restart `drbd-reactor` on each machine, using this command:
-```
+
+<Terminal shell title="1. Reset resource file config">{`
 systemctl restart drbd-reactor
-```
+`}</Terminal>
 
 Reboot the hosts if the controller doesn't restart.
 
 After this point, the controller should be running. Find it and list the resources:
-```
+
+<Terminal shell title="root@xcp-ng-host — 1. Reset resource file config">{`
 linstor r list
-```
+`}</Terminal>
 
 If the array is empty, execute:
-```
+
+<Terminal shell title="1. Reset resource file config">{`
 systemctl stop linstor-controller
-```
+`}</Terminal>
 
 The controller will restart on the current machine or another one.  
 Check again the resource list.
@@ -967,9 +1014,10 @@ Check again the resource list.
 #### 2. Reset the active satellite connection
 
 Verify the node list:
-```
+
+<Terminal shell title="root@xcp-ng-host — 2. Reset the active satellite…">{`
 linstor n list
-```
+`}</Terminal>
 
 If you have a similar result, there is still something wrong:
 ```
@@ -983,9 +1031,10 @@ If you have a similar result, there is still something wrong:
 ```
 
 Verify the interfaces using:
-```
+
+<Terminal shell title="root@xcp-ng-host — 2. Reset the active satellite…">{`
 linstor node interface list r620-s1
-```
+`}</Terminal>
 
 If you don't have "StltCon" in the first column for the default interface (or if this interface is missing), the active connection should be reset:
 ```
@@ -997,18 +1046,20 @@ If you don't have "StltCon" in the first column for the default interface (or if
 ```
 
 Try using this command for each host interface (replace `r620-s1` using the right hostname):
-```
+
+<Terminal shell title="root@xcp-ng-host — 2. Reset the active satellite…">{`
 linstor node interface modify r620-s1 default --active
-```
+`}</Terminal>
 
 Verify every interface of each node again.
 
 #### 3. H2 modification to reset active connection and use default interface
 
 If you cannot modify the connections using:
-```
+
+<Terminal shell title="root@xcp-ng-host — 3. H2 modification to reset…">{`
 linstor node interface modify <HOSTNAME> default --active
-```
+`}</Terminal>
 
 You probably have a similar error:
 ```
@@ -1023,11 +1074,12 @@ Show reports:
 
 In this situation, the LINSTOR database should be modified manually.  
 Copy the database to another directory:
-```
+
+<Terminal shell title="3. H2 modification to reset active connection and…">{`
 mkdir /root/linstor-db/
 cp /var/lib/linstor/linstordb.mv.db /root/linstor-db/linstordb.mv.db.backup
 cp /root/linstor-db/linstordb.mv.db.backup /root/linstor-db/linstordb.mv.db
-```
+`}</Terminal>
 
 Connect to the DB backup using:
 ```
@@ -1133,30 +1185,34 @@ COMMIT;
 ```
 
 Then, you can override the LINSTOR database:
-```
+
+<Terminal shell title="5. Modify interface IPs">{`
 cp /root/linstor-db/linstordb.mv.db /var/lib/linstor/linstordb.mv.db
-```
+`}</Terminal>
 
 Finally, you can stop the controller on the host currently running.
 `drbd-reactor` will restart it and you should have a valid database again.
 
 Check using:
-```
+
+<Terminal shell title="root@xcp-ng-host — 5. Modify interface IPs">{`
 linstor n list
 linstor r list
-```
+`}</Terminal>
 
 ### What to do when a node is in an EVICTED state?
 
 A controller can mark a node as EVICTED if the LINSTOR default configuration is used and a satellite offline for 60 minutes. The DRBD resources are then replicated on the remaining nodes as a protection against data loss. The following command is usually enough to re-import the evicted machine:
-```
+
+<Terminal shell title="root@xcp-ng-host — What to do when a node is in an…">{`
 linstor node restore <NODE_NAME>
-```
+`}</Terminal>
 
 If the machine has to be removed:
-```
+
+<Terminal shell title="root@xcp-ng-host — What to do when a node is in an…">{`
 linstor node lost <NODE_NAME>
-```
+`}</Terminal>
 
 The next step is to remove the machine from the pool using XAPI commands.  
 Or using `xsconsole`: "Resource Pool Configuration" => "Remove This Host from the Pool".
@@ -1176,27 +1232,31 @@ This feature is currently experimental and not covered by [Vates Pro Support](ht
 :::
 
 On each host, create a new PV and VG using your cache devices:
-```
+
+<Terminal shell title="How to enable dm-cache (Device mapper cache)?">{`
 vgcreate linstor_group_cache <CACHE_DEVICES>
-```
+`}</Terminal>
 
 Using `linstor`, create new storage pools for all nodes:
-```
+
+<Terminal shell title="root@xcp-ng-host — How to enable dm-cache (Device…">{`
 linstor storage-pool create lvm <NODE_NAME> linstor_group_cache linstor_group_cache
-```
+`}</Terminal>
 
 Then you can enable the cache with a few commands using the linstor controller.
 
 Verify the group to modify, it must start with "xcp-sr-" (generally `linstor_group_thin_device` for thin):
-```
+
+<Terminal shell title="root@xcp-ng-host — How to enable dm-cache (Device…">{`
 linstor storage-pool list
-```
+`}</Terminal>
 
 Make sure the primary resource group is configured with cache support and enable the cache on the volume group:
-```
+
+<Terminal shell title="root@xcp-ng-host — How to enable dm-cache (Device…">{`
 linstor rg modify xcp-sr-linstor_group_thin_device --layer-list drbd,cache,storage
 linstor vg set-property xcp-sr-linstor_group_thin_device 0 Cache/CachePool linstor_group_cache
-```
+`}</Terminal>
 
 :::warning
 The previous and following commands are only valid for a thin configuration. For thick configuration, you need to replace all occurrences of `xcp-sr-linstor_group_thin_device` with `xcp-sr-linstor_group`. If you use another group or thin device replace `linstor_group` and/or `thin_device`.
@@ -1209,27 +1269,31 @@ You can list caches on a host using `dmsetup ls`. Also one important thing, a ca
 ### How to disable dm-cache (Device mapper cache)?
 
 Execute these commands:
-```
+
+<Terminal shell title="root@xcp-ng-host — How to disable dm-cache (Device…">{`
 linstor vg set-property xcp-sr-linstor_group_thin_device 0 Cache/CachePool
 linstor rg modify xcp-sr-linstor_group_thin_device --layer-list ""
-```
+`}</Terminal>
 
 And for each node:
-```
+
+<Terminal shell title="root@xcp-ng-host — How to disable dm-cache (Device…">{`
 linstor sp delete <NODE_NAME> linstor_group_cache
-```
+`}</Terminal>
 
 #### How to configure the cache size?
 
 By default, a VDI uses a cache size of 1% of its volume size. But it can be changed globally for all VDIs:
-```
+
+<Terminal shell title="root@xcp-ng-host — How to configure the cache size?">{`
 linstor vg set-property xcp-sr-linstor_group_thin_device 0 Cache/Cachesize <PERCENTAGE>
-```
+`}</Terminal>
 
 You can change this value globally or on a particular resource definition with:
-```
+
+<Terminal shell title="root@xcp-ng-host — How to configure the cache size?">{`
 linstor rd set-property <VOLUME_NAME> Cache/Cachesize <PERCENTAGE>
-```
+`}</Terminal>
 
 It's totally arbitrary. You can go up to 20-30% for for VMS with a high write rate. This should be enough to support a significant number of requests. 10% for solicited VMs. Between 1-5% for VMs with a few requests. You can use 100% if you want, for example for a database on a small VDI with a lot of queries.
 
@@ -1240,9 +1304,10 @@ Due to too-long VHD chains, snapshots can consume more memory than necessary. It
 #### How to switch between read and read-write modes?
 
 Simply use:
-```
+
+<Terminal shell title="root@xcp-ng-host — How to switch between read and…">{`
 linstor vg set-property xcp-sr-linstor_group_thin_device 0 Cache/OpMode <MODE>
-```
+`}</Terminal>
 
 By default `writethrough` mode is used. This mode is only useful for improving read performance.
 
@@ -1281,49 +1346,57 @@ To repair the driver, follow these steps:
 1. Disconnect the SR from each host in the pool via XOA. If this fails, proceed to the next step.
 
 2. Stop the satellites on each host:
-```
+
+<Terminal shell title="How to fix a LINSTOR database corruption?">{`
 systemctl stop linstor-satellite
-```
+`}</Terminal>
 
 3. Log in to the host where the controller is running. The `/var/lib/linstor` folder should be mounted. You can verify this using the `mountpoint` command:
-```
+
+<Terminal title="How to fix a LINSTOR database corruption?">{`
 mountpoint /var/lib/linstor
 /var/lib/linstor is a mountpoint
-```
+`}</Terminal>
 
 Copy these files from the database folder: `linstordb.mv.db` and `linstordb.trace.db` ​​into another folder:
-```
+
+<Terminal shell title="How to fix a LINSTOR database corruption?">{`
 mkdir linstor.bak
 cp /var/lib/linstor/*.db linstor.bak/
-```
+`}</Terminal>
 
 4. Download the `H2` tool from [the official website](https://www.h2database.com/html/download-archive.html). The version to download corresponds to the one used by the installed version of LINSTOR. This information can be found on the LINSTOR server [git repository](https://github.com/LINBIT/linstor-server/blob/master/build.gradle).
 
 5. Extract the H2 archive, replace the `<H2_FOLDER>` and `<H2_VERSION>` and run the recovery tool in the copied database folder:
-```
+
+<Terminal shell title="How to fix a LINSTOR database corruption?">{`
 java -cp <H2_FOLDER>/bin/h2-<H2_VERSION>.jar org.h2.tools.Recover -dir linstor.bak
-```
+`}</Terminal>
 
 The recovery tool generates a SQL file. The contents of `linstor.bak` should look like this:
-```
+
+<Terminal title="How to fix a LINSTOR database corruption?">{`
 ls linstor.bak/
 linstordb.h2.sql  linstordb.mv.db  linstordb.mv.txt  linstordb.trace.db
-```
+`}</Terminal>
 
 6. Generate a new database in a temporary folder:
-```
+
+<Terminal shell title="How to fix a LINSTOR database corruption?">{`
 java -cp <H2_FOLDER>/bin/h2-<H2_VERSION>.jar org.h2.tools.RunScript -url jdbc:h2:/tmp/linstordb -user linstor -password linstor -script linstor.bak/linstordb.h2.sql
-```
+`}</Terminal>
 
 7. Replace the corrupted database with the temporary one:
-```
+
+<Terminal shell title="How to fix a LINSTOR database corruption?">{`
 mv /tmp/linstordb.mv.db /var/lib/linstor/linstordb.mv.db
-```
+`}</Terminal>
 
 8. Stop the controller:
-```
+
+<Terminal shell title="How to fix a LINSTOR database corruption?">{`
 systemctl stop linstor-controller
-```
+`}</Terminal>
 
 9. Reconnect the SR to each host via XOA.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,6 +11,7 @@ const config = {
   url: 'https://docs.xcp-ng.org',
   baseUrl: '/',
   onBrokenLinks: 'throw',
+  onBrokenAnchors: 'throw',
   favicon: 'img/xcpcrop128.png',
   trailingSlash: true,
   markdown: {
@@ -66,6 +67,7 @@ const config = {
         docs: {
           routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
+          showLastUpdateTime: true,
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
@@ -188,7 +190,20 @@ const config = {
     }),
   plugins: [
     require.resolve('docusaurus-plugin-image-zoom'),
-    require.resolve('docusaurus-lunr-search')
+    require.resolve('docusaurus-lunr-search'),
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        // Whenever a page is moved or renamed, add a redirect here so the
+        // old URL keeps working (external links, search engines, forum posts).
+        redirects: [
+          {
+            from: '/troubleshooting/storage/disk-failure-softwaire-RAID/',
+            to: '/troubleshooting/storage/disk-failure-software-RAID/',
+          },
+        ],
+      },
+    ],
   ],
 };
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "^3.10.1",
+    "@docusaurus/plugin-client-redirects": "^3.10.2",
     "@docusaurus/preset-classic": "^3.10.1",
     "@docusaurus/theme-mermaid": "^3.10.1",
     "@mdx-js/react": "^3.0.0",

--- a/src/components/Cards/index.tsx
+++ b/src/components/Cards/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import styles from './styles.module.css';
+
+/**
+ * Quiet link cards for landing pages, in the spirit of enterprise doc
+ * portals: a title, one descriptive line, no decoration. Use CardGrid as
+ * the container and LinkCard for each entry.
+ */
+export function CardGrid({children}: {children: React.ReactNode}): JSX.Element {
+  return <div className={styles.grid}>{children}</div>;
+}
+
+export function LinkCard({
+  title,
+  href,
+  children,
+}: {
+  title: string;
+  href: string;
+  children?: React.ReactNode;
+}): JSX.Element {
+  return (
+    <Link to={href} className={styles.card}>
+      <span className={styles.title}>{title}</span>
+      {children ? <span className={styles.desc}>{children}</span> : null}
+    </Link>
+  );
+}

--- a/src/components/Cards/styles.module.css
+++ b/src/components/Cards/styles.module.css
@@ -1,0 +1,36 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+  gap: 0.9rem;
+  margin: 1.2rem 0 1.8rem;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.95rem 1.05rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 10px;
+  color: var(--ifm-font-color-base);
+  text-decoration: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.card:hover {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 6px 18px -12px rgba(0, 0, 0, 0.4);
+  color: var(--ifm-font-color-base);
+  text-decoration: none;
+}
+
+.title {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.desc {
+  font-size: 0.84rem;
+  line-height: 1.45;
+  color: var(--ifm-color-emphasis-700);
+}

--- a/src/components/Schema/index.tsx
+++ b/src/components/Schema/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import styles from './styles.module.css';
+
+/**
+ * A framed technical schematic. Renders hand-drawn SVG diagrams on the same
+ * dark board in both themes, matching the <Terminal> component, with a faint
+ * dot grid and an engineering-style caption.
+ *
+ * Wire color convention (keep it consistent across all diagrams):
+ *   green #56c288  replication / data safety
+ *   gray  #7a8699  client traffic / neutral links
+ *   amber #e0a94a  arbitration / tiebreaker paths
+ *   red   #ef6a5f  failure / fenced elements
+ * Text: #c6d2e1 primary, #7a8699 dim. Boxes: fill rgba(255,255,255,0.04),
+ * stroke rgba(255,255,255,0.28).
+ */
+export interface SchemaProps {
+  /** Engineering-drawing caption, e.g. "Fate-shared topology". */
+  label: string;
+  /** Optional legend entries, e.g. [["#56c288", "replication"], ...] */
+  legend?: [string, string][];
+  /** Max width of the drawing area, e.g. "520px". */
+  maxWidth?: string;
+  /** The inline SVG. */
+  children: React.ReactNode;
+}
+
+export default function Schema({label, legend, maxWidth = '760px', children}: SchemaProps): JSX.Element {
+  return (
+    <figure className={styles.board}>
+      <div className={styles.canvas}>
+        <div className={styles.drawing} style={{maxWidth}}>
+          {children}
+        </div>
+      </div>
+      <figcaption className={styles.caption}>
+        <span className={styles.label}>{label}</span>
+        {legend && legend.length > 0 ? (
+          <span className={styles.legend}>
+            {legend.map(([color, text]) => (
+              <span key={text} className={styles.legendItem}>
+                <span className={styles.swatch} style={{background: color}} />
+                {text}
+              </span>
+            ))}
+          </span>
+        ) : null}
+      </figcaption>
+    </figure>
+  );
+}

--- a/src/components/Schema/styles.module.css
+++ b/src/components/Schema/styles.module.css
@@ -1,0 +1,90 @@
+/* A schematic board: always dark in both themes, like the <Terminal> frame,
+   so consoles and diagrams read as one family of technical panels. */
+.board {
+  margin: 1.4rem 0;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #0c1119;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  box-shadow: 0 14px 34px -20px rgba(0, 0, 0, 0.55);
+}
+
+/* The board fills the text column; the drawing inside is capped by its
+   maxWidth prop and centered. No breakout: the doc layout has sidebars on
+   both sides, so anything wider than the column collides with them. */
+
+/* Faint blueprint dot grid behind the drawing. */
+.canvas {
+  padding: 1.4rem 1.2rem 1.1rem;
+  background-image: radial-gradient(rgba(255, 255, 255, 0.055) 1px, transparent 1px);
+  background-size: 18px 18px;
+  background-position: 9px 9px;
+}
+
+.drawing {
+  margin: 0 auto;
+}
+
+.drawing svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  font-family: var(--ifm-font-family-monospace);
+}
+
+/* Engineering-drawing title strip. */
+.caption {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding: 0.5rem 1rem 0.55rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.09);
+  background: #171b26;
+}
+
+/* Book-style caption: a mono "FIG. n" stamp, then the description in
+   sentence-case italic body type. */
+.label {
+  font-family: var(--ifm-font-family-base);
+  font-size: 0.84rem;
+  font-style: italic;
+  line-height: 1.4;
+  color: #8b96a8;
+}
+
+/* Automatic figure numbering, per page. The counter is reset on <article>
+   in src/css/custom.css. */
+.label::before {
+  counter-increment: schema-fig;
+  content: 'Fig. ' counter(schema-fig) '  ';
+  font-family: var(--ifm-font-family-monospace);
+  font-style: normal;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #c6d2e1;
+}
+
+.legend {
+  margin-left: auto;
+  display: flex;
+  gap: 0.9rem;
+  flex-wrap: wrap;
+}
+
+.legendItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.78rem;
+  color: #7a8699;
+}
+
+.swatch {
+  width: 14px;
+  height: 3px;
+  border-radius: 2px;
+  display: inline-block;
+}

--- a/src/components/Terminal/index.tsx
+++ b/src/components/Terminal/index.tsx
@@ -1,0 +1,158 @@
+import React, {useState} from 'react';
+import styles from './styles.module.css';
+
+// Auto-coloring for `twinstor status` output: color only the values that carry
+// state, mirroring the CLI's own TTY palette. Keyword sets are intentionally
+// small and explicit — this is for docs, not a general ANSI renderer.
+const GOOD = /^(UpToDate|Connected|ready|active|ok|enabled|healthy|Primary)$/;
+const WARN = /^(Inconsistent|SyncTarget|SyncSource|Connecting|Secondary|Disconnecting|DISABLED|degraded)$/;
+const BAD = /^(StandAlone|Diskless|Outdated|DUnknown|Unconnected|critical|frozen|error|Failed)$/;
+
+function sevClass(tok: string): string | undefined {
+  if (GOOD.test(tok)) return styles.good;
+  if (WARN.test(tok)) return styles.warn;
+  if (BAD.test(tok)) return styles.bad;
+  return undefined;
+}
+
+function renderLine(line: string, isCommand: boolean): React.ReactNode {
+  if (isCommand) {
+    return (
+      <>
+        <span className={styles.dim}># </span>
+        <span className={styles.cmd}>{line}</span>
+      </>
+    );
+  }
+  // The health verdict dot (●) takes the severity of the verdict word on its line.
+  const verdictSev = /\bhealthy\b/.test(line)
+    ? styles.good
+    : /\bdegraded\b/.test(line)
+      ? styles.warn
+      : /\bcritical\b/.test(line)
+        ? styles.bad
+        : undefined;
+
+  let inParen = false;
+  return line.split(/(\s+)/).map((tok, i) => {
+    if (tok === '') return null;
+    if (/^\s+$/.test(tok)) return tok;
+
+    let cls: string | undefined;
+    if (inParen || tok.startsWith('(')) cls = styles.dim; // dim parentheticals
+    if (tok.startsWith('(')) inParen = true;
+    if (tok.endsWith(')')) inParen = false;
+
+    if (!cls) {
+      if (tok === '✓') cls = styles.good;
+      else if (tok === '⚠') cls = styles.warn;
+      else if (tok === '✗') cls = styles.bad;
+      else if (tok === '●') cls = verdictSev;
+      else if (tok.endsWith(':')) cls = styles.dim; // labels
+      else cls = sevClass(tok);
+    }
+    return cls ? (
+      <span key={i} className={cls}>
+        {tok}
+      </span>
+    ) : (
+      tok
+    );
+  });
+}
+
+// Shell mode: every non-empty line is a command behind a root prompt; full-line
+// `#` comments and trailing ` # …` comments render dim, like a real session.
+function renderShellLine(line: string): React.ReactNode {
+  if (line.trim() === '') return null;
+  if (line.trimStart().startsWith('#')) {
+    return <span className={styles.dim}>{line}</span>;
+  }
+  const m = line.match(/^(.*?)(\s+#\s.*)$/);
+  return (
+    <>
+      <span className={styles.dim}># </span>
+      <span className={styles.cmd}>{m ? m[1] : line}</span>
+      {m ? <span className={styles.dim}>{m[2]}</span> : null}
+    </>
+  );
+}
+
+function commandLines(lines: string[], shell: boolean): string[] {
+  if (!shell) {
+    const first = lines.find((l) => l.trim() !== '');
+    return first ? [first.trim()] : [];
+  }
+  return lines
+    .filter((l) => l.trim() !== '' && !l.trimStart().startsWith('#'))
+    .map((l) => l.replace(/\s+#\s.*$/, ''));
+}
+
+function CopyButton({text}: {text: string}): JSX.Element {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      className={styles.copy}
+      aria-label="Copy the commands"
+      onClick={() => {
+        navigator.clipboard.writeText(text).then(() => {
+          setCopied(true);
+          window.setTimeout(() => setCopied(false), 1500);
+        });
+      }}>
+      {copied ? 'Copied ✓' : 'Copy'}
+    </button>
+  );
+}
+
+export interface TerminalProps {
+  /** Title-bar text, e.g. "root@twinstor-1 — twinstor status". */
+  title: string;
+  /**
+   * Shell mode: every non-empty line is a command (dom0 root prompt), and
+   * `#` comments are dimmed. Without it, only the first non-empty line is
+   * the command and the rest is status-colored output.
+   */
+  shell?: boolean;
+  /** The terminal content. */
+  children: string;
+}
+
+export default function Terminal({title, shell = false, children}: TerminalProps): JSX.Element {
+  const lines = String(children).replace(/^\n+|\n+$/g, '').split('\n');
+  let commandSeen = false;
+  const toCopy = commandLines(lines, shell).join('\n');
+
+  return (
+    <div className={styles.term}>
+      <div className={styles.bar}>
+        <span className={styles.dots}>
+          <span className={styles.dot} />
+          <span className={styles.dot} />
+          <span className={styles.dot} />
+        </span>
+        <span className={styles.title}>{title}</span>
+        <CopyButton text={toCopy} />
+      </div>
+      <pre className={styles.screen}>
+        {lines.map((line, i) => {
+          let node: React.ReactNode;
+          if (shell) {
+            node = renderShellLine(line);
+          } else {
+            const isCommand = !commandSeen && line.trim() !== '';
+            if (isCommand) commandSeen = true;
+            node = renderLine(line, isCommand);
+          }
+          return (
+            <React.Fragment key={i}>
+              {node}
+              {i < lines.length - 1 ? '\n' : null}
+            </React.Fragment>
+          );
+        })}
+      </pre>
+    </div>
+  );
+}

--- a/src/components/Terminal/styles.module.css
+++ b/src/components/Terminal/styles.module.css
@@ -1,0 +1,77 @@
+/* A terminal frame with a title bar + traffic-light dots. Always a dark
+   console (in both Docusaurus light and dark themes), matching the CDN. */
+.term {
+  margin: 1.4rem 0;
+  border-radius: 10px;
+  overflow: hidden;
+  background: #0c1119;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  box-shadow: 0 14px 34px -20px rgba(0, 0, 0, 0.55);
+}
+
+.bar {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.55rem 0.8rem;
+  background: #171b26;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.09);
+}
+
+.dots {
+  display: flex;
+  gap: 0.42rem;
+}
+.dot {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  display: block;
+}
+.dots .dot:nth-child(1) { background: #ec6a5e; }
+.dots .dot:nth-child(2) { background: #f4bf4f; }
+.dots .dot:nth-child(3) { background: #61c554; }
+
+.title {
+  margin: 0 auto;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.72rem;
+  color: #7a8699;
+  letter-spacing: 0.01em;
+}
+
+.copy {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.68rem;
+  color: #7a8699;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 5px;
+  padding: 0.14rem 0.5rem;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+.copy:hover {
+  color: #c6d2e1;
+  border-color: rgba(255, 255, 255, 0.3);
+}
+
+/* Override Infima's <pre> defaults; the frame provides the background. */
+.screen {
+  margin: 0;
+  padding: 1rem 1.15rem 1.15rem;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.82rem;
+  line-height: 1.62;
+  color: #c6d2e1;
+  overflow-x: auto;
+}
+
+.cmd { color: #ffffff; font-weight: 600; }
+.dim { color: #7a8699; }
+.good { color: #56c288; }
+.warn { color: #e0a94a; }
+.bad { color: #ef6a5f; }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -53,3 +53,9 @@
 .hidden {
   display: none;
 }
+
+/* Each doc page numbers its <Schema> figures from 1 (see the Schema
+   component's styles). */
+article {
+  counter-reset: schema-fig;
+}

--- a/src/theme/MDXComponents.tsx
+++ b/src/theme/MDXComponents.tsx
@@ -1,0 +1,14 @@
+import MDXComponents from '@theme-original/MDXComponents';
+import Schema from '@site/src/components/Schema';
+import Terminal from '@site/src/components/Terminal';
+import {CardGrid, LinkCard} from '@site/src/components/Cards';
+
+// Make the shared components available in every .md/.mdx doc without a
+// per-file import. Same set/style as the Vates product-docs site.
+export default {
+  ...MDXComponents,
+  Schema,
+  Terminal,
+  CardGrid,
+  LinkCard,
+};


### PR DESCRIPTION
## What this PR does

A large coherency and completeness pass on the whole documentation.

### New and expanded content

Day-2 operations, written for XCP-ng workflows (`xe` CLI plus Xen Orchestra), each page pointing to XO for at-scale management:

- **Management**: hosts and pools operations (pool lifecycle, maintenance mode, passwords, NTP, remote power-on, pool-wide settings), monitoring and alerts, users and permissions, backup extended with DR and pool metadata backup/restore
- **VMs**: lifecycle, templates, snapshots, migration, import/export, advanced settings (boot options, vTPM, memory, time), Windows VMs (sysprep, in-place upgrades), supported guest OS statement
- **Storage**: SR and VDI management (probe, space reclamation, I/O tuning); multipathing clarified (recommended for iSCSI/FC, enablement ordering, standard MTU guidance)
- **Networking**: full bonds documentation, dedicated storage NIC, management interface operations, VIF QoS, switch port locking, NBD backup network
- **Installation**: boot from SAN (flags verified against the host-installer source), network ports reference
- **Troubleshooting**: advanced host troubleshooting (serial console, Xen boot options, debug keys, crash dumps), remote syslog
- **Glossary** rewritten (40 linked entries); intro page with task cards and a documentation-set orientation (XCP-ng / Xen Orchestra / Vates)

### Structure

- Uniform heading policy: topical emoji on every H2 outside `appendix/`, each with an explicit clean `{#anchor}`; all internal links rewritten; `onBrokenAnchors: 'throw'` enforces it from now on
- Sidebar position collisions fixed, orphan category removed, one filename typo fixed with a redirect (`@docusaurus/plugin-client-redirects` added)
- `showLastUpdateTime` enabled; external links moved to canonical URLs

### Visual system (shared with the Vates product-docs site)

- **Schema** component: 15 diagram boards (platform overview, pool topology, storage object model, snapshot chain, multipathing, HA architecture, tapdisk I/O path, network architecture, toolstack comparison, xapi internals, XAPI object model, pool design), replacing hand-drawn images, hotlinked external images and topology mermaid diagrams
- **Terminal** component: ~430 command blocks converted to consoles with command-only copy; scripts, config files and ambiguous blocks intentionally left as fences
- **CardGrid/LinkCard** for landing pages

## URL safety

Verified by diffing the production sitemap against the new build: every live URL is preserved except the one renamed page, which redirects. In-page anchors on emoji headings changed to the clean explicit IDs (internal links all updated and build-enforced; old external deep links still land on the right page).

## Testing

- `npm run build` green with `onBrokenLinks` and `onBrokenAnchors` set to throw
- All schemas reviewed rendered; wire endpoints checked with a geometry lint
- Reviewed locally with `npm run serve`
