### PR TITLE
Fix the vApp example: the VM parameter is order, not start-order

### DIFF
--- a/docs/vms/vm-lifecycle.md
+++ b/docs/vms/vm-lifecycle.md
@@ -102,7 +102,7 @@ XAPI can group VMs into an *appliance* (also called vApp): a set of VMs started 
 
 <Terminal shell title="root@xcp-ng-host — VM groups with a start order…">{`
 xe appliance-create name-label="my-app"
-xe vm-param-set uuid=<vm-uuid> appliance=<appliance-uuid> start-order=1 start-delay=30
+xe vm-param-set uuid=<vm-uuid> appliance=<appliance-uuid> order=1 start-delay=30
 xe appliance-start uuid=<appliance-uuid>
 `}</Terminal>
 


### PR DESCRIPTION
> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]."
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco

The vApp example in `docs/vms/vm-lifecycle.md` uses `start-order`, which `xe` rejects. Anyone copying the command gets an error and no appliance.

```
# xe vm-param-set uuid=<uuid> start-order=1
Error: Unknown field 'start-order'
```

The field is `order`. The CLI reference has it right: "`order` start order (read/write) for vApp startup/shutdown and for startup after HA failover".

Ran the corrected line as it appears on the page, on XCP-ng 8.3.0, xapi 26.1:

```
# A=$(xe appliance-create name-label=doc-test-vapp)
# xe vm-param-set uuid=<vm-uuid> appliance=$A order=1 start-delay=30
# echo $?
0
# xe vm-param-get uuid=<vm-uuid> param-name=order
1
# xe vm-param-get uuid=<vm-uuid> param-name=start-delay
30
```

Test appliance destroyed and the VM's parameters put back afterwards.

Found while testing the claims in #505, which is where the same mistake sent me: `start-order` looks plausible because the surrounding prose calls it a start order.

`npm run build` passes.
