### PR TITLE
Streamline the navbar and make it similar to the other documentations

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -113,14 +113,9 @@ const config = {
           src: 'img/xcpcrop128.png',
         },
         items: [
-          {href: 'https://xcp-ng.org', label: 'Home', position: 'right'},
-          {href: 'https://xcp-ng.org/blog', label: 'Blog', position: 'right'},
-          {href: 'https://vates.tech', label: 'Pro Support', position: 'right'},
-          {
-            href: 'https://github.com/xcp-ng',
-            label: 'GitHub',
-            position: 'right',
-          },
+          {to: 'https://docs.vates.tech/', label: 'Vates VMS', position: 'right', target: '_self'},
+          {href: '/', label: 'XCP-ng', position: 'right'},
+          {to: 'https://docs.xen-orchestra.com/', label: 'Xen Orchestra', position: 'right', target: '_self'},
         ],
       },
       footer: {
@@ -130,7 +125,11 @@ const config = {
             title: 'Learn',
             items: [
               {
-                label: 'Introduction',
+                label: 'About XCP-ng',
+                href: 'https://xcp-ng.org',
+              },
+              {
+                label: 'XCP-ng doc',
                 href: '/',
               },
               {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -113,7 +113,7 @@ const config = {
           src: 'img/xcpcrop128.png',
         },
         items: [
-          {to: 'https://docs.vates.tech/', label: 'Vates VMS', position: 'right', target: '_self'},
+          {href: 'https://docs.vates.tech/', label: 'Vates VMS', position: 'right'},
           {href: '/', label: 'XCP-ng', position: 'right'},
           {to: 'https://docs.xen-orchestra.com/', label: 'Xen Orchestra', position: 'right', target: '_self'},
         ],

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -59,3 +59,8 @@
 article {
   counter-reset: schema-fig;
 }
+
+/* Make links to Vates VMS/XO/XCP-ng docs more visible in the documentation header */
+.navbar__item {
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary

This pull request completes the navbar refresh started for the [Vates VMS](https://docs.vates.tech/) and [Xen Orchestra](https://docs.xen-orchestra.com/) docs (see the [corresponding PR for Xen Orchestra](https://github.com/vatesfr/xen-orchestra/pull/10067)).

The goal is to provide a more consistent experience across our three docs by simplifying the navigation bar, making links to the different doc sites more prominent, and opening them in the same tab so that they feel like a single documentation portal.

## Changes

- Simplify the navbar by removing the redundant **Blog**, **Pro Support**, and **GitHub** links. These remain available in the footer:
    - The **Blog** link is available as **News**, under the **More** section.
    - The **Pro Support** link is available as **Vates Stack**, under the **Pro Support** section.
    - The footer already contains a **GitHub** link, but it points to [https://github.com/xcp-ng/xcp-ng-org](https://github.com/xcp-ng/xcp-ng-org), whereas the navbar link points to [https://github.com/xcp-ng](https://github.com/xcp-ng). 
        **Question:** Should we keep both links in the footer, or would a single GitHub link be enough? As of now, this PR just keeps the GitHub link from the footer, as-is.
- Rename the **Introduction** link in the footer to **XCP-ng doc** for clarity.
- Move the **Home** link from the navbar to the footer and rename it **About XCP-ng**, to avoid confusion with the **XCP-ng doc** link (see the previous point).
- Add links to the Vates VMS and Xen Orchestra docs in the navbar.
- Display navbar links in **bold**.
- When clicking the links to the other docs in the navigation bar, the pages now open in the same browser tab.

## Preview

### Before

<img width="1794" height="548" alt="XCP-ng doc header - Before" src="https://github.com/user-attachments/assets/9004c0d2-ea09-43f6-bcb6-ead71276e0d5" />

<img width="1557" height="605" alt="XCP-ng doc footer - Before" src="https://github.com/user-attachments/assets/d6f76b36-543c-49f4-b4a6-523247c10f58" />

### After

<img width="1993" height="530" alt="XCP-ng doc header" src="https://github.com/user-attachments/assets/086ad96f-0ad7-4cd6-a069-0ac1ee090a3b" />

<img width="1984" height="744" alt="XCP-ng doc footer" src="https://github.com/user-attachments/assets/5fc7fa8f-f459-416d-b974-0ffba5f426c7" />

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
