### PR TITLE
Federated search across the Vates docs sites

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -35,7 +35,7 @@ const config = {
     locales: ['en'],
   },
 
-  themes: ['@docusaurus/theme-mermaid'],
+  themes: ['@docusaurus/theme-mermaid', 'docusaurus-theme-search-typesense'],
 
   customFields: {
     // Formbricks feedback widget (see src/components/PageFeedback).
@@ -84,6 +84,28 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      // Federated search across docs.xcp-ng.org, docs.vates.tech and
+      // docs.xen-orchestra.com. Results group by product; hits from the
+      // two sibling sites keep their absolute URL (externalUrlRegex).
+      // The API key is search-only and public by design.
+      // Local dev against a local Typesense (prod only allows CORS from
+      // the three doc domains):
+      //   TYPESENSE_HOST=localhost TYPESENSE_PORT=8108 \
+      //   TYPESENSE_PROTOCOL=http TYPESENSE_SEARCH_KEY=<key> npm start
+      typesense: {
+        typesenseCollectionName: 'vates_federated',
+        externalUrlRegex: 'docs\\.vates\\.tech|docs\\.xen-orchestra\\.com',
+        typesenseServerConfig: {
+          nodes: [{
+            host: process.env.TYPESENSE_HOST ?? 'typesense.vates.tech',
+            port: Number(process.env.TYPESENSE_PORT ?? 443),
+            protocol: process.env.TYPESENSE_PROTOCOL ?? 'https',
+          }],
+          apiKey: process.env.TYPESENSE_SEARCH_KEY ?? 'b2806f42e60429ceecb3808a2c6bb31cc9ca955cb1e4290c',
+        },
+        typesenseSearchParameters: {},
+        contextualSearch: false,
+      },
       navbar: {
         title: 'XCP-ng Documentation',
         logo: {
@@ -190,6 +212,9 @@ const config = {
     }),
   plugins: [
     require.resolve('docusaurus-plugin-image-zoom'),
+    // Kept even though Typesense provides the search UI: this plugin
+    // generates search-doc.json, which the federated search indexer
+    // consumes (src/theme/SearchBar picks the Typesense bar).
     require.resolve('docusaurus-lunr-search'),
     [
       '@docusaurus/plugin-client-redirects',

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@mdx-js/react": "^3.0.0",
     "docusaurus-lunr-search": "^3.6.0",
     "docusaurus-plugin-image-zoom": "^3.0.1",
+    "docusaurus-theme-search-typesense": "^0.26.0",
     "prism-react-renderer": "^2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -1,0 +1,9 @@
+/**
+ * Force the Typesense DocSearch bar (federated search across the three
+ * doc sites), while docusaurus-lunr-search stays installed: that plugin
+ * must keep generating search-doc.json at every build, because the
+ * federation indexer consumes it. Both packages register a SearchBar;
+ * themes resolve after plugins, so @theme-original picks the Typesense
+ * one.
+ */
+export {default} from '@theme-original/SearchBar';


### PR DESCRIPTION
This swaps the search bar for a federated one: a single search now covers **docs.xcp-ng.org, docs.vates.tech and docs.xen-orchestra.com**, with results grouped by product in the search modal, typo tolerance, and cross-doc synonyms (HCL <-> hardware compatibility list, DR, SR...).

How it works:

- The UI is `docusaurus-theme-search-typesense`, querying a self-hosted Typesense at `typesense.vates.tech` (collection alias `vates_federated`). The API key in the config is search-only and public by design, same model as Algolia DocSearch.
- Results from the two sibling sites keep their absolute URLs (`externalUrlRegex`), so cross-site hits navigate to the right domain; XCP-ng hits keep instant client-side routing.
- `docusaurus-lunr-search` stays installed but UI-less (a `SearchBar` swizzle picks the Typesense bar): the federation indexer consumes the `search-doc.json` this plugin generates at build time, so please don't remove it.
- The index is rebuilt nightly server-side from the three sites' published `search-doc.json` files - no crawler involved. Offline/local builds still render the search button; queries just require reaching `typesense.vates.tech`.

Already live on docs.vates.tech; this brings the same bar here.