### PR TITLE
Add a time synchronization page

### DIFF
--- a/docs/management/time-synchronization.md
+++ b/docs/management/time-synchronization.md
@@ -4,17 +4,17 @@ sidebar_position: 8
 
 # Time synchronization
 
-XCP-ng keeps the dom0 clock with `chronyd`. A host whose date is wrong carries on working
-normally until something needs to trust that date, and the failures it produces then rarely
-mention time at all. This page covers why the clock matters, how to configure NTP, and how
-to check and correct it.
+XCP-ng keeps the dom0 clock synchronized using `chronyd`. A host whose date is wrong keeps
+working normally until something needs to trust that date. When that happens, the resulting
+failures rarely point to the clock as the cause. This page explains why the clock matters, how
+to configure NTP, and how to check and correct it.
 
 ## ⏰ Why the clock must be correct {#why-the-clock-must-be-correct}
 
 - **Access to the repositories.** Updates are fetched over HTTPS, and TLS validates the
-  server's certificate against the host's own date. A host set far in the past cannot
-  complete the handshake, because from where it is standing the mirror's certificate is not
-  valid yet. The error `yum` prints in that situation does not mention time.
+  server's certificate against the host's own date. If the host's clock is set too far in the
+  past, the TLS handshake fails because, from the host's perspective, the mirror's certificate
+  is not yet valid. The error `yum` prints in that situation does not mention time.
 - **Pool membership.** A host joining a pool must have its clock synchronized with the pool
   master. See [Pool Requirements](../../installation/requirements#pool-requirements).
 - **Certificates.** Certificates are only valid inside a validity window. A host whose date
@@ -28,16 +28,16 @@ to check and correct it.
 
 The time daemon on dom0 is `chronyd`, configured through `/etc/chrony.conf`.
 
-The shipped configuration enables `rtcsync`, so chronyd keeps the hardware clock in step
-with the system clock on its own. There is no need to copy a corrected time to the hardware
-clock by hand, and a correction survives a reboot.
+The default configuration enables `rtcsync`, allowing chronyd to keep the hardware clock
+synchronized with the system clock automatically. There is no need to manually update the
+hardware clock after correcting the system time, and the correction persists across reboots.
 
 ## 🔧 Configuring the time sources {#configuring-the-time-sources}
 
 ### During installation
 
-The installer asks for the timezone and the time at step 11, and lets you either give it NTP
-servers or set the time manually. Always give it an NTP server. See
+At step 11, the installer prompts you to enter the time, select a time zone and either
+configure NTP servers or set the time manually. Always configure at least one NTP server. See
 [Install XCP-ng](../../installation/install-xcp-ng).
 
 :::warning
@@ -73,13 +73,17 @@ enabled while having **no time sources configured at all**:
 210 Number of sources = 0
 ```
 
-The service is then behaving exactly as configured, and doing nothing. Every other check an
+Then, the service behaves exactly as configured, and does nothing. Every other check an
 operator would normally run looks healthy, which is what makes this one worth running early
 rather than late.
 
 When sources are configured, `chronyc sources` lists them. In the `MS` column, the second
-character is the state of that source: `*` marks the one currently being used, `+` marks
-another acceptable source being combined with it, and `?` means the source is unreachable.
+character is the state of that source:
+
+- `*` marks the one currently being used.
+- `+` marks another acceptable source being combined with it.
+- `?` means the source is unreachable.
+
 At least one source should reach the `*` state.
 
 To see the offset chrony believes it has, and whether it has settled:
@@ -102,35 +106,37 @@ chronyc makestep
 date
 ```
 
-`chronyc makestep` is what does the work here. By default chrony corrects an offset by
-slewing the clock gradually, which never converges for an offset of months or years.
+`chronyc makestep` is what does the work here. By default, chrony corrects time offsets by
+gradually slewing the system clock, which never converges for an offset of months or years.
 
 ### If `Number of sources = 0`
 
 Do not start with `makestep`. It will report success and move nothing, because chrony has no
-measured offset to step to. Add time sources to `/etc/chrony.conf` first:
+measured offset to step to.
 
-```
-server 0.centos.pool.ntp.org iburst
-server 1.centos.pool.ntp.org iburst
-server 2.centos.pool.ntp.org iburst
-server 3.centos.pool.ntp.org iburst
-```
+1. Add time sources to `/etc/chrony.conf`:
 
-Then restart the service and confirm that a source has become reachable, as described in
-[Checking the time sources](#checking-the-time-sources):
+   ```
+   server 0.pool.ntp.org iburst
+   server 1.pool.ntp.org iburst
+   server 2.pool.ntp.org iburst
+   server 3.pool.ntp.org iburst
+   ```
 
-```bash
-systemctl restart chronyd
-chronyc sources
-```
+2. Restart the service and confirm that a source has become reachable, as described in
+   [Checking the time sources](#checking-the-time-sources):
 
-Once a source is reachable, correct the clock:
+   ```bash
+   systemctl restart chronyd
+   chronyc sources
+   ```
 
-```bash
-chronyc makestep
-date
-```
+3. Once a source is reachable, correct the clock:
+
+   ```bash
+   chronyc makestep
+   date
+   ```
 
 :::note
 Correcting the date does not invalidate the host's own certificate. XAPI issues it with a
@@ -146,16 +152,15 @@ host is running; it cannot help a clock that loses its value when the power goes
 
 ## 🌐 Isolated networks {#isolated-networks}
 
-Hosts without access to the internet cannot reach the public NTP pool, and the symptom is
-the same as having no sources at all: `chronyc sources` lists servers that never leave the
-`?` state.
+Hosts without Internet access cannot reach the public NTP pool. The result is the same as
+having no sources at all: `chronyc sources` lists servers that never leave the `?` state.
 
-On such a network, point `/etc/chrony.conf` at a time source that hosts can actually reach,
+On such networks, point `/etc/chrony.conf` at a time source that hosts can actually reach,
 such as an appliance on the same network or a local server that is itself synchronized.
 
 ## 🎱 Pools {#pools}
 
 Keep every host in a pool synchronized, ideally against the same sources. A host whose clock
-disagrees with the pool master is not merely inconvenient: clock synchronization is one of
-the requirements for joining a pool in the first place, alongside the others listed in
+differs from the pool master is not just inconvenient: clock synchronization is one of
+the requirements for joining a pool, along with the other requirements listed in
 [Pool Requirements](../../installation/requirements#pool-requirements).

--- a/docs/management/time-synchronization.md
+++ b/docs/management/time-synchronization.md
@@ -77,14 +77,34 @@ Then, the service behaves exactly as configured, and does nothing. Every other c
 operator would normally run looks healthy, which is what makes this one worth running early
 rather than late.
 
-When sources are configured, `chronyc sources` lists them. In the `MS` column, the second
-character is the state of that source:
+On a host that is synchronizing normally, the same two commands look like this:
+
+```
+# systemctl status chronyd
+● chronyd.service - NTP client/server
+   Loaded: loaded (/usr/lib/systemd/system/chronyd.service; enabled; vendor preset: enabled)
+   Active: active (running) since Wed 2026-08-12 08:38:14 CEST; 46min ago
+
+# chronyc sources
+210 Number of sources = 4
+MS Name/IP address         Stratum Poll Reach LastRx Last sample
+===============================================================================
+^* vps1.websters-computers.>     2   7   377    59   -361us[ -444us] +/- 8522us
+^+ meshflow.net                  3   9   377   118   +203us[ +122us] +/-   12ms
+^+ mail.rapidooo.fr              2   9   377   113  -1029us[-1110us] +/- 9934us
+^- 88-185-213-3.subs.proxad>     3   8   377   506   +688us[ +491us] +/-   49ms
+```
+
+In the `MS` column, the first character is the source type, `^` for a server, and the second
+is the state of that source:
 
 - `*` marks the one currently being used.
-- `+` marks another acceptable source being combined with it.
+- `+` marks another acceptable source, combined with it.
+- `-` marks a source chrony is measuring but has excluded from the combination.
 - `?` means the source is unreachable.
 
-At least one source should reach the `*` state.
+At least one source should reach the `*` state. Seeing `-` on some of the others is normal
+and does not need correcting.
 
 To see the offset chrony believes it has, and whether it has settled:
 

--- a/docs/management/time-synchronization.md
+++ b/docs/management/time-synchronization.md
@@ -19,7 +19,8 @@ to configure NTP, and how to check and correct it.
   master, and must stay synchronized afterwards. A failed join tells you what is wrong. Drift
   that sets in later does not: it surfaces as hosts disagreeing about when things happened,
   each of them convinced by its own clock. Keep every host in a pool on the same time sources.
-  See [Pool Requirements](../../installation/requirements#pool-requirements).
+  See [Pool Requirements](../../installation/requirements#pool-requirements) for the other
+  conditions a host has to meet before it can join.
 - **Certificates.** Certificates are only valid inside a validity window. A host whose date
   falls outside that window will reject, or be rejected by, connections that would otherwise
   succeed.
@@ -50,21 +51,23 @@ had no time source to begin with.
 ### During installation
 
 The installer prompts you to enter the time, select a time zone, and either configure NTP
-servers or set the time manually. Always configure at least one NTP server. See
-[Install XCP-ng](../../installation/install-xcp-ng).
+servers or set the time manually. Always configure at least one NTP server (see
+[Install XCP-ng](../../installation/install-xcp-ng) for where this falls in the installation
+sequence).
 
 :::warning
 If you set the time manually at this step, the host can end up with `chronyd` running but no
 time source configured at all. The clock still ticks, but nothing ever checks it: it drifts
 from the date you typed, and if that date was wrong, it stays wrong. This is also the one
 case that does not fix itself at boot, since `makestep` needs a source to measure against.
-See [Checking the time sources](#checking-the-time-sources) below.
+[Checking the time sources](#checking-the-time-sources) below shows how to recognise that
+state on a running host.
 :::
 
 ### During an automated installation
 
 The installation answer file accepts one or more NTP servers through the `<ntp-server>`
-element. See [Answer file](../../appendix/answerfile).
+element (see [Answer file](../../appendix/answerfile) for its syntax).
 
 ### On an installed host
 
@@ -149,8 +152,8 @@ Work outward, from the configuration to the network:
    ever configured, which is the manual-time-at-install case. Add them with `xsconsole`.
 2. **Are they reachable?** Sources stuck at `?` are configured but unanswered. NTP goes out
    over UDP 123, so a firewall between the host and its servers produces exactly this, as
-   does a network with no route to the public pool. See
-   [Networks without internet access](#networks-without-internet-access).
+   does a network with no route to the public pool, which
+   [Networks without internet access](#networks-without-internet-access) below covers.
 3. **Is the daemon healthy?** `systemctl status chronyd`, and `journalctl -u chronyd` for
    what it made of its configuration at startup.
 4. **Was the configuration changed underneath you?** `rpm -V chrony` reports whether

--- a/docs/management/time-synchronization.md
+++ b/docs/management/time-synchronization.md
@@ -9,7 +9,7 @@ working normally until something needs to trust that date. When that happens, th
 failures rarely point to the clock as the cause. This page explains why the clock matters, how
 to configure NTP, and how to check and correct it.
 
-## ⏰ Why the clock must be correct {#why-the-clock-must-be-correct}
+## Why the clock must be correct {#why-the-clock-must-be-correct}
 
 - **Access to the repositories.** Updates are fetched over HTTPS, and TLS validates the
   server's certificate against the host's own date. If the host's clock is set too far in the
@@ -27,7 +27,7 @@ to configure NTP, and how to check and correct it.
   anything that runs on a schedule such as backups, depend on the hosts agreeing on what
   time it is.
 
-## 🕰️ How XCP-ng keeps time {#how-xcp-ng-keeps-time}
+## How XCP-ng keeps time {#how-xcp-ng-keeps-time}
 
 The time daemon on dom0 is `chronyd`, configured through `/etc/chrony.conf`.
 
@@ -45,7 +45,7 @@ After those three updates chronyd only slews, which for an offset of months or y
 converges. That is the case the manual correction below exists for, along with the host that
 had no time source to begin with.
 
-## 🔧 Configuring the time sources {#configuring-the-time-sources}
+## Configuring the time sources {#configuring-the-time-sources}
 
 ### During installation
 
@@ -80,7 +80,7 @@ field in the XOA deployment form does the same for the appliance being deployed.
 touches the chrony configuration of the hosts XO manages.
 :::
 
-## 🔍 Checking the time sources {#checking-the-time-sources}
+## Checking the time sources {#checking-the-time-sources}
 
 Check that the service is running, and that it actually has something to synchronize with:
 
@@ -136,7 +136,7 @@ To see the offset chrony believes it has, and whether it has settled:
 chronyc tracking
 ```
 
-## 🛠️ Correcting a wrong clock {#correcting-a-wrong-clock}
+## Correcting a wrong clock {#correcting-a-wrong-clock}
 
 A host with working time sources does not usually have a wrong clock, because chronyd steps
 it within seconds of starting. So a clock that is still wrong is telling you that something
@@ -221,7 +221,7 @@ dead and should be replaced. `rtcsync` can only keep the hardware clock in step 
 host is running; it cannot help a clock that loses its value when the power goes.
 :::
 
-## 🌐 Networks without internet access {#networks-without-internet-access}
+## Networks without internet access {#networks-without-internet-access}
 
 Hosts without Internet access cannot reach the public NTP pool. The result is the same as
 having no sources at all: `chronyc sources` lists servers that never leave the `?` state.

--- a/docs/management/time-synchronization.md
+++ b/docs/management/time-synchronization.md
@@ -150,13 +150,14 @@ dead and should be replaced. `rtcsync` can only keep the hardware clock in step 
 host is running; it cannot help a clock that loses its value when the power goes.
 :::
 
-## 🌐 Isolated networks {#isolated-networks}
+## 🌐 Networks without internet access {#networks-without-internet-access}
 
 Hosts without Internet access cannot reach the public NTP pool. The result is the same as
 having no sources at all: `chronyc sources` lists servers that never leave the `?` state.
 
-On such networks, point `/etc/chrony.conf` at a time source that hosts can actually reach,
-such as an appliance on the same network or a local server that is itself synchronized.
+On such networks, point `/etc/chrony.conf` to a time source that hosts can actually reach,
+such as an appliance on the same network, or a local server that is itself synchronized and
+acts as the reference time for the network.
 
 ## 🎱 Pools {#pools}
 

--- a/docs/management/time-synchronization.md
+++ b/docs/management/time-synchronization.md
@@ -16,7 +16,10 @@ to configure NTP, and how to check and correct it.
   past, the TLS handshake fails because, from the host's perspective, the mirror's certificate
   is not yet valid. The error `yum` prints in that situation does not mention time.
 - **Pool membership.** A host joining a pool must have its clock synchronized with the pool
-  master. See [Pool Requirements](../../installation/requirements#pool-requirements).
+  master, and must stay synchronized afterwards. A failed join tells you what is wrong. Drift
+  that sets in later does not: it surfaces as hosts disagreeing about when things happened,
+  each of them convinced by its own clock. Keep every host in a pool on the same time sources.
+  See [Pool Requirements](../../installation/requirements#pool-requirements).
 - **Certificates.** Certificates are only valid inside a validity window. A host whose date
   falls outside that window will reject, or be rejected by, connections that would otherwise
   succeed.
@@ -32,18 +35,30 @@ The default configuration enables `rtcsync`, allowing chronyd to keep the hardwa
 synchronized with the system clock automatically. There is no need to manually update the
 hardware clock after correcting the system time, and the correction persists across reboots.
 
+It also sets `makestep 1.0 3`, which lets chronyd jump the clock rather than ease it into
+place, for the first three updates after the service starts. A host that boots with a badly
+wrong date therefore fixes itself within seconds, as long as it can reach a time source.
+Measured on 8.3: a clock put 45 days in the past was corrected between five and ten seconds
+after `chronyd` started.
+
+After those three updates chronyd only slews, which for an offset of months or years never
+converges. That is the case the manual correction below exists for, along with the host that
+had no time source to begin with.
+
 ## 🔧 Configuring the time sources {#configuring-the-time-sources}
 
 ### During installation
 
-At step 11, the installer prompts you to enter the time, select a time zone and either
-configure NTP servers or set the time manually. Always configure at least one NTP server. See
+The installer prompts you to enter the time, select a time zone, and either configure NTP
+servers or set the time manually. Always configure at least one NTP server. See
 [Install XCP-ng](../../installation/install-xcp-ng).
 
 :::warning
 If you set the time manually at this step, the host can end up with `chronyd` running but no
-time source configured at all. It will keep whatever date it was installed with. See
-[Checking the time sources](#checking-the-time-sources) below.
+time source configured at all. The clock still ticks, but nothing ever checks it: it drifts
+from the date you typed, and if that date was wrong, it stays wrong. This is also the one
+case that does not fix itself at boot, since `makestep` needs a source to measure against.
+See [Checking the time sources](#checking-the-time-sources) below.
 :::
 
 ### During an automated installation
@@ -53,8 +68,17 @@ element. See [Answer file](../../appendix/answerfile).
 
 ### On an installed host
 
-You can configure NTP from `xsconsole`, or by editing `/etc/chrony.conf` directly and
-restarting the service.
+Use `xsconsole`. Its NTP screen adds and removes time servers and restarts `chronyd` for you.
+
+:::warning
+Editing `/etc/chrony.conf` by hand is a last resort, for when no other route works. Reach for
+`xsconsole` first.
+
+Xen Orchestra does not configure NTP on hosts. Its `xoa network ntp` command sets the time
+servers of the XOA appliance itself, which is a Debian VM keeping its own clock, and the NTP
+field in the XOA deployment form does the same for the appliance being deployed. Neither
+touches the chrony configuration of the hosts XO manages.
+:::
 
 ## 🔍 Checking the time sources {#checking-the-time-sources}
 
@@ -89,10 +113,10 @@ On a host that is synchronizing normally, the same two commands look like this:
 210 Number of sources = 4
 MS Name/IP address         Stratum Poll Reach LastRx Last sample
 ===============================================================================
-^* vps1.websters-computers.>     2   7   377    59   -361us[ -444us] +/- 8522us
-^+ meshflow.net                  3   9   377   118   +203us[ +122us] +/-   12ms
-^+ mail.rapidooo.fr              2   9   377   113  -1029us[-1110us] +/- 9934us
-^- 88-185-213-3.subs.proxad>     3   8   377   506   +688us[ +491us] +/-   49ms
+^* ntp1.example.net              2   7   377    59   -361us[ -444us] +/- 8522us
+^+ ntp2.example.net              3   9   377   118   +203us[ +122us] +/-   12ms
+^+ ntp3.example.net              2   9   377   113  -1029us[-1110us] +/- 9934us
+^- ntp4.example.net              3   8   377   506   +688us[ +491us] +/-   49ms
 ```
 
 In the `MS` column, the first character is the source type, `^` for a server, and the second
@@ -114,54 +138,75 @@ chronyc tracking
 
 ## 🛠️ Correcting a wrong clock {#correcting-a-wrong-clock}
 
-Start with `chronyc sources`, because the answer decides which of the two paths below
-applies.
+A host with working time sources does not usually have a wrong clock, because chronyd steps
+it within seconds of starting. So a clock that is still wrong is telling you that something
+upstream of it is broken. Find that first. Stepping the clock by hand gets you working again
+today, and if you stop there the date is wrong again in a few weeks.
 
-### If sources are listed
+Work outward, from the configuration to the network:
 
-Correct the clock and check the result:
+1. **Are there any sources?** `chronyc sources`. `Number of sources = 0` means none were
+   ever configured, which is the manual-time-at-install case. Add them with `xsconsole`.
+2. **Are they reachable?** Sources stuck at `?` are configured but unanswered. NTP goes out
+   over UDP 123, so a firewall between the host and its servers produces exactly this, as
+   does a network with no route to the public pool. See
+   [Networks without internet access](#networks-without-internet-access).
+3. **Is the daemon healthy?** `systemctl status chronyd`, and `journalctl -u chronyd` for
+   what it made of its configuration at startup.
+4. **Was the configuration changed underneath you?** `rpm -V chrony` reports whether
+   `/etc/chrony.conf` still matches the package. Hand edits and `xsconsole` both show up here.
+
+Once sources are reachable, restarting the daemon corrects the clock on its own, because the
+`makestep` allowance applies again from a fresh start:
+
+```bash
+systemctl restart chronyd
+chronyc sources
+date
+```
+
+### Stepping the clock immediately
+
+If you need the correct date right now and the daemon has been running for a while, its
+`makestep` allowance is already spent and it will only slew:
 
 ```bash
 chronyc makestep
 date
 ```
 
-`chronyc makestep` is what does the work here. By default, chrony corrects time offsets by
-gradually slewing the system clock, which never converges for an offset of months or years.
-
-### If `Number of sources = 0`
-
-Do not start with `makestep`. It will report success and move nothing, because chrony has no
-measured offset to step to.
-
-1. Add time sources to `/etc/chrony.conf`:
-
-   ```
-   server 0.pool.ntp.org iburst
-   server 1.pool.ntp.org iburst
-   server 2.pool.ntp.org iburst
-   server 3.pool.ntp.org iburst
-   ```
-
-2. Restart the service and confirm that a source has become reachable, as described in
-   [Checking the time sources](#checking-the-time-sources):
-
-   ```bash
-   systemctl restart chronyd
-   chronyc sources
-   ```
-
-3. Once a source is reachable, correct the clock:
-
-   ```bash
-   chronyc makestep
-   date
-   ```
+This is a stopgap. It needs at least one reachable source to have something to step to, and
+on a host with `Number of sources = 0` it reports success while moving nothing. It also does
+nothing about the reason the clock was wrong, so treat it as buying time for the diagnosis
+above rather than as the end of it.
 
 :::note
-Correcting the date does not invalidate the host's own certificate. XAPI issues it with a
-ten-year validity, so a host installed with a wrong date still holds a certificate that
-covers the corrected date. `xe host-refresh-server-certificate` is not needed for this.
+**Check the host certificate after a large correction.**
+
+XAPI issues the host certificate with a ten-year validity, anchored on the clock at the time
+it was generated. Small corrections stay comfortably inside that window, so most of the time
+there is nothing to do.
+
+A big correction is different. A host that installed itself believing the year was 2010 holds
+a certificate valid 2010 to 2020, and moving the clock to the real date leaves that
+certificate expired. A clock set far into the future at install produces the mirror image: a
+certificate that is not valid yet once the date is corrected backwards.
+
+Check the window against the corrected date:
+
+```bash
+openssl x509 -in /etc/xensource/xapi-ssl.pem -noout -dates
+date -u
+```
+
+If the current date falls outside `notBefore` to `notAfter`, regenerate the certificate:
+
+```bash
+xe host-refresh-server-certificate host=<host>
+```
+
+On a host whose certificate is already rejected, and which therefore cannot be reached the
+usual way, `xe host-emergency-reset-server-certificate` runs locally on the host itself.
 :::
 
 :::tip
@@ -175,13 +220,6 @@ host is running; it cannot help a clock that loses its value when the power goes
 Hosts without Internet access cannot reach the public NTP pool. The result is the same as
 having no sources at all: `chronyc sources` lists servers that never leave the `?` state.
 
-On such networks, point `/etc/chrony.conf` to a time source that hosts can actually reach,
-such as an appliance on the same network, or a local server that is itself synchronized and
+On such networks, point the hosts at a time source they can actually reach, using `xsconsole`
+as above: an appliance on the same network, or a local server that is itself synchronized and
 acts as the reference time for the network.
-
-## 🎱 Pools {#pools}
-
-Keep every host in a pool synchronized, ideally against the same sources. A host whose clock
-differs from the pool master is not just inconvenient: clock synchronization is one of
-the requirements for joining a pool, along with the other requirements listed in
-[Pool Requirements](../../installation/requirements#pool-requirements).

--- a/docs/management/time-synchronization.md
+++ b/docs/management/time-synchronization.md
@@ -183,29 +183,35 @@ above rather than as the end of it.
 :::note
 **Check the host certificate after a large correction.**
 
-XAPI issues the host certificate with a ten-year validity, anchored on the clock at the time
-it was generated. Small corrections stay comfortably inside that window, so most of the time
+XAPI issues certificates with a ten-year validity, anchored on the clock at the moment they
+are generated. Small corrections stay comfortably inside that window, so most of the time
 there is nothing to do.
 
-A big correction is different. A host that installed itself believing the year was 2010 holds
-a certificate valid 2010 to 2020, and moving the clock to the real date leaves that
-certificate expired. A clock set far into the future at install produces the mirror image: a
-certificate that is not valid yet once the date is corrected backwards.
+A big correction is different. A host that generated its certificates believing the year was
+2016 holds them valid 2016 to 2026, and moving the clock to the real date can leave them
+expired. A clock set far into the future produces the mirror image: certificates not valid
+yet once the date is corrected backwards.
 
-Check the window against the corrected date:
+There are two, and they are refreshed by different commands:
+
+| Certificate | What it is | Regenerate with |
+|---|---|---|
+| `/etc/xensource/xapi-ssl.pem` | The TLS certificate clients see, including Xen Orchestra | `xe host-reset-server-certificate` |
+| `/etc/xensource/xapi-pool-tls.pem` | The internal certificate hosts use between themselves | `xe host-refresh-server-certificate host=<host>` |
+
+Check both windows against the corrected date:
 
 ```bash
 openssl x509 -in /etc/xensource/xapi-ssl.pem -noout -dates
+openssl x509 -in /etc/xensource/xapi-pool-tls.pem -noout -dates
 date -u
 ```
 
-If the current date falls outside `notBefore` to `notAfter`, regenerate the certificate:
+If the date falls outside `notBefore` to `notAfter`, regenerate the one concerned using the
+table above. Do not reach for `host-refresh-server-certificate` to fix `xapi-ssl.pem`: it
+refreshes the internal certificate, reports success, and leaves the TLS one untouched.
 
-```bash
-xe host-refresh-server-certificate host=<host>
-```
-
-On a host whose certificate is already rejected, and which therefore cannot be reached the
+On a host whose TLS certificate is already rejected, and which therefore cannot be reached the
 usual way, `xe host-emergency-reset-server-certificate` runs locally on the host itself.
 :::
 

--- a/docs/management/time-synchronization.md
+++ b/docs/management/time-synchronization.md
@@ -1,0 +1,161 @@
+---
+sidebar_position: 8
+---
+
+# Time synchronization
+
+XCP-ng keeps the dom0 clock with `chronyd`. A host whose date is wrong carries on working
+normally until something needs to trust that date, and the failures it produces then rarely
+mention time at all. This page covers why the clock matters, how to configure NTP, and how
+to check and correct it.
+
+## ⏰ Why the clock must be correct {#why-the-clock-must-be-correct}
+
+- **Access to the repositories.** Updates are fetched over HTTPS, and TLS validates the
+  server's certificate against the host's own date. A host set far in the past cannot
+  complete the handshake, because from where it is standing the mirror's certificate is not
+  valid yet. The error `yum` prints in that situation does not mention time.
+- **Pool membership.** A host joining a pool must have its clock synchronized with the pool
+  master. See [Pool Requirements](../../installation/requirements#pool-requirements).
+- **Certificates.** Certificates are only valid inside a validity window. A host whose date
+  falls outside that window will reject, or be rejected by, connections that would otherwise
+  succeed.
+- **Logs and scheduled operations.** Correlating events across the hosts of a pool, and
+  anything that runs on a schedule such as backups, depend on the hosts agreeing on what
+  time it is.
+
+## 🕰️ How XCP-ng keeps time {#how-xcp-ng-keeps-time}
+
+The time daemon on dom0 is `chronyd`, configured through `/etc/chrony.conf`.
+
+The shipped configuration enables `rtcsync`, so chronyd keeps the hardware clock in step
+with the system clock on its own. There is no need to copy a corrected time to the hardware
+clock by hand, and a correction survives a reboot.
+
+## 🔧 Configuring the time sources {#configuring-the-time-sources}
+
+### During installation
+
+The installer asks for the timezone and the time at step 11, and lets you either give it NTP
+servers or set the time manually. Always give it an NTP server. See
+[Install XCP-ng](../../installation/install-xcp-ng).
+
+:::warning
+If you set the time manually at this step, the host can end up with `chronyd` running but no
+time source configured at all. It will keep whatever date it was installed with. See
+[Checking the time sources](#checking-the-time-sources) below.
+:::
+
+### During an automated installation
+
+The installation answer file accepts one or more NTP servers through the `<ntp-server>`
+element. See [Answer file](../../appendix/answerfile).
+
+### On an installed host
+
+You can configure NTP from `xsconsole`, or by editing `/etc/chrony.conf` directly and
+restarting the service.
+
+## 🔍 Checking the time sources {#checking-the-time-sources}
+
+Check that the service is running, and that it actually has something to synchronize with:
+
+```bash
+systemctl status chronyd
+chronyc sources
+```
+
+Both matter, and the second is the one that gets skipped. `chronyd` can be running and
+enabled while having **no time sources configured at all**:
+
+```
+# chronyc sources
+210 Number of sources = 0
+```
+
+The service is then behaving exactly as configured, and doing nothing. Every other check an
+operator would normally run looks healthy, which is what makes this one worth running early
+rather than late.
+
+When sources are configured, `chronyc sources` lists them. In the `MS` column, the second
+character is the state of that source: `*` marks the one currently being used, `+` marks
+another acceptable source being combined with it, and `?` means the source is unreachable.
+At least one source should reach the `*` state.
+
+To see the offset chrony believes it has, and whether it has settled:
+
+```bash
+chronyc tracking
+```
+
+## 🛠️ Correcting a wrong clock {#correcting-a-wrong-clock}
+
+Start with `chronyc sources`, because the answer decides which of the two paths below
+applies.
+
+### If sources are listed
+
+Correct the clock and check the result:
+
+```bash
+chronyc makestep
+date
+```
+
+`chronyc makestep` is what does the work here. By default chrony corrects an offset by
+slewing the clock gradually, which never converges for an offset of months or years.
+
+### If `Number of sources = 0`
+
+Do not start with `makestep`. It will report success and move nothing, because chrony has no
+measured offset to step to. Add time sources to `/etc/chrony.conf` first:
+
+```
+server 0.centos.pool.ntp.org iburst
+server 1.centos.pool.ntp.org iburst
+server 2.centos.pool.ntp.org iburst
+server 3.centos.pool.ntp.org iburst
+```
+
+Then restart the service and confirm that a source has become reachable, as described in
+[Checking the time sources](#checking-the-time-sources):
+
+```bash
+systemctl restart chronyd
+chronyc sources
+```
+
+Once a source is reachable, correct the clock:
+
+```bash
+chronyc makestep
+date
+```
+
+:::note
+Correcting the date does not invalidate the host's own certificate. XAPI issues it with a
+ten-year validity, so a host installed with a wrong date still holds a certificate that
+covers the corrected date. `xe host-refresh-server-certificate` is not needed for this.
+:::
+
+:::tip
+If `date` is wrong again after every power cycle, the motherboard's RTC battery is probably
+dead and should be replaced. `rtcsync` can only keep the hardware clock in step while the
+host is running; it cannot help a clock that loses its value when the power goes.
+:::
+
+## 🌐 Isolated networks {#isolated-networks}
+
+Hosts without access to the internet cannot reach the public NTP pool, and the symptom is
+the same as having no sources at all: `chronyc sources` lists servers that never leave the
+`?` state.
+
+On such a network, point `/etc/chrony.conf` at a time source that hosts can actually reach,
+such as an appliance on the same network or a local server that is itself synchronized.
+
+## 🎱 Pools {#pools}
+
+Keep every host in a pool synchronized, ideally against the same sources. A host whose clock
+disagrees with the pool master is not merely inconvenient: clock synchronization is one of
+the requirements for joining a pool in the first place, alongside the others listed in
+[Pool Requirements](../../installation/requirements#pool-requirements).


### PR DESCRIPTION
> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]."
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco

@stormi asked for this in #504:

> Wrong dates can cause a lot of different issues. We must make sure we have a dedicated page or section somewhere in the docs that gives all details about NTP and why it must be set correctly, and this specific troubleshooting topic about yum would then link to it for details.

NTP was documented in three places, each in passing: the installer walkthrough tells you to always use an NTP server, the answer file reference lists `<ntp-server>`, and the pool requirements mention clock synchronization. Nothing said what to do when the clock is already wrong, or how to tell whether chrony is actually doing anything.

This gathers it into one page: why the date matters, how to set the sources at install time and afterwards, how to check them, and how to correct a host that has already drifted.

The part I had not seen documented anywhere is that `chronyd` can be running *and* enabled while having no time sources configured at all. `systemctl status chronyd` looks healthy, the network is fine, and the host simply keeps its installation date. The only check that reveals it is `chronyc sources` returning `Number of sources = 0`, which nobody runs until they already suspect the clock. So the page puts that check first, and splits the correction into two paths, because `chronyc makestep` reports success and moves nothing when there is no source to step to.

#504 will link here for detail once this lands, and sheds its NTP how-to in the process. I have deliberately not linked from here to that troubleshooting section yet, since it does not exist on `master` and `onBrokenLinks` is set to `throw`.
