### PR TITLE
Document that host Secure Boot must be disabled

### DIFF
--- a/docs/installation/install-xcp-ng.md
+++ b/docs/installation/install-xcp-ng.md
@@ -35,7 +35,7 @@ Start the host and boot on the USB media.
 
 :::warning
 If the firmware refuses to boot the media, or reports that the operating system loader failed
-signature verification, check that [Secure Boot](../../installation/requirements#host-secure-boot)
+signature verification, make sure [Secure Boot](../../installation/requirements#host-secure-boot)
 is disabled. XCP-ng does not support Secure Boot for the host.
 :::
 

--- a/docs/installation/install-xcp-ng.md
+++ b/docs/installation/install-xcp-ng.md
@@ -33,6 +33,12 @@ On Windows, you can use Rufus to create the bootable USB stick.
 
 Start the host and boot on the USB media.
 
+:::warning
+If the firmware refuses to boot the media, or reports that the operating system loader failed
+signature verification, check that [Secure Boot](../../installation/requirements#host-secure-boot)
+is disabled. XCP-ng does not support Secure Boot for the host.
+:::
+
 ### Follow instructions
 
 #### 1. UEFI vs BIOS

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -105,6 +105,12 @@ Despite the wording, nothing has been tampered with: the firmware is refusing a 
 it has no certificate for. If Secure Boot is re-enabled later (whether after a firmware reset
 or to meet compliance requirements) the host will fail to boot until you disable it again.
 
+This is not a permanent position. Host Secure Boot is
+[in progress](../project/roadmap.md#in-progress) on the roadmap and is planned for XCP-ng 9.
+Neither the date nor the shape of that first release is settled: part of the work depends on
+review outside the project, and the initial support may require enrolling your own keys.
+Until it lands, disabling Secure Boot is the only supported configuration.
+
 ## 📋 XCP-ng Configuration Limits {#xcp-ng-configuration-limits}
 
 XCP-ng supports the following per host:

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -80,7 +80,7 @@ Set the server's BIOS clock to the current UTC time. For debugging support cases
 
 ## 🔒 Host Secure Boot {#host-secure-boot}
 
-XCP-ng does not support Secure Boot for the host. Its boot chain is not signed by a
+XCP-ng does not support Secure Boot for the host. The XCP-ng boot chain is not signed by a
 certificate that stock firmware trusts, so with Secure Boot enabled the machine refuses to
 boot the installation media, and refuses the installed host afterwards. Disable Secure Boot
 in the firmware setup before installing, and leave it disabled.

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -78,6 +78,31 @@ XCP-ng 8.2 is EOL. This 8.2-specific information is retained solely to assist wi
 Set the server's BIOS clock to the current UTC time. For debugging support cases, serial console access may be required: see [how to configure it](../troubleshooting/advanced.md#serial-console-access). For systems without physical serial ports, embedded management devices (Dell iDRAC, HP iLO...) provide Serial-over-LAN.
 :::
 
+## 🔒 Host Secure Boot {#host-secure-boot}
+
+XCP-ng does not support Secure Boot for the host. Its boot chain is not signed by a
+certificate that stock firmware trusts, so with Secure Boot enabled the machine refuses to
+boot the installation media, and refuses the installed host afterwards. Disable Secure Boot
+in the firmware setup before installing, and leave it disabled.
+
+Depending on the firmware, this shows up in one of two ways: the UEFI boot entry silently
+disappears from the boot menu, or it stays and the machine reports something like:
+
+```
+Operating System Loader failed signature verification. WARNING: The file may have been tampered with!
+
+All bootable devices failed Secure Boot verification.
+```
+
+Despite the wording, nothing has been tampered with: the firmware is refusing a boot loader
+it has no certificate for. Re-enabling Secure Boot later, after a firmware reset or to
+satisfy a compliance baseline, will stop the host booting until it is turned off again.
+
+:::note
+This concerns Secure Boot for the **host**. Secure Boot for **VMs** is a separate feature and
+is supported: see [Guest UEFI Secure Boot](../../guides/guest-UEFI-Secure-Boot).
+:::
+
 ## 📋 XCP-ng Configuration Limits {#xcp-ng-configuration-limits}
 
 XCP-ng supports the following per host:

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -80,28 +80,30 @@ Set the server's BIOS clock to the current UTC time. For debugging support cases
 
 ## 🔒 Host Secure Boot {#host-secure-boot}
 
-XCP-ng does not support Secure Boot for the host. The XCP-ng boot chain is not signed by a
-certificate that stock firmware trusts, so with Secure Boot enabled the machine refuses to
-boot the installation media, and refuses the installed host afterwards. Disable Secure Boot
-in the firmware setup before installing, and leave it disabled.
+:::note
+This section concerns Secure Boot for the **host**. Secure Boot for **VMs** is a separate
+feature and is supported: see [Guest UEFI Secure Boot](../../guides/guest-UEFI-Secure-Boot).
+:::
 
-Depending on the firmware, this shows up in one of two ways: the UEFI boot entry silently
-disappears from the boot menu, or it stays and the machine reports something like:
+XCP-ng does not support Secure Boot for the host. Its boot chain is not signed by a
+certificate that stock firmware trusts. Because of that, enabling Secure Boot will prevent
+the machine from booting both the installation media and the installed host. Disable Secure
+Boot in the firmware setup before installing, and leave it disabled.
 
-```
-Operating System Loader failed signature verification. WARNING: The file may have been tampered with!
+Depending on the firmware, this shows up in one of two ways:
 
-All bootable devices failed Secure Boot verification.
-```
+1. The UEFI boot entry silently disappears from the boot menu.
+2. The entry stays, and the machine reports something like:
+
+   ```
+   Operating System Loader failed signature verification. WARNING: The file may have been tampered with!
+
+   All bootable devices failed Secure Boot verification.
+   ```
 
 Despite the wording, nothing has been tampered with: the firmware is refusing a boot loader
-it has no certificate for. Re-enabling Secure Boot later, after a firmware reset or to
-satisfy a compliance baseline, will stop the host booting until it is turned off again.
-
-:::note
-This concerns Secure Boot for the **host**. Secure Boot for **VMs** is a separate feature and
-is supported: see [Guest UEFI Secure Boot](../../guides/guest-UEFI-Secure-Boot).
-:::
+it has no certificate for. If Secure Boot is re-enabled later (whether after a firmware reset
+or to meet compliance requirements) the host will fail to boot until you disable it again.
 
 ## 📋 XCP-ng Configuration Limits {#xcp-ng-configuration-limits}
 


### PR DESCRIPTION
XCP-ng's host boot chain is not signed by a certificate that stock firmware trusts. With Secure Boot enabled the machine refuses the installation media, and after installation it refuses the installed host as well. The firmware message names Secure Boot on some machines and on others the boot entry just vanishes from the menu, so people reasonably conclude the installation media is bad and re-write it a few times before suspecting firmware.

This is already the project's position, stated once, in the 8.1 release notes:

> In XCP-ng, support for Secure Boot is *NOT INCLUDED* because it relies on proprietary packages.

Nothing in the installation docs repeats it. Worse, searching for "XCP-ng Secure Boot" lands on the Guest UEFI Secure Boot guide, which is a different feature and one that *is* supported. That is an actively misleading path for someone who cannot boot an installer, so the new section calls out the distinction explicitly.

Forum evidence: [topic 8485](https://xcp-ng.org/forum/topic/8485), the same failure on a Dell OptiPlex 7060 Micro. Olivier Lambert answered there: "You need to disable secure boot in your BIOS", and "to be compatible with XCP-ng, we would need a valid Microsoft certificate and other things".

## What I checked before writing this

* On master, `docs/installation/requirements.md`, `docs/installation/install-xcp-ng.md` and `docs/troubleshooting/installation-upgrade.md` contain no mention of host Secure Boot. The only mentions anywhere are the 8.1 release notes and the roadmap entry "Host secure boot (Xen/platform)".
* Reproduced on 2026-07-31, XCP-ng 8.3 on a Dell OptiPlex 7060 Micro. Toggling Secure Boot alone flips the outcome, repeatedly, in both directions. With Secure Boot on and XCP-ng installed, the firmware reports `All bootable devices failed Secure Boot verification`, having first said the OS loader failed signature verification.
* The symptom is not consistent: sometimes the UEFI boot entry silently disappears from the boot menu instead of producing any message at all. Both shapes are covered in the text.

## What the change does

* Adds a "Host Secure Boot" section to `requirements.md`, including the verbatim firmware messages so the page can be found by searching the error.
* Notes that the "may have been tampered with" wording is expected here and does not indicate a compromised machine.
* Distinguishes host Secure Boot from Guest UEFI Secure Boot, and links to the guest guide.
* Adds a warning under "Start the host" in `install-xcp-ng.md`, which is where people actually meet the failure, pointing back at the prerequisites.

## Changed after review

The first version of this PR also covered a wrong BIOS clock breaking signature verification. @stormi pointed out that this is a different failure at a different layer: the installer failing to import a key, not the firmware refusing a boot loader. He is right, and the clock is already documented in `requirements.md`. That half is dropped and this PR is now host Secure Boot only.
