### PR TITLE
Note that rc.local needs the executable bit

### DIFF
--- a/docs/troubleshooting/common-problems.md
+++ b/docs/troubleshooting/common-problems.md
@@ -105,6 +105,18 @@ echo "xen" > /sys/devices/system/clocksource/clocksource0/current_clocksource
   printf '%s\n\t%s\n%s\n' 'if test -f /sys/devices/system/clocksource/clocksource0/current_clocksource; then' 'echo xen > /sys/devices/system/clocksource/clocksource0/current_clocksource' 'fi' >> /etc/rc.local
 `}</Terminal>
 
+:::warning
+The second command makes the change persistent by appending to `/etc/rc.local`, but that file
+is only executed at boot if `/etc/rc.d/rc.local` is executable. If it is not, the workaround is
+skipped at every boot and nothing reports it: the clocksource silently reverts. Check the
+permissions, and set them if needed:
+:::
+
+<Terminal title="Make sure rc.local runs at boot">{`
+ls -l /etc/rc.d/rc.local
+chmod +x /etc/rc.d/rc.local
+`}</Terminal>
+
 ---
 
 ## 🐌 Async Tasks/Commands Hang or Execute Extremely Slowly {#async-taskscommands-hang-or-execute-extremely-slowly}


### PR DESCRIPTION
The clocksource workaround on this page ends by appending a snippet to `/etc/rc.local` to make the change survive a reboot. That file only runs at boot if `/etc/rc.d/rc.local` is executable, and the page doesn't say so.

When the bit isn't set, nothing complains: the append succeeds, the host reboots, the snippet never runs, and the clocksource is back where it started. The reader is left thinking they applied a documented fix.

This came up on the forum from the other direction, on an 8.2 to 8.3 upgrade where `/etc/rc.d/rc.local` was back at `-rw-r--r--` and VM autostart driven from rc.local had stopped firing. The reporter found it himself by reading the comment block inside the file, which does mention the `chmod`. Our docs are the place people look first, so it seemed worth putting there too.

I've phrased it as "check the permissions" rather than "the upgrade resets them", because I haven't tested whether an upgrade clears the bit every time or whether it just happened in that one case. Happy to make it more assertive if someone knows.

Related forum thread: https://xcp-ng.org/forum/topic/12389
