### PR TITLE
RFC: replace unicode emojis with :emoji-name: for accessibility purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,36 @@ The one exception to the no-characters rule is **quoted material**: sample termi
 JSON payload, a code span, an inline SVG. There the character is part of what is being quoted,
 and a shortcode would not be converted anyway. Keep it as it is.
 
+#### What the build does with them
+
+The same reasoning applies to the published page, so the build does not simply drop the
+character into the HTML. Nothing here needs anything from you — it is worth knowing only
+because it explains why a heading looks bare in the browser's inspector.
+
+A heading's emoji is decoration: the heading reads correctly without it, and announcing it
+ahead of the title on every heading is noise to anyone navigating by heading. So it is hidden
+where it stands, and the table of contents entry gets the same treatment:
+
+```html
+<h2 id="where-to-start"><span aria-hidden="true">🚀</span> Where to start</h2>
+```
+
+Drawing it from CSS instead would additionally keep it out of the text copied with the heading
+and out of the search index, but `aria-hidden` needs no CSS at all, so the emoji still renders
+in a text-mode browser such as w3m and in browsers too old for the CSS involved. That trade is
+forced rather than chosen: in a text browser the visible text *is* what a screen reader gets,
+so nothing can show w3m the emoji while hiding it from assistive tech.
+
+Every other emoji means something, so it stays where it is and gets a name instead:
+
+```html
+<span role="img" aria-label="warning">⚠️</span>
+```
+
+That name is what a braille display receives in place of the character, which is the point: a
+braille table has no cell for an emoji, so a bare one arrives as a placeholder the reader has
+to stop and inspect. Speech is unchanged — it is the name a screen reader announces anyway.
+
 `npm run lint:emoji` checks all of this, in both directions. It reports emoji characters in the
 sources, and it reports shortcodes that would silently not work:
 

--- a/README.md
+++ b/README.md
@@ -63,16 +63,28 @@ The one exception to the no-characters rule is **quoted material**: sample termi
 JSON payload, a code span, an inline SVG. There the character is part of what is being quoted,
 and a shortcode would not be converted anyway. Keep it as it is.
 
-`npm run lint:emoji` checks all of this. It exempts fenced code blocks and code spans; for a
-quoted case outside those, put `<!-- allow-emoji -->` on the line before.
+`npm run lint:emoji` checks all of this, in both directions. It reports emoji characters in the
+sources, and it reports shortcodes that would silently not work:
+
+- a name nothing resolves — a typo, or an emoji missing from the tables below — which renders as
+  the literal text `:name:`;
+- a name that resolves without the U+FE0F variation selector, which some fonts draw as a flat
+  monochrome glyph;
+- a shortcode in front matter or in an attribute value such as `title=":rocket: Install"`, where
+  nothing converts it;
+- a heading with an emoji and no explicit `{#id}`.
+
+Fenced code blocks, code spans and the JSX template literals in `<Terminal>` blocks are exempt,
+in both directions: quoted output keeps its characters, and shortcodes are not converted there
+anyway. For a quoted case outside them, put `<!-- allow-emoji -->` on the line before.
 
 #### When a name does not work
 
 Docusaurus converts the shortcodes, and its emoji dataset is a few Unicode versions behind
 gemoji: names for anything recent, and for the profession sequences like `:technologist:`, are
 missing. Two tables in `src/plugins/emoji/vocabulary.js` fill the gap, and that file is the one
-place in the documentation build where emoji characters belong. Which table you add to depends
-on what the built page shows:
+place in the documentation build where emoji characters belong. `npm run lint:emoji` tells you
+which table to add to, and so does the built page:
 
 - **The literal text `:melting_face:`, shortcode and all** — Docusaurus has never heard of the
   name. Add it to `ALIASES`, keeping the list alphabetical:

--- a/README.md
+++ b/README.md
@@ -35,3 +35,75 @@ This command generates static content into the `build` directory and can be serv
 ### Autogeneration
 
 This documentation is automatically rebuilt after each push event on `master` branch.
+
+### Emoji
+
+**Never write an emoji character in a documentation file.** Not in a heading, not in a
+paragraph, not in a table. People read our markdown sources directly — on GitHub, in an
+editor, through the "Edit this page" link — and a screen reader or a braille display turns an
+emoji into noise or a question mark, so a heading like `## 📋 Contents` reads as gibberish to a
+blind contributor.
+
+Write the name instead, in the `:name:` form GitHub uses, and the build inserts the character:
+
+```markdown
+## :rocket: Where to start {#where-to-start}
+
+- `zfs` updated to version 2.1.15. :warning: Existing ZFS pools may need an upgrade.
+```
+
+Names are the ones [gemoji](https://github.com/github/gemoji) lists, the set GitHub
+understands, so anything you are used to typing in an issue works here too.
+
+**A heading with an emoji needs an explicit `{#id}`**, as every heading here already has.
+Heading ids are computed before the shortcode is converted, so without one the id would be
+built out of the emoji name. `npm run write-heading-ids` adds the missing ones.
+
+The one exception to the no-characters rule is **quoted material**: sample terminal output, a
+JSON payload, a code span, an inline SVG. There the character is part of what is being quoted,
+and a shortcode would not be converted anyway. Keep it as it is.
+
+`npm run lint:emoji` checks all of this. It exempts fenced code blocks and code spans; for a
+quoted case outside those, put `<!-- allow-emoji -->` on the line before.
+
+#### When a name does not work
+
+Docusaurus converts the shortcodes, and its emoji dataset is a few Unicode versions behind
+gemoji: names for anything recent, and for the profession sequences like `:technologist:`, are
+missing. Two tables in `src/plugins/emoji/vocabulary.js` fill the gap, and that file is the one
+place in the documentation build where emoji characters belong. Which table you add to depends
+on what the built page shows:
+
+- **The literal text `:melting_face:`, shortcode and all** — Docusaurus has never heard of the
+  name. Add it to `ALIASES`, keeping the list alphabetical:
+
+  ```js
+  const ALIASES = {
+    // ...
+    melting_face: '🫠',
+  };
+  ```
+
+  Use the name [gemoji](https://github.com/github/gemoji) gives the emoji, not one of your own:
+  the point is that contributors can write what they are used to. If gemoji has no name for it
+  either, the emoji is too new or too obscure to be worth using.
+
+- **The emoji, but flat and monochrome** instead of in colour — the name resolved to the
+  text-presentation codepoint, without the U+FE0F variation selector that asks for the colourful
+  form. Add that form to `PRESENTATION`, again alphabetically:
+
+  ```js
+  const PRESENTATION = {
+    // ...
+    skull_and_crossbones: '☠️',
+  };
+  ```
+
+  Copy the character from somewhere that keeps the variation selector — pasting the bare glyph
+  gives you back exactly what you were trying to fix — and confirm it comes out in colour.
+
+Either way, run `npm run start` and look at the page: a name that resolves to nothing renders as
+`:name:`, which is the failure you are checking for. Nothing else to update — both tables are
+read by the remark plugin sitting next to them, with no build step and no dependency involved.
+Adding a name Docusaurus already handles is harmless but pointless; the tables exist only to
+cover what it gets wrong, so keeping them short keeps them reviewable.

--- a/docs/compute.md
+++ b/docs/compute.md
@@ -6,7 +6,7 @@ sidebar_position: 8
 
 This section is dedicated to compute related things, like GPU/vGPU or PCI passthrough, nested virtualization or advanced Xen features.
 
-## 🔗 PCI Passthrough {#pci-passthrough}
+## :link: PCI Passthrough {#pci-passthrough}
 
 ### 0. Prerequisites
 
@@ -202,7 +202,7 @@ If you want to get the PCI device accessible again in the Dom0, you also need to
 
 It will be back in the Dom0 after a reboot.
 
-## 🎮 GPU Passthrough {#gpu-passthrough}
+## :video_game: GPU Passthrough {#gpu-passthrough}
 To passthrough a complete graphics card to a VM (not virtualize it into multiple virtual vGPUs, which is different, see the vGPU section below), just follow the regular PCI passthrough instructions, no special steps are needed. Most Nvidia and AMD video cards should work without issue.  
 
 :::warning
@@ -213,7 +213,7 @@ Passthrough of an AMD APU's integrated GPU is not currently supported. An integr
 Previously, Nvidia would block the use of gaming/consumer video cards for passthrough (the Nvidia installer would throw an **Error 43** when installing the driver inside your VM). They lifted this restriction in 2021 with driver R465 and above, so be sure to use the latest driver. [Details from Nvidia here.](https://nvidia.custhelp.com/app/answers/detail/a_id/5173/)
 :::
 
-## 🖥️ vGPU {#vgpu}
+## :desktop_computer: vGPU {#vgpu}
 
 ### NVIDIA vGPU
 
@@ -246,7 +246,7 @@ Start the VM and log into the guest OS and load the appropriate guest driver fro
 > Known working cards:
 * S7150x2
 
-## 🖱️ USB Passthrough {#usb-passthrough}
+## :computer_mouse: USB Passthrough {#usb-passthrough}
 
 :::tip
 There's no need to alter any files manually as some older guides suggest
@@ -329,7 +329,7 @@ Then run
 xe pusb-scan host-uuid=<host_uuid>
 `}</Terminal>
 
-## 📦 Nested Virtualization {#nested-virtualization}
+## :package: Nested Virtualization {#nested-virtualization}
 
 Nested virtualization is the ability to run a hypervisor within another hypervisor. For example, running XCP-ng inside a VM that itself runs on XCP-ng.
 
@@ -345,13 +345,13 @@ XCP-ng allows to enable this partial nested virtualization support. It can be us
 
 We understand the use cases that necessitate nested virtualization and are committed to making this feature available in a supported form in the future. Until it is implemented, there is unfortunately no supported way to enable it.
 
-## 🌡 CPU Temperature on Intel {#cpu-temperature-on-intel}
+## :thermometer: CPU Temperature on Intel {#cpu-temperature-on-intel}
 
 As coretemp is not supported in XCP-ng, you can't rely on `sensors` to get the CPU temperatures on Intel platforms.
 
 Starting with XCP-ng 8.3 (`xen-4.17.6-9.3.xcpng8.3`), the `xenpm get-core-temp` command was introduced as an alternative.
 
-## 🐼 Advanced Xen {#advanced-xen}
+## :panda_face: Advanced Xen {#advanced-xen}
 
 This section is dedicated to advanced Xen use cases. Use it with caution!
 

--- a/docs/guides/TLS-certificates-xcpng.md
+++ b/docs/guides/TLS-certificates-xcpng.md
@@ -8,7 +8,7 @@ If you would like to replace this certificate by a valid one, either from an int
 
 Note that if you use an non-public certificate authority and XenOrchestra, you have [additional configuration to specify on Xen Orchestra side](https://xen-orchestra.com/docs/configuration.html#custom-certificate-authority).
 
-## 📝 Generate certificate signing request {#generate-certificate-signing-request}
+## :memo: Generate certificate signing request {#generate-certificate-signing-request}
 
 You can use the auto-generated key to create a certificate signing request:
 
@@ -16,7 +16,7 @@ You can use the auto-generated key to create a certificate signing request:
 openssl req -new -key /etc/xensource/xapi-ssl.pem -subj '/CN=XCP-ng hypervisor/' -out xcp-ng.csr
 `}</Terminal>
 
-## 🔗 Install the certificate chain (for XCP-ng v8.2+) {#install-the-certificate-chain-for-xcp-ng-v82}
+## :link: Install the certificate chain (for XCP-ng v8.2+) {#install-the-certificate-chain-for-xcp-ng-v82}
 
 Once you have your certificates, upload the certificates to your XCP-ng host, then use the following command to install the certificates:
 
@@ -31,7 +31,7 @@ The `certificate-chain` parameter is optional. The private key can be deleted af
 Done! Visit your XCP-ng host ip using a browser and validate the certificate is correct.
 
 
-## 🧓 Install the certificate chain (for XCP-ng up to v8.1) {#install-the-certificate-chain-for-xcp-ng-up-to-v81}
+## :older_adult: Install the certificate chain (for XCP-ng up to v8.1) {#install-the-certificate-chain-for-xcp-ng-up-to-v81}
 
 :::note
 This information about deprecated releases is retained solely to assist with the transition to a supported release.
@@ -45,7 +45,7 @@ Then, you have to restart xapi :
 systemctl restart xapi
 `}</Terminal>
 
-## 🛡️ Pool certificate verification (XCP-ng 8.3) {#pool-certificate-verification}
+## :shield: Pool certificate verification (XCP-ng 8.3) {#pool-certificate-verification}
 
 Since XCP-ng 8.3, hosts of a pool can verify each other's TLS certificates. New pools have it enabled; on upgraded pools, enable it once every member runs 8.3:
 

--- a/docs/guides/VLAN-trunking-vm.md
+++ b/docs/guides/VLAN-trunking-vm.md
@@ -26,7 +26,7 @@ For this scenario, we are assuming a configuration of 3 physical interfaces:
 - `eth1`: WAN side - ethernet
 - `eth2`: LAN side - VLAN trunk
 
-## 📏 MTU configuration {#mtu-configuration}
+## :straight_ruler: MTU configuration {#mtu-configuration}
 
 The [MTU](https://en.wikipedia.org/wiki/Maximum_transmission_unit) needs to be the same on all the switch's ports carrying 802.1Q packets.
 As the VLAN header adds 4-byte overhead, a standard 1500 ethernet MTU should be configured with MTU 1504.
@@ -110,7 +110,7 @@ or more simply, just reboot the host.
 
 ```
 
-## 🔌 VM interfaces {#vm-interfaces}
+## :electric_plug: VM interfaces {#vm-interfaces}
 
 Once the MTU is properly configured, create a new VM for OPNsense with several VIFs:
 - `VIF #0` - the management interface (MTU 1500)
@@ -121,7 +121,7 @@ The MTU isn't configurable here and the value is taken from the underlying netwo
 If the MTU isn't 1504 for your trunk network,
 please go back and review the configuration.
 
-## 🛡️ OPNsense installation {#opnsense-installation}
+## :shield: OPNsense installation {#opnsense-installation}
 
 Once you've booted OPNsense, start the manual interface assignment and configure VLANs.
 

--- a/docs/guides/amd-performance-improvements.md
+++ b/docs/guides/amd-performance-improvements.md
@@ -2,7 +2,7 @@
 
 This page details performance improvements on AMD processors and how to deploy the fixes on your pool.
 
-## 📖 What's the "AMD EPYC performance" story? {#whats-the-amd-epyc-performance-story}
+## :open_book: What's the "AMD EPYC performance" story? {#whats-the-amd-epyc-performance-story}
 
 This issue was first identified on EPYC processors in 2024, which is why it was first called the "AMD EPYC performance issue". However, it affects all AMD processors, not just the EPYC product line.
 
@@ -11,7 +11,7 @@ Network traffic is efficient for many workloads, but not the most demanding ones
 
 As with most performance issues, this case is complicated. The issue can stem from multiple causes, but at least one bottleneck has been eliminated.
 
-## 🩹 Fix 1 (significant): uncached grant-tables {#fix-1-significant-uncached-grant-tables}
+## :adhesive_bandage: Fix 1 (significant): uncached grant-tables {#fix-1-significant-uncached-grant-tables}
 
 ### Technical description of the issue and its fix
 
@@ -105,7 +105,7 @@ Guest kernel version determines whether the performance fix is supported or not.
 * _SOON_: Distro needs to update its kernel
 
 
-## ⚡ Fix 2: spurious interrupts {#fix-2-spurious-interrupts}
+## :zap: Fix 2: spurious interrupts {#fix-2-spurious-interrupts}
 
 ### Technical description of the issue and its fix
 
@@ -138,7 +138,7 @@ Here are the LTS kernels that have been fixed:
 * v6.15.11
 * v6.16.2
 
-## 🔮 Future improvements and leads {#future-improvements-and-leads}
+## :crystal_ball: Future improvements and leads {#future-improvements-and-leads}
 
 The last improvement does not work on every platform, so the story may not be over yet. At least one bottleneck remains.
 

--- a/docs/guides/autostart-vm.md
+++ b/docs/guides/autostart-vm.md
@@ -4,14 +4,14 @@ How to start VM on host boot?
 
 A VM can be started at XCP-ng boot itself, it's called **Auto power on**. We have two ways to configure it: using Xen Orchestra or via the CLI.
 
-## 🛰️ With Xen Orchestra {#with-xen-orchestra}
+## :artificial_satellite: With Xen Orchestra {#with-xen-orchestra}
 
 In Xen Orchestra we can just enable a toggle in VM "Advanced" view, called **Auto power on**. Everything will be set accordingly.
 
 ![XO's VM advanced tab showing the Auto power on option.](../../assets/img/autopoweron1.png)
 
 
-## 🧑‍💻 With the CLI {#with-the-cli}
+## :technologist: With the CLI {#with-the-cli}
 
 1. Determine the UUID of the pool for which we want to enable Auto Start. To do this, run the console command on the server:
 

--- a/docs/guides/create-use-custom-xcpng-ubuntu-templates.md
+++ b/docs/guides/create-use-custom-xcpng-ubuntu-templates.md
@@ -17,7 +17,7 @@ This post explains in detail the steps to create templates based on Ubuntu. The 
 
 All experiments will be conducted using the graphical virtual machine manager [Xen Orchestra](https://xen-orchestra.com), except for the last part where we will use XO-CLI (Xen Orchestra CLI) to bypass the graphical interface.
 
-## ℹ️ Prerequisites {#prerequisites}
+## :information_source: Prerequisites {#prerequisites}
 
 * [XCP-NG](https://xcp-ng.org/)
 * [Xen Orchestra](https://xen-orchestra.com) from the sources or Xen Orchestra virtual Appliance (XOA)
@@ -25,7 +25,7 @@ All experiments will be conducted using the graphical virtual machine manager [X
 * [JQ](https://jqlang.github.io/jq/) (for the last part of this post)
 * Ubuntu 22.04.04 Server LTS under ISO and OVA formats
 
-## 🏗️ Create a new Virtual Machine {#create-a-new-virtual-machine}
+## :building_construction: Create a new Virtual Machine {#create-a-new-virtual-machine}
 
 Two approaches for creating a virtual machine will be presented in this post:
 
@@ -225,7 +225,7 @@ The creation of the virtual image *custom-ubuntu22.04* from an ISO file is compl
 * If a problem occurs when creating or using your template, go to `/var/log` and look for `cloud-init.log` to troubleshoot the issue.
 :::
 
-## 📸 Template creation {#template-creation}
+## :camera_flash: Template creation {#template-creation}
 
 The template creation step involves converting an existing virtual machine into the format used for templates. This step is irreversible in the sense that the virtual machine will no longer appear in the list of virtual machines in [Xen Orchestra](https://xen-orchestra.com).
 
@@ -235,7 +235,7 @@ The template creation step involves converting an existing virtual machine into 
 
 The template has been created and added to the list of existing templates. The created template is named after the virtual machine *custom-ubuntu22.04*.
 
-## 🚀 Using the template {#using-the-template}
+## :rocket: Using the template {#using-the-template}
 
 Using the previously created template will allow you to rely on an existing virtual machine on which it will be possible to add configurations supported by Cloud-init. The [documentation](https://cloudinit.readthedocs.io/en/latest/index.html) for [Cloud-init](https://cloud-init.io/) regarding configurations is not user friendly. This [GitHub repository](https://github.com/number5/cloud-init/tree/main/doc/examples) associated with the official documentation makes it easier to understand the complexity of [Cloud-init](https://cloud-init.io/).
 
@@ -356,7 +356,7 @@ ssh_authorized_keys:
 
 Note that it is possible to use a programming language to call the JSON-RPC API over WebSocket. This [post](https://mickael-baron.fr/blog/2021/05/28/xo-server-websocket-jsonrcp) provides more details on how to use either Python or Java.
 
-## 🏁 Conclusion {#conclusion}
+## :checkered_flag: Conclusion {#conclusion}
 
 This post has detailed the creation of templates based on the Ubuntu distribution. These described steps can also be applied to other Linux distributions, such as Debian. Regarding the creation of Linux virtual machines from a template using [Cloud-init](https://cloud-init.io/), there are still many configurations to explore. The [Cloud-init](https://cloud-init.io/) documentation, despite its complexity, allows you to express all the constraints to initialize virtual machines tailored to your needs.
 

--- a/docs/guides/dom0-memory.md
+++ b/docs/guides/dom0-memory.md
@@ -12,7 +12,7 @@ In any case:
 * monitor RAM usage in the control domain
 * if issues arise (failed live migration for example), [look at the logs](../../troubleshooting/log-files) for messages related to lack of memory
 
-## 📏 Recommended values {#recommended-values}
+## :straight_ruler: Recommended values {#recommended-values}
 
 * we advise to give at least 2GiB of RAM for Dom0. Below that your XCP-ng may experience performance issues or other weird errors.
 * up to 64GiB RAM on your machine, at least 4GiB RAM for Dom0
@@ -22,11 +22,11 @@ In any case:
 Note: If you use ZFS, assign at least 16GB RAM to avoid swapping. ZFS (in standard configuration) uses half the Dom0 RAM as cache!
 :::
 
-## 📊 Current RAM usage {#current-ram-usage}
+## :bar_chart: Current RAM usage {#current-ram-usage}
 
 You can use `htop` to see how much RAM is currently used in the dom0. Alternatively, you can have Netdata to show you past values.
 
-## 🔧 Change dom0 memory {#change-dom0-memory}
+## :wrench: Change dom0 memory {#change-dom0-memory}
 
 Example with 4 GiB:
 

--- a/docs/guides/guest-UEFI-Secure-Boot.md
+++ b/docs/guides/guest-UEFI-Secure-Boot.md
@@ -4,7 +4,7 @@ How to configure UEFI Secure boot?
 
 Enabling UEFI Secure Boot for guests ensures that XCP-ng VMs will only execute trusted binaries at boot. In practice, these are the binaries released by the operating system (OS) vendor for the OS running in the VM (Microsoft Windows, Debian, RHEL, Alpine, etc.).
 
-## 🆕 Recent changes in guest Secure Boot configuration {#recent-changes-in-guest-secure-boot-configuration}
+## :new: Recent changes in guest Secure Boot configuration {#recent-changes-in-guest-secure-boot-configuration}
 
 The default guest Secure Boot keys in XCP-ng are changing.
 
@@ -44,7 +44,7 @@ This step is also required for Secure Boot support on previously V2V-migrated VM
 **Risk of data loss:** Propagating certificates to an existing VM will change its Secure Boot vTPM measurements. If you depend on these measurements (e.g. BitLocker with TPM protector), you must carefully read the [Preparing for Secure Boot Variable Changes](#preparing-for-secure-boot-variable-changes) procedure.
 :::
 
-## ℹ️ Requirements {#requirements}
+## :information_source: Requirements {#requirements}
 
 * XCP-ng >= 8.2.1.
 * UEFI Secure Boot Certificates installed on the pool (this is detailed below).
@@ -52,13 +52,13 @@ This step is also required for Secure Boot support on previously V2V-migrated VM
 
 Note: it's not necessary that the XCP-ng host boots in UEFI mode for Secure Boot to be enabled on VMs.
 
-## 🆙 8.3 with varstored >= 1.2.0-3.4 {#83-with-varstored--120-34}
+## :up: 8.3 with varstored >= 1.2.0-3.4 {#83-with-varstored--120-34}
 
 Secure Boot is ready to use on new VMs without extra configuration. Simply activate Secure Boot on your VMs, and they will be provided with an appropriate set of default Secure Boot variables.
 
 We will keep updating the default Secure Boot variables with future updates from Microsoft. If you don't want this behavior, you can lock in these variables by using the [Manually Install the Default UEFI Certificates](#manually-install-the-default-uefi-certificates) procedure.
 
-## 🧓 8.2.1 and 8.3 with varstored < 1.2.0-3.4 {#821-and-83-with-varstored--120-34}
+## :older_adult: 8.2.1 and 8.3 with varstored < 1.2.0-3.4 {#821-and-83-with-varstored--120-34}
 
 These versions of XCP-ng require manual configuration to enable Secure Boot.
 
@@ -89,7 +89,7 @@ Starting with XCP-ng 8.3, Xen Orchestra was made to help you in the setup of Sec
 More about this in [Troubleshoot Guest Secure Boot Issues](#troubleshoot-guest-secure-boot-issues)
 :::
 
-## 🎓 How XCP-ng Manages the Certificates {#how-xcp-ng-manages-the-certificates}
+## :mortar_board: How XCP-ng Manages the Certificates {#how-xcp-ng-manages-the-certificates}
 
 Let's embark on our journey towards understanding how all this works.
 
@@ -125,7 +125,7 @@ At the VM level:
 * The VM's Operating System may update some of the VM's certificates by itself (Windows updates the revocation list, `dbx`, when needed).
 * We provide administrators with tools to [manage a VM's UEFI certificates](#certificate-management) if needed.
 
-## 🎱 Configure the Pool {#configure-the-pool}
+## :8ball: Configure the Pool {#configure-the-pool}
 
 For pools with varstored version >= 1.2.0-3.4, no action is required.
 
@@ -261,7 +261,7 @@ secureboot-certs clear
 
 Existing VMs will not be affected.
 
-## ✅ Enable Secure Boot for a Guest VM {#enable-secure-boot-for-a-guest-vm}
+## :white_check_mark: Enable Secure Boot for a Guest VM {#enable-secure-boot-for-a-guest-vm}
 
 ### Enable Secure Boot at VM creation
 
@@ -331,7 +331,7 @@ Consequences:
 Also see [VMs that won't boot due to a revoked certificate](#vms-that-wont-boot-due-to-a-revoked-certificate).
 :::
 
-## 🚫 Disable Secure Boot for a Guest VM {#disable-secure-boot-for-a-guest-vm}
+## :no_entry_sign: Disable Secure Boot for a Guest VM {#disable-secure-boot-for-a-guest-vm}
 
 ### Disable Secure Boot for a Guest VM using XO
 
@@ -348,7 +348,7 @@ xe vm-param-set uuid=<vm-uuid> platform:secureboot=false
 
 Reboot the VM and Secure Boot will be disabled.
 
-## 🧑‍⚕️ Troubleshoot Guest Secure Boot Issues {#troubleshoot-guest-secure-boot-issues}
+## :health_worker: Troubleshoot Guest Secure Boot Issues {#troubleshoot-guest-secure-boot-issues}
 You may encounter the following issues with your VMs when enabling Secure Boot:
 * The VM won't boot.
 * The VM does boot, but SecureBoot is actually disabled.
@@ -361,11 +361,11 @@ Starting with XCP-ng 8.3, you can get a "secureboot readiness" status of a VM: f
 | first_boot | SecureBoot enforced, pending first boot | Normal transient state. Secure Boot was enabled by the user but the VM hasn't booted yet so its certificates are still empty. | Boot the VM at least once so that the pool's UEFI certificates are propagated to it. |
 | ready | SecureBoot enforced | From the hypervisor's point of view, all is ready for Secure Boot in the VM, and it's enforced. If the VM boots to a UEFI shell, this means that the boot binaries didn't pass the Secure Boot validation.| In case of boot failure, either the installed OS doesn't support Secure Boot, or its binaries were signed with a key which is not valid ([anymore?](#vms-that-wont-boot-due-to-a-revoked-certificate)) according to the UEFI certificates installed in the VM's UEFI variable store, or the installed certificates are wrong or inconsistent. |
 | ready_no_dbx | SecureBoot enforced, but no dbx present | The minimum certificates necessary to enforce Secure Boot are present, but the revocation list is missing. This is not a good idea. See [Secure Boot and revoked certificates](#secure-boot-and-revoked-certificates).| We advise to install the `dbx` revocation list. |
-| setup_mode | ⚠️ SecureBoot wanted, but disabled due to the VM being in UEFI setup mode | There is a mismatch between the user intent (enabling Secure Boot) and the state of the VM certificates (no PK, so the VM is in [Setup Mode](#uefi-setup-mode)). The VM boots, but Secure Boot is actually disabled! | [Check your pool was setup](#view-certificates-already-installed-on-the-pool) for Secure Boot, [set it up](#configure-the-pool) if needed, then [propagate the pool certificates to the VM](#propagate-pool-certificates-to-a-vm).|
-| certs_incomplete | ⚠️ SecureBoot wanted, but some EFI certificates are missing | Unbootable VM because Secure Boot can't be enforced, due to missing certificates. Only some certs are present. This will often mean that your VM was booted before your pool was setup for Secure Boot, so it only has the `PK` key, and is missing the rest of the necessary certificates. | [Check your pool was setup](#view-certificates-already-installed-on-the-pool) for Secure Boot, [set it up](#configure-the-pool) if needed, then [propagate the pool certificates to the VM](#propagate-pool-certificates-to-a-vm).|
+| setup_mode | :warning: SecureBoot wanted, but disabled due to the VM being in UEFI setup mode | There is a mismatch between the user intent (enabling Secure Boot) and the state of the VM certificates (no PK, so the VM is in [Setup Mode](#uefi-setup-mode)). The VM boots, but Secure Boot is actually disabled! | [Check your pool was setup](#view-certificates-already-installed-on-the-pool) for Secure Boot, [set it up](#configure-the-pool) if needed, then [propagate the pool certificates to the VM](#propagate-pool-certificates-to-a-vm).|
+| certs_incomplete | :warning: SecureBoot wanted, but some EFI certificates are missing | Unbootable VM because Secure Boot can't be enforced, due to missing certificates. Only some certs are present. This will often mean that your VM was booted before your pool was setup for Secure Boot, so it only has the `PK` key, and is missing the rest of the necessary certificates. | [Check your pool was setup](#view-certificates-already-installed-on-the-pool) for Secure Boot, [set it up](#configure-the-pool) if needed, then [propagate the pool certificates to the VM](#propagate-pool-certificates-to-a-vm).|
 
 
-## ⛔ Secure Boot and revoked certificates {#secure-boot-and-revoked-certificates}
+## :no_entry: Secure Boot and revoked certificates {#secure-boot-and-revoked-certificates}
 
 ### Revocation database updates
 
@@ -404,7 +404,7 @@ Despite this, we still recommend that you always install the latest revocation d
   * either disable Secure Boot for the VM, as its binaries are not secure anymore anyway. This can be temporary until an update brings properly signed binaries.
   * or [install](#change-the-certificates-already-installed-on-a-vm) an older `dbx` to the VM, [downloaded from the archive of prior versions of `dbx` files](https://uefi.org/revocationlistfile/archive). Let us stress again that this exposes the VM to risk, and therefore, we recommend that before choosing an archived `dbx` users evaluate the vulnerabilities that their guest system will be exposed to by omitting the most recent revocations. Above all, downgrading the `dbx` must not give you a dangerous false sense of security.
 
-## 🗂️ Certificate Management {#certificate-management}
+## :card_index_dividers: Certificate Management {#certificate-management}
 
 ### View Certificates Already Installed on the Pool
 
@@ -539,7 +539,7 @@ To update an individual certificate in the VM's NVRAM store:
    d719b2cb-3d3a-4596-a3bc-dad00e67656f dbx
    ```
 
-## ⛑️ Misc {#misc}
+## :rescue_worker_helmet: Misc {#misc}
 
 ### Secure Boot and the UEFI Firmware Menu in the Guest
 

--- a/docs/guides/host-reboot.md
+++ b/docs/guides/host-reboot.md
@@ -2,7 +2,7 @@
 
 How to properly handle host power cycle?
 
-## 🔄 General case {#general-case}
+## :arrows_counterclockwise: General case {#general-case}
 
 The proper way to reboot or shutdown a host is:
 
@@ -22,7 +22,7 @@ The proper way to reboot or shutdown a host is:
 Step 1 is especially important if [High Availability](../../management/ha) is enforced on your pool. You don't want the other hosts to believe that a host crashed or self-fenced - and take consecutive action - when it's actually planned maintenance. Alternatively, you can also disable HA on the pool for the duration of the maintenance operations to avoid issues caused by HA.
 :::
 
-## 🤸 With "agile" VMs {#with-agile-vms}
+## :cartwheeling: With "agile" VMs {#with-agile-vms}
 
 If all your VMs are "agile", that is, they're not tied to local storage or local devices (device pass-through), and if there are enough resources on other hosts in the pool, the above can be simplified as:
 

--- a/docs/guides/lacp-install-upgrade.md
+++ b/docs/guides/lacp-install-upgrade.md
@@ -1,6 +1,6 @@
 # Using LACP to Net Install or Upgrade XCP-ng
 
-## 📖 Foreword {#foreword}
+## :open_book: Foreword {#foreword}
 
 :::warning
 - This guide is specifically for environments using LACP-only networks, without LACP fallback. It assumes you do not want to reconfigure your switches.
@@ -13,7 +13,7 @@ Our installer does not support LACP. This guide explains how to bypass this limi
 When using LACP, your switch needs to be configured for it. If you cannot or prefer not to reconfigure your switch, you won’t be able to use the single-interface option provided by the installer.
 For other bonding methods (active-backup, balance-lsb), the switch does not need to be aware of the bond, and you can simply use one of the interfaces that will be part of the bond.
 
-## 🌐 When does the installer need network? {#when-does-the-installer-need-network}
+## :globe_with_meridians: When does the installer need network? {#when-does-the-installer-need-network}
 
 A working network configuration is only necessary in the following scenarios:
 
@@ -26,7 +26,7 @@ Network access is not required for:
 - A new installation from the full ISO.
 - Upgrading the master host from the full ISO.
 
-## 🪜 Installation or Upgrade steps {#installation-or-upgrade-steps}
+## :ladder: Installation or Upgrade steps {#installation-or-upgrade-steps}
 
 :::info
 During an upgrade, the installer will not detect your existing bond configuration. In XCP-ng, network settings are managed by XAPI and applied to Open vSwitch, but the installation process operates independently of these components.

--- a/docs/guides/logs.md
+++ b/docs/guides/logs.md
@@ -6,7 +6,7 @@ How to get further with XCP-ng logs?
 Any manual modification to the configuration files described below may prevent future XCP-ng updates to update the contents of those files. Avoid modifying them and ask for advice if you have a use case that appears to require such modifications.
 :::
 
-## ♻️ logrotate {#logrotate}
+## :recycle: logrotate {#logrotate}
 
 `logrotate` is the tool to administrate the rotation, compression, removal, ... of log files.
 The configuration is located in `/etc/logrotate.conf`; the `/etc/logrotate.d` directory is included by this file for additional rules (for example for specific packages after RPM installation like `xha`, `blktap`, `SMlog`...).
@@ -18,18 +18,18 @@ By default a file is rotated if:
 
 Also a file is compressed after two rotations, the first time it is just renamed.
 
-## 📡 rsyslog {#rsyslog}
+## :satellite: rsyslog {#rsyslog}
 
 Because a file must be rotated if a log exceeds 100 MiB, the `rsyslog` daemon is used to trigger automatically the `/etc/cron.daily/logrotate` script without waiting for the logrotate cron job to run. (Conf location: `/etc/rsyslog.d/xenserver.conf`)
 
-## 📜 Specific config: `xensource.log` {#specific-config-xensourcelog}
+## :scroll: Specific config: `xensource.log` {#specific-config-xensourcelog}
 
 `xensource.log` has many particular and different configuration parameters, so another `logrotate` config is used: `/etc/xensource/xapi-logrotate.conf` in a shell script `/opt/xensource/libexec/xapi-logrotate.sh` that executes `logrotate` with this specific config.
 
 There is normally no need to run it manually, a cron task `/etc/cron.d/xapi-logrotate.cron` is present to schedule it each hour.
 The goal of this special config is to keep the `xensource.log` files for one month, and to limit the number of log files to 100.
 
-## 📤 Remote syslog {#remote-syslog}
+## :outbox_tray: Remote syslog {#remote-syslog}
 
 Sending logs to a central syslog server keeps them available even when a host dies, and offloads the (very verbose) log writing from the host's disk:
 

--- a/docs/guides/pfsense.md
+++ b/docs/guides/pfsense.md
@@ -4,13 +4,13 @@ A guide to run pfSense in a VM.
 
 Despite pfSense and OPNsense do work great in a VM, there are a few extra steps that need to be taken first.
 
-## 🏗️ 1. Create VM as normal. {#1-create-vm-as-normal}
+## :building_construction: 1. Create VM as normal. {#1-create-vm-as-normal}
 
 * When creating the VM, choose the `other install media` VM template
 * Prefer `UEFI` boot mode for pfSense versions > 2.4 (`BIOS` mode works but will be slower to boot)
 * Continue through the installer like normal
 
-## 🛠️ 2. Install Guest Utilities {#2-install-guest-utilities}
+## :hammer_and_wrench: 2. Install Guest Utilities {#2-install-guest-utilities}
 
 There are 2 ways of doing that, either using the CLI (pfSense or OPNsense) or the Web UI (OPNsense).
 
@@ -33,7 +33,7 @@ Next: Reboot the system to have the guest tools started (installer doesn't do th
 
 Guest Tools are now installed and running, and will automatically run on every boot of the VM.
 
-## 🚫 3. Disable TX Checksum Offload {#3-disable-tx-checksum-offload}
+## :no_entry_sign: 3. Disable TX Checksum Offload {#3-disable-tx-checksum-offload}
 
 Now is the most important step: we must disable TX checksum offload on the virtual xen interfaces of the VM. This is because network traffic between VMs in a hypervisor is not populated with a typical Ethernet checksum, since they only traverse server memory and never leave over a physical cable. The majority of operating systems know to expect this when virtualized and handle Ethernet frames with empty checksums without issue. However `pf` in FreeBSD does not handle them correctly and will drop them, leading to broken performance.
 
@@ -47,14 +47,14 @@ Disabling checksum offloading is only necessary for virtual interfaces. When usi
 Many guides on the internet for pfSense in Xen VMs will tell you to uncheck checksum options in the pfSense web UI, or to also disable RX offload on the Xen side. These are not only unnecessary, but some of them will make performance worse.
 :::
 
-## 🛰️ Using Xen Orchestra {#using-xen-orchestra}
+## :artificial_satellite: Using Xen Orchestra {#using-xen-orchestra}
 
 - Head to the "Network" tab of your VM : in the advanced settings (click the blue gear icon) for each adapter, disable TX checksumming.
 - Restart the VM.
 
 That's it !
 
-## 🧑‍💻 Using CLI {#using-cli}
+## :technologist: Using CLI {#using-cli}
 
 SSH to dom0 on your XCP-NG hypervisor and run the following:
 

--- a/docs/guides/shrink_virtual_drive.md
+++ b/docs/guides/shrink_virtual_drive.md
@@ -2,7 +2,7 @@
 
 XCP-ng doesn't support VDI (Virtual Disk Image) shrinking, only growing. However, there are solutions to achieve the same result, albeit with some manual steps.
 
-## 🪟 Windows VMs {#windows-vms}
+## :window: Windows VMs {#windows-vms}
 
 There are two options to do this. The most reliable is the Clonezilla method, but the XenConvert route might also work.
 
@@ -58,6 +58,6 @@ When it's done:
 1. Detach the bigger disk (keep it as a backup in case something goes wrong).
 1. Boot the VM.
 
-## 🐧 Linux VMs {#linux-vms}
+## :penguin: Linux VMs {#linux-vms}
 
 You can use the same Clonezilla method. However, since "everything is a file" in Linux/BSDs, you can also use `rsync` to migrate the files from the original system to the new one.

--- a/docs/guides/software-RAID-SR.md
+++ b/docs/guides/software-RAID-SR.md
@@ -18,7 +18,7 @@ In addition, the example presented below is a fresh installation and not being i
 
 These instructions assume you are starting with a server already installed with software RAID and have no other storage repositories defined except what may be on the existing RAID.
 
-## 🖥️ Example System {#example-system}
+## :desktop_computer: Example System {#example-system}
 
 The example system we're demonstrating here is a small server using 5 identical 1TB hard drives. XCP-ng has already been installed in a software RAID configuration using 2 of the 5 drives. There is already a default "Local storage" repository configured as part of the XCP-ng setup on the existing RAID 1 drive pair.
 
@@ -55,7 +55,7 @@ unused devices: <none>
 
 The 5 drives are in place as `sda` through `sde` and as can be seen from the list are exactly the same size. The RAID 1 drive pair is set up as the XCP-ng default of a partitioned RAID 1 array `md127` using drives `sda` and `sdb` and is in a healthy state.
 
-## 🧱 Building the Second RAID {#building-the-second-raid}
+## :brick: Building the Second RAID {#building-the-second-raid}
 
 We have 3 remaining identical drives,  `sdc`, `sdd`, and `sde` and we're going to create a RAID 5 array using them in order to maximize the amount of space. We'll create this using the mdadm command like this:
 
@@ -103,7 +103,7 @@ unused devices: <none>
 
 Here we can see that the new RAID 5 array is in place as array `md0`, is using drives `sdc`, `sdd`, and `sde` and is healthy. As expected for a 3 drive RAID 5 array, it is providing about twice as much available space as a single drive.
 
-## 💽 Building the Storage Repository {#building-the-storage-repository}
+## :minidisc: Building the Storage Repository {#building-the-storage-repository}
 
 Now we create a new storage repository on the new RAID array like this:
 
@@ -118,7 +118,7 @@ At this point, we'd expect that the system could just be used as is, virtual mac
 
 Unfortunately, we'd be wrong.
 
-## 🫨 Unstable RAID Arrays When Booting {#unstable-raid-arrays-when-booting}
+## :shaking_face: Unstable RAID Arrays When Booting {#unstable-raid-arrays-when-booting}
 
 What really happens when XCP-ng boots with a software RAID is that code in the Linux kernel and in the initrd file will attempt to find and automatically assemble any RAID arrays in the system. When there is just the single `md127` RAID 1 array, the process works pretty well. Unfortunately, the system seems to occasionally break down where there are more drives, more arrays, and more complex arrays.
 
@@ -132,7 +132,7 @@ This can also happen to the `md127` boot array where it will show with only one 
 
 So what can we do about this?  Fortunately, we can give the system more information about what RAID arrays are in the system and specify that they should be started up at boot.
 
-## 📌 Stabilizing the RAID Boot Configuration: The mdadm.conf File {#stabilizing-the-raid-boot-configuration-the-mdadmconf-file}
+## :pushpin: Stabilizing the RAID Boot Configuration: The mdadm.conf File {#stabilizing-the-raid-boot-configuration-the-mdadmconf-file}
 
 The first thing we need to do is give the system more information on what RAID arrays exist and how they're put together. The way to do this is by creating a raid configuration file `/etc/mdadm.conf`.
 
@@ -172,7 +172,7 @@ So what do these lines do? The first line instructs the system to allow or attem
 
 This file gives the system a description of what arrays are configured in the system and what drives are used to create them but doesn't specify what to do with them. The system should be able to use this information at boot for automatic assembly of the arrays. Booting with the `mdadm.conf` file in place is more reliable but still runs into same problems as before.
 
-## 🧬 Stabilizing the RAID Boot Configuration: The initrd Configuration {#stabilizing-the-raid-boot-configuration-the-initrd-configuration}
+## :dna: Stabilizing the RAID Boot Configuration: The initrd Configuration {#stabilizing-the-raid-boot-configuration-the-initrd-configuration}
 
 The other thing we need to do is give the system some idea of what to do with the RAID arrays at boot time. The way to do this is by adding instructions for the `dracut` program creating the initrd file to enable all RAID support, use the `mdadm.conf` file we created, and to start the arrays at boot time.
 
@@ -207,7 +207,7 @@ The second set instructs the booting Linux kernel to support automatic RAID asse
 
 Something to note when creating the file is to allow extra space between command line parameters. That is why most of the lines have extra space before and after parameters within the quotes.
 
-## 🧪 Building and Testing the New initrd File {#building-and-testing-the-new-initrd-file}
+## :test_tube: Building and Testing the New initrd File {#building-and-testing-the-new-initrd-file}
 
 Now that we have all of this extra configuration, we need to get the system to include it for use at boot. To do that we use the `dracut` command to create a new initrd file like this:
 
@@ -235,7 +235,7 @@ unused devices: <none>
 
 We can see that both arrays are active and healthy with all drives accounted for. Examining the storage repositories using Xen Orchestra, XCP-ng, or `xe` commands shows that both the Local storage and RAID storage repositories are available.
 
-## 🧑‍⚕️ Troubleshooting {#troubleshooting}
+## :health_worker: Troubleshooting {#troubleshooting}
 
 The most common problems in this process stem from one of a few things.
 
@@ -279,7 +279,7 @@ Another possible but rare problem is caused by drives that shift their identific
 
 This type of problem is very difficult to diagnose and correct. It may be possible to resolve it using different BIOS or setup configurations in the host system or by updating BIOS or controller firmware.
 
-## ♻️ Updates and Upgrades {#updates-and-upgrades}
+## :recycle: Updates and Upgrades {#updates-and-upgrades}
 
 We will eventually need to update or patch the system to fix problems or close security holes as they are discovered.
 
@@ -339,7 +339,7 @@ After the rebuilding of the initrd file has finished, it should be safe to reboo
 
 In some cases it is also possible to perform [an upgrade using `yum`](../../installation/upgrade#from-command-line) instead of booting from CD. This type of upgrade does not completely replace the running system and does not create a backup copy. It is really a long series of updates instead of a full replacement. When upgrading a system using `yum`, the `mdadm.conf` and `dracut_mdraid.conf` files should remain in place just as with updates but copies of the files should be saved before the upgrade just in case.
 
-## 🎨 More and Different {#more-and-different}
+## :art: More and Different {#more-and-different}
 
 So what if we don't have or don't want a system that's identical to the example we just built in these instructions? Here are some of the possible and normal variations of software RAID under XCP-ng.
 

--- a/docs/guides/vm-encryption.md
+++ b/docs/guides/vm-encryption.md
@@ -11,7 +11,7 @@ This guide covers two common methods: encrypting data inside the VM and using en
 
 :::
 
-## 🔒 Encrypting inside the VM {#encrypting-inside-the-vm}
+## :lock: Encrypting inside the VM {#encrypting-inside-the-vm}
 
 The easiest and most flexible way to secure your VM's data is by enabling encryption directly within the operating system.
 
@@ -52,13 +52,13 @@ For Linux VMs, here are two popular tools:
     sudo mount /dev/mapper/encrypted_volume /mnt
     ```
 
-## 🗄️ Encrypting a shared storage repository {#encrypting-a-shared-storage-repository}
+## :file_cabinet: Encrypting a shared storage repository {#encrypting-a-shared-storage-repository}
 
 If you want to protect data across multiple hosts, consider using an encrypted storage repository (SR) for your VM disks. A popular option for this is TrueNAS, which can manage and encrypt SRs.
 
 For detailed instructions, refer to the TrueNAS guide on [storage encryption](https://www.truenas.com/docs/core/13.0/coretutorials/storage/pools/storageencryption/).
 
-## 🧠 Things to keep in mind {#things-to-keep-in-mind}
+## :brain: Things to keep in mind {#things-to-keep-in-mind}
 
 - **Encryption inside the VM** is the easiest and most flexible option. It works regardless of your storage setup and lets you choose the encryption method you prefer. However, this only protects data inside the VM. Your hypervisor and storage layer stay unencrypted.
 - **Encrypted storage repositories** secure data at the storage level, protecting all virtual disks in the SR. This is useful if you want to safeguard data across multiple VMs or hosts. Just be aware that it may affect performance and requires compatible storage hardware.

--- a/docs/guides/winpv-update.md
+++ b/docs/guides/winpv-update.md
@@ -14,7 +14,7 @@ To contextualize the update process, we will test it on a VM vulnerable to XSA-4
 
 ![A banner indicating that some of the VMs are vulnerable with a link to check them.](../assets/img/winpv-update/vuln1.png)
 
-## ⚙️ Setting up automatic installation {#setting-up-automatic-installation}
+## :gear: Setting up automatic installation {#setting-up-automatic-installation}
 
 Create a new GPO in your desired OU and edit it:
 
@@ -39,7 +39,7 @@ In **Select deployment method**, select **Assigned**. You can change this later.
 
 The targeted VMs will now pick up and install the driver package you selected.
 
-## 🔄 Setting up automatic reboot {#setting-up-automatic-reboot}
+## :arrows_counterclockwise: Setting up automatic reboot {#setting-up-automatic-reboot}
 
 The Windows PV drivers require multiple reboots to be installed or updated.
 In this section, we will set up the Autoreboot feature of Windows PV drivers.
@@ -69,7 +69,7 @@ Specify the following settings:
 
 Click **OK** to save the changes.
 
-## 👀 Observing the installation process {#observing-the-installation-process}
+## :eyes: Observing the installation process {#observing-the-installation-process}
 
 You'll need to reboot your VMs to apply the updates.
 After reboot, the VMs will pick up on your new GPO and install the linked driver package.
@@ -84,12 +84,12 @@ Once the update finishes, you should no longer see the vulnerability warning in 
 
 ![Hosts list showing no banner and no warning icon now that everything is installed.](../assets/img/winpv-update/vuln2.png)
 
-## 🔗 Useful links {#useful-links}
+## :link: Useful links {#useful-links}
 
 - If you want to remove existing Xen drivers, refer to the [XenClean guide](/vms/#fully-removing-xen-pv-drivers-with-xenclean).
 - Refer to the [XenBootFix guide](/troubleshooting/windows-pv-tools/#windows-fails-to-boot-hangs-inaccessible_boot_device) if you encounter VM boot issues after the update.
 
-## 🛡️ Appendix: Blocking vulnerable Xen drivers with Application Control for Windows {#appendix-blocking-vulnerable-xen-drivers-with-application-control-for-windows}
+## :shield: Appendix: Blocking vulnerable Xen drivers with Application Control for Windows {#appendix-blocking-vulnerable-xen-drivers-with-application-control-for-windows}
 
 :::warning
 **Risk of BSOD**: Incorrect application of App Control rules can prevent the system from booting.

--- a/docs/guides/xcpng-in-a-vm.md
+++ b/docs/guides/xcpng-in-a-vm.md
@@ -16,7 +16,7 @@ Here is the list of hypervisors on which you can try XCP-ng :
 * [QEMU/KVM](#nested-xcp-ng-using-qemukvm)
 * [Virtualbox](https://www.virtualbox.org) (Nested Virtualisation implemented only in v6.1.x and above - [https://www.virtualbox.org/ticket/4032](https://www.virtualbox.org/ticket/4032))
 
-## 📦 Nested XCP-ng using XCP-ng {#nested-xcp-ng-using-xcp-ng}
+## :package: Nested XCP-ng using XCP-ng {#nested-xcp-ng-using-xcp-ng}
 
 * create a new VM from CentOS 7 template with minimum 2 vCPU and 4GB RAM
 * change disk size to 100GB
@@ -24,7 +24,7 @@ Here is the list of hypervisors on which you can try XCP-ng :
 * default NIC type of Realtek may create stability issue for nested XCP-NG, change it to Intel e1000 : `xe vm-param-set uuid=<UUID> platform:nic_type="e1000"`
 * install/use it like normal :-)
 
-## 🐼 Nested XCP-ng using Xen {#nested-xcp-ng-using-xen}
+## :panda_face: Nested XCP-ng using Xen {#nested-xcp-ng-using-xen}
 
 It's a pretty standard HVM, but you need to use a `vif` of `ioemu` type. Check this configuration example:
 
@@ -58,7 +58,7 @@ on_reboot   = 'destroy'
 on_crash    = 'destroy'
 ```
 
-## 🇻 Nested XCP-ng using VMware (ESXi and Workstation) {#nested-xcp-ng-using-vmware-esxi-and-workstation}
+## :regional_indicator_v: Nested XCP-ng using VMware (ESXi and Workstation) {#nested-xcp-ng-using-vmware-esxi-and-workstation}
 
 _The following steps can be performed under VMware Workstation Pro, the settings will remain the same but the configuration will be slightly different. We will discuss this point at the end of this section about VMware._
 
@@ -122,7 +122,7 @@ Once your host's network is set up, we'll look at configuring the XCP-ng virtual
    * Check if the virtual machine correctly works by trying to connect using XCP-ng Center and by creating a virtual machine on your nested XCP-ng.
 
 
-## 🇭 Nested XCP-ng using Microsoft Hyper-V (Windows 10 - Windows Server 2016) {#nested-xcp-ng-using-microsoft-hyper-v-windows-10---windows-server-2016}
+## :regional_indicator_h: Nested XCP-ng using Microsoft Hyper-V (Windows 10 - Windows Server 2016) {#nested-xcp-ng-using-microsoft-hyper-v-windows-10---windows-server-2016}
 
 
 _The following steps can be performed with Hyper-V on Windows 10 (version 1607 minimum) and Windows Server 2016 (Hyper-V Server also). The settings will remain the same for both OS._
@@ -158,7 +158,7 @@ The VM settings :
 
 ![Windows Server on XCP-ng under Hyper-V](http://image.noelshack.com/fichiers/2018/39/5/1538145459-2.png)
 
-## 🇰 Nested XCP-ng using QEMU/KVM {#nested-xcp-ng-using-qemukvm}
+## :regional_indicator_k: Nested XCP-ng using QEMU/KVM {#nested-xcp-ng-using-qemukvm}
 
 _The following steps can be performed using QEMU/KVM on a Linux host, Proxmox or oVirt._
 

--- a/docs/installation/hardware.md
+++ b/docs/installation/hardware.md
@@ -14,13 +14,13 @@ A given device may be supported at one of two levels:
 1. Presence on the [Hardware Compatibility List](#hardware-compatibility-list-hcl) guarantees support by XCP-ng. With some exceptions described in the next section.
 2. Many devices outside the HCL are also supported, but are not tested routinely. See [Supported hardware outside the HCL](#supported-hardware-outside-the-hcl).
 
-## 📖 Hardware Compatibility List (HCL) {#hardware-compatibility-list-hcl}
+## :open_book: Hardware Compatibility List (HCL) {#hardware-compatibility-list-hcl}
 
 XCP-ng 8.3 shares a compatibility list with XenServer 8.4. Thus, devices listed on [XenServer's Hardware Compatibility List](http://hcl.xenserver.com/) are supported, with rare exceptions.
 
 Exceptions include devices which require *proprietary* software components to operate (closed source drivers, for example). Such devices do not impede the use of XCP-ng, but their features cannot be exploited.
 
-## ♻ Supported hardware outside the HCL {#supported-hardware-outside-the-hcl}
+## :recycle: Supported hardware outside the HCL {#supported-hardware-outside-the-hcl}
 
 Many devices outside the HCL actually work perfectly with XCP-ng. Contrarily to some hypervisors, XCP-ng does not demand the use of servers from a curated short list. Most of the hardware support depends on the Linux kernel drivers plus vendor drivers covering a very large range of devices.
 
@@ -30,7 +30,7 @@ Concretely, if your hardware is not on the HCL, there's still a very high chance
 
 Let's mention one particular kind of exceptions to support, though. **Security on older hardware having hardware vulnerabilities.** Older hardware, while usually still running very well - and we're all for using existing hardware while it lasts rather than buying new machines - may not receive hardware-related security updates from their very vendor. In particular those related to side-channel attacks (Spectre, Meltdown, and everything that ensued). In this case, you can use XCP-ng, but without expecting protection against this kind of vulnerablity, because it simply doesn't depend on XCP-ng (or any other hypervisor): it depends on the hardware vendor.
 
-## 🧰 Alternate drivers {#alternate-drivers}
+## :toolbox: Alternate drivers {#alternate-drivers}
 
 XCP-ng occasionally provides alternate drivers for users who have issues with the main drivers installed with XCP-ng.
 
@@ -84,14 +84,14 @@ A list is maintained at [https://github.com/xcp-ng/xcp/wiki/Drivers](https://git
 Check the "XCP-ng X.Y alternate driver" column, which provides packages names and versions for every available alternate driver.
 
 
-## 🎁 Additional kernel modules {#additional-kernel-modules}
+## :gift: Additional kernel modules {#additional-kernel-modules}
 
 Additional kernel modules are a lot like [alternate drivers](#alternate-drivers) (most of the above section applies to them) except that they don't replace an existing driver from the system. They add a new one that didn't exist at all.
 
 Their list is maintained at [https://github.com/xcp-ng/xcp/wiki/Drivers](https://github.com/xcp-ng/xcp/wiki/Drivers), in a table named "Other kernel modules available in XCP-ng X.Y".
 
 
-## 🚒 Alternate kernel {#alternate-kernel}
+## :fire_engine: Alternate kernel {#alternate-kernel}
 
 We provide an "alternate Linux kernel" on XCP-ng 8.0 and above, named `kernel-alt`. It is kernel 4.19, as the main kernel, but with all updates from the Linux 4.19 branch applied. By construction, it should thus be stable. However it **receives less testing** so we cannot fully guarantee against regressions (any detected regression we'd work on a fix quickly, of course). We also backport security fixes from the main kernel to the alternate kernel when needed.
 
@@ -131,7 +131,7 @@ yum remove kernel-alt
 
 This will remove the added grub entry automatically too and set default boot to main kernel if needed.
 
-## 🛠️ Tips related to specific hardware {#tips-related-to-specific-hardware}
+## :hammer_and_wrench: Tips related to specific hardware {#tips-related-to-specific-hardware}
 
 Below is a non-exhaustive list of server models or devices for which the XCP-ng community provided extra tips.
 

--- a/docs/installation/install-xcp-ng.md
+++ b/docs/installation/install-xcp-ng.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 How to install XCP-ng.
 
-## 💿 ISO installation {#iso-installation}
+## :cd: ISO installation {#iso-installation}
 
 If you want to use the netinstall ISO, see the [Netinstall section](#netinstall).
 
@@ -164,9 +164,9 @@ After a reboot, you should see the GRUB menu:
 
 ![XCP-ng GRUB menu, with entries for XCP-ng, a serial console, Safe Mode and 2 fallback options for console and serial using xen and linux fallback images.](https://xcp-ng.org/assets/img/screenshots/install23.png)
 
-It means the system is correctly installed! Enjoy XCP-ng 🚀
+It means the system is correctly installed! Enjoy XCP-ng :rocket:
 
-## 🌐 Netinstall {#netinstall}
+## :globe_with_meridians: Netinstall {#netinstall}
 
 The netinstall image is a lightweight ISO (around 150MiB) that will only contain the installer, but no actual RPM packages. Sometimes, it's more convenient/faster when your ISO is on a slow connection (e.g. a virtual media using a server IPMI).
 
@@ -180,7 +180,7 @@ dd if=xcp-ng-8.3.0-20250606-netinstall.iso of=/dev/sdX bs=8M oflag=direct
 
 Everything else is like the [regular install](#start-the-host), except that it will not offer to install from local media, only from distant ones.
 
-## 🎬 PXE boot install {#pxe-boot-install}
+## :clapper: PXE boot install {#pxe-boot-install}
 
 ### Requirements
 
@@ -278,7 +278,7 @@ When you do copy the installation files, **DO NOT FORGET** the `.treeinfo` file.
 3. Select boot from the Ethernet card
 4. You should see the PXE menu you created before!
 
-## ✨ iPXE over HTTP install {#ipxe-over-http-install}
+## :sparkles: iPXE over HTTP install {#ipxe-over-http-install}
 
 This guide is for UEFI boot, using iPXE over an HTTP server to serve files needed for installation.
 
@@ -338,7 +338,7 @@ configfile /EFI/xenserver/grub.cfg
 7. Continue with installation as normal.
 
 
-## 🤖 Automated install {#automated-install}
+## :robot: Automated install {#automated-install}
 <a name="-automatedinstall"></a>
 XCP-ng's installation can be automated by using network boot (PXE) or a custom installation image.
 
@@ -534,7 +534,7 @@ echo 0 > /proc/sys/dev/raid/speed_limit_min
 
 Upon server reboot, normal `md` resync will take place.
 
-## 🧭 Boot from SAN {#boot-from-san}
+## :compass: Boot from SAN {#boot-from-san}
 
 Instead of local disks, a host can be installed on (and boot from) a SAN LUN. Facts verified against the XCP-ng installer:
 
@@ -550,7 +550,7 @@ device_mapper_multipath=enabled use_ibft
 
 The same applies to [automated installs](#automated-install): these are installer *boot* parameters, they go on the kernel command line, not in the answer file.
 
-## 🎛️ Advanced installation options (installer command-line parameters) {#advanced-installation-options-installer-command-line-parameters}
+## :control_knobs: Advanced installation options (installer command-line parameters) {#advanced-installation-options-installer-command-line-parameters}
 
 The XCP-ng installer can be further parameterized to support advanced installation environments. The command line options are passed as parameters to the ```vmlinuz``` kernel of the installer.
 
@@ -661,11 +661,11 @@ Read the scriptlocation execute it and use its standard output as an answerfile 
 
 See ```network_device=```.
 
-## 🧑‍⚕️ Troubleshooting {#troubleshooting}
+## :health_worker: Troubleshooting {#troubleshooting}
 
 See [the Troubleshooting page](../../troubleshooting/after-upgrade).
 
-## ⛑️ Misc {#misc}
+## :rescue_worker_helmet: Misc {#misc}
 
 ### Installation on USB drives
 

--- a/docs/installation/migrate-to-xcp-ng.md
+++ b/docs/installation/migrate-to-xcp-ng.md
@@ -12,25 +12,25 @@ This documentation will help you to make a migration to XCP-ng, from any most co
 OVA import method will miss the information if the VM is running BIOS or UEFI mode. Double check your settings on your original system, and then enable (or not) UEFI on XCP-ng side for the destination VM. You can do so in VM advanced tab in Xen Orchestra.
 :::
 
-## 🇽 From XenServer {#from-xenserver}
+## :regional_indicator_x: From XenServer {#from-xenserver}
 
 We got a dedicated section on [how to migrate from XenServer to XCP-ng](../../installation/upgrade#upgrade-from-xenserver).
 
-## 🍋 From Citrix Hypervisor {#from-citrix-hypervisor}
+## :lemon: From Citrix Hypervisor {#from-citrix-hypervisor}
 
 We got a dedicated section on [how to migrate from Citrix Hypervisor to XCP-ng](../../installation/upgrade#upgrade-from-xenserver).
 
-## 🐼 From Xen on Linux {#from-xen-on-linux}
+## :panda_face: From Xen on Linux {#from-xen-on-linux}
 
 If you are running Xen on your usual distro (Debian, Ubuntu…), you are using `xl` to manage your VMs, and also plain text configuration files. You can migrate to an existing XCP-ng host thanks to [the `xen2xcp` script](https://github.com/xcp-ng/xen2xcp).
 
 Check [the README](https://github.com/xcp-ng/xen2xcp/blob/master/README.md) for usage instructions.
 
-## 📦 From Virtualbox {#from-virtualbox}
+## :package: From Virtualbox {#from-virtualbox}
 
 Export your VM in OVA format, and use Xen Orchestra to import it. If you have an issue on VM boot, check the [VMware](#from-vmware) section.
 
-## 🇻 From VMware {#from-vmware}
+## :regional_indicator_v: From VMware {#from-vmware}
 
 :::warning
 
@@ -337,7 +337,7 @@ qemu-img convert -f vmdk -O vpc myVMwaredisk.vmdk /run/sr-mount/<SR UUID>/\`uuid
 
 You need to rescan the SR where you new VHD file is, so it can be detected. It will appear in the disk list, without a name or description though. Attach it to any VM you created before (eg without booting it first), and boot.
 
-## 🇭 From Hyper-V {#from-hyper-v}
+## :regional_indicator_h: From Hyper-V {#from-hyper-v}
 
 There's two options, both requiring to export your Hyper-V VM disk in VHD format.
 
@@ -417,7 +417,7 @@ As soon you did scan the SR, the new disk is visible in the SR/disk view. Don't 
 If you lost ability to extend migrated volume (opening journal failed: -2) You need to move disk to another storage, VM should be ON during moving process. This issue can occur when vhd files was directly copied to storage folder.
 :::
 
-## 🇰 From KVM (Libvirt) {#from-kvm-libvirt}
+## :regional_indicator_k: From KVM (Libvirt) {#from-kvm-libvirt}
 
 Related forum thread: [https://xcp-ng.org/forum/topic/1465/migrating-from-kvm-to-xcp-ng](https://xcp-ng.org/forum/topic/1465/migrating-from-kvm-to-xcp-ng)
 
@@ -463,7 +463,7 @@ _Due the fact I have only server here, I have setup a "buffer" machine on my des
 
 ![The virtual UEFI boot manager showing the QEMU HARDDISK selected.](../../assets/img/migrate-to-xcp-ng_bootloader.png)
 
-* Select `UEFI QEMU HARDDISK`, the screen should be black for seconds and you should see the GRUB. Let the machine worked for minutes and you should see the prompt finally 👍
+* Select `UEFI QEMU HARDDISK`, the screen should be black for seconds and you should see the GRUB. Let the machine worked for minutes and you should see the prompt finally :+1:
 
 * Install Guest Tools and reboot. The reboot shouldn't take long, you don't have to redo step 13, the OS seems to have repair the boot sequence by itself.
 

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -12,7 +12,7 @@ An XCP-ng server is dedicated entirely to running XCP-ng and hosting VMs. It is 
 Installing third-party software directly in the XCP-ng control domain is not supported, except for software supplied in the official repositories. If you wish to add extra packages to XCP-ng, please [submit your request here](https://github.com/xcp-ng/xcp/issues/56).
 :::
 
-## 📋 XCP-ng System Requirements {#xcp-ng-system-requirements}
+## :clipboard: XCP-ng System Requirements {#xcp-ng-system-requirements}
 
 XCP-ng is generally deployed on server-class hardware, but it also supports many workstation and laptop models. For more information, refer to the [Hardware Compatibility List (HCL)](../../installation/hardware).
 
@@ -78,7 +78,7 @@ XCP-ng 8.2 is EOL. This 8.2-specific information is retained solely to assist wi
 Set the server's BIOS clock to the current UTC time. For debugging support cases, serial console access may be required: see [how to configure it](../troubleshooting/advanced.md#serial-console-access). For systems without physical serial ports, embedded management devices (Dell iDRAC, HP iLO...) provide Serial-over-LAN.
 :::
 
-## 📋 XCP-ng Configuration Limits {#xcp-ng-configuration-limits}
+## :clipboard: XCP-ng Configuration Limits {#xcp-ng-configuration-limits}
 
 XCP-ng supports the following per host:
 
@@ -120,7 +120,7 @@ The theoretical, untested limit is 2,048 logical processors.
 
 - Up to 800 VLANs.
 
-## 📋 Virtual Machine Configuration Limits {#virtual-machine-configuration-limits}
+## :clipboard: Virtual Machine Configuration Limits {#virtual-machine-configuration-limits}
 
 Below are the supported limits for virtual machines on XCP-ng.
 
@@ -193,7 +193,7 @@ XCP-ng 8.2 is EOL. This 8.2-specific information is retained solely to assist wi
 
 - **Passed-through USB devices**: Up to **6**.
 
-## 🎱 Pool Requirements {#pool-requirements}
+## :8ball: Pool Requirements {#pool-requirements}
 
 A resource pool is a collection of one or more servers (up to 64), which can be homogeneous or heterogeneous. Before creating or joining a pool, ensure the following:
 
@@ -227,7 +227,7 @@ Technologies such as Intel FlexMigration or AMD Extended Migration allow you to 
 
 For detailed information, see [Hosts and pools operations](../management/hosts-pools.md).
 
-## 🔌 Network ports and connectivity {#network-ports-and-connectivity}
+## :electric_plug: Network ports and connectivity {#network-ports-and-connectivity}
 
 What needs to be reachable, if you have firewalls between your management network, your hosts and your storage.
 

--- a/docs/installation/upgrade.md
+++ b/docs/installation/upgrade.md
@@ -14,14 +14,14 @@ For updates that don't change the version numbers (bugfixes, security fixes), se
 There are 3 upgrade methods, detailed below:
 * [Using the installation ISO (recommended)](#upgrade-via-installation-iso-recommended).
 * [Using the installation ISO when you can't boot from it: remote upgrade](#using-the-installation-iso-when-you-cant-boot-from-it-remote-upgrade).
-* [From command line a.k.a. yum-style upgrade](#from-command-line). ⚠️ Only for some point version upgrades.
+* [From command line a.k.a. yum-style upgrade](#from-command-line). :warning: Only for some point version upgrades.
 :::
 
 :::warning
 For upgrading XCP-ng machines with an XOSTOR SR, please refer to this [additional information](../../xostor#upgrade) before taking any action.
 :::
 
-## ☢️ Release Notes & Known Issues {#release-notes--known-issues}
+## :radioactive: Release Notes & Known Issues {#release-notes--known-issues}
 
 Read the [Release Notes and Known Issues](../../releases#xcp-ng-release-history) for every release that is higher than your current release. They may provide additional instructions for specific situations. Also **please read the following warnings**:
 
@@ -39,7 +39,7 @@ Read the [Release Notes and Known Issues](../../releases#xcp-ng-release-history)
 * When upgrading from *XCP-ng 7.5 or lower* or from *XenServer* or *Citrix Hypervisor*, **it is very important to make sure clustering is not enabled on your pool**. It's a functionality that relies on proprietary software and that is not available in XCP-ng, and having it enabled before the upgrade will lead to XAPI being unable to start due to unexpected data in the database. If it is enabled or you already upgraded, see [this comment](https://github.com/xcp-ng/xcp/issues/94#issuecomment-437838544).
 :::
 
-## 💿 Upgrade via installation ISO (recommended) {#upgrade-via-installation-iso-recommended}
+## :cd: Upgrade via installation ISO (recommended) {#upgrade-via-installation-iso-recommended}
 
 This is the standard XCP-ng way. With this method, note that you can often skip intermediate release (e.g. from 7.5 to 8.2 directly) without needing intermediate upgrade, but there are exceptions, so check the [release notes](../../releases#xcp-ng-release-history)! For example, we strongly advise to upgrade to XCP-ng 8.2.1 first before jumping to XCP-ng 8.3.
 
@@ -100,7 +100,7 @@ Note: it has been brought to our attention that [a DHCP server may be necessary 
 
 Once upgraded, **keep the system regularly updated** (see [Updates Howto](../../management/updates)).
 
-## 🧑‍💻 From command line {#from-command-line}
+## :technologist: From command line {#from-command-line}
 
 A.k.a. yum-style upgrade.
 
@@ -214,7 +214,7 @@ find /etc \( -name "*.rpmnew" -or -name "*.rpmsave" ! -name "logrotate.cron.rpms
 
 #### 4. Reboot the host
 
-## 🇽 Upgrade from XenServer {#upgrade-from-xenserver}
+## :regional_indicator_x: Upgrade from XenServer {#upgrade-from-xenserver}
 
 This article describes how to proceed in order to convert your Citrix XenServer infrastructure into a XCP-ng infrastructure.
 
@@ -348,7 +348,7 @@ The output should also be true. It has created a temporary entry in the grub boo
 
 To start the process, just tell the host to reboot. It is best to watch the progress by using KVM if it's available, but if not, it should proceed fine and boot into upgraded XCP-NG in 10 to 20 minutes.
 
-## 👴 Migrate VMs from older XenServer/XCP-ng {#migrate-vms-from-older-xenserverxcp-ng}
+## :older_man: Migrate VMs from older XenServer/XCP-ng {#migrate-vms-from-older-xenserverxcp-ng}
 
 ### Live migration
 
@@ -358,7 +358,7 @@ Live migration **should work** from any older XenServer/XCP-ng toward the latest
 
 If a live migration doesn't work, Xen Orchestra is able to do a warm migration for you. It's safer and still have a reasonable downtime. [Read this dedicated article](https://xen-orchestra.com/blog/warm-migration-with-xen-orchestra/) to learn more about it.
 
-## ☣ Handling alternate drivers or kernel {#handling-alternate-drivers-or-kernel}
+## :biohazard: Handling alternate drivers or kernel {#handling-alternate-drivers-or-kernel}
 
 If - before the upgrade - your host depends on [alternate drivers](../../installation/hardware#alternate-drivers) or on the [alternate kernel](../../installation/hardware#alternate-kernel) to function, then it is possible that the upgraded system doesn't need such alternatives anymore. It is also possible that it still needs them.
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -19,7 +19,7 @@ Visit the [main website](https://xcp-ng.org) to learn more. Latest updates are p
 Discover the growing network around XCP-ng and Xen Orchestra, collectively known as the [Vates Stack](https://vates.tech). Visit the [ecosystem page](https://docs.vates.tech/compatible-solutions/xcp-ng-ecosystem) at the Vates VMS documentation to explore our current partnerships and certification opportunities. Interested in joining? We’d love to [hear from you](https://vates.tech/contact)!
 :::
 
-## 🚀 Where to start {#where-to-start}
+## :rocket: Where to start {#where-to-start}
 
 <CardGrid>
 <LinkCard title="Install XCP-ng" href="/installation/install-xcp-ng/">Download the ISO and install your first host.</LinkCard>
@@ -32,7 +32,7 @@ Discover the growing network around XCP-ng and Xen Orchestra, collectively known
 <LinkCard title="Troubleshooting" href="/troubleshooting/">The 3-step guide, common problems, log files.</LinkCard>
 </CardGrid>
 
-## 🧭 Which documentation for what? {#which-documentation}
+## :compass: Which documentation for what? {#which-documentation}
 
 Three documentation sets work together. Knowing which one to open saves time:
 
@@ -44,7 +44,7 @@ Three documentation sets work together. Knowing which one to open saves time:
 
 As a rule of thumb: if it happens **on a host or pool**, it's documented here; if you do it **from Xen Orchestra**, it's in the XO docs; if it's about **the offer around the software** (trial, licenses, support, certified hardware), it's on the Vates docs.
 
-## ⚙️ General design {#general-design}
+## :gear: General design {#general-design}
 
 XCP-ng contains multiple components, built around the Xen Hypervisor. It's meant to run on top of bare-metal machines.
 
@@ -114,7 +114,7 @@ XCP-ng contains multiple components, built around the Xen Hypervisor. It's meant
 </svg>
 </Schema>
 
-## 📚 Stack overview {#stack-overview}
+## :books: Stack overview {#stack-overview}
 
 The main goal of XCP-ng is to be a fully integrated and dedicated virtualization platform, without requiring any deep Linux or system knowledge. It's meant to be managed in a centralized manner via [Xen Orchestra](management/#manage-at-scale), whether you have only one host or thousands of them. Backup is also included inside Xen Orchestra.
 
@@ -122,7 +122,7 @@ The main goal of XCP-ng is to be a fully integrated and dedicated virtualization
 ![Vates VMS stack overview.](../assets/img/vates-vms.png)
 </div>
 
-## 🎓 Concepts {#concepts}
+## :mortar_board: Concepts {#concepts}
 
 There are a few concepts to grasp in order to get a clear picture about what XCP-ng is.
 
@@ -152,7 +152,7 @@ Some clients are stateless (only running when you open or use them) and others a
 
 Xen Orchestra is a complete and agentless backup solution for your VMs running on XCP-ng. Please read the dedicated [backup section](management/backup) to get more details.
 
-## 📹 Community videos on XCP-ng {#community-videos-on-xcp-ng}
+## :video_camera: Community videos on XCP-ng {#community-videos-on-xcp-ng}
 
 :::note
 Those videos are made by 3rd parties. However, for example, Tom from Lawrence Systems is providing a lot of content on XCP-ng and Xen Orchestra. Check his [YouTube channel](https://www.youtube.com/channel/UCHkYOD-3fZbuGhwsADBd9ZQ).
@@ -170,7 +170,7 @@ A quick intro by Raid Owl:
 <iframe width="560" height="315" src="https://www.youtube.com/embed/kguTbVBqmuw?si=bWze86s07ZDkLzlU" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </div>
 
-## 🌍 Project and community {#project-and-community}
+## :earth_africa: Project and community {#project-and-community}
 
 XCP-ng is a community-driven Open Source project, backed by [Vates](https://vates.tech). Everything about the project itself (roadmap, contributing, development process, security handling) lives in the [project pages](/category/project).
 

--- a/docs/management/additional-packages.md
+++ b/docs/management/additional-packages.md
@@ -13,7 +13,7 @@ Best effort support is provided for additional packages provided by the XCP-ng p
 * [supported list for XCP-ng 8.3](http://reports.xcp-ng.org/8.3/extra_installable.txt)
 :::
 
-## 📜 Rules {#rules}
+## :scroll: Rules {#rules}
 
 ### 1. Never enable additional repositories
 
@@ -84,7 +84,7 @@ The `wpa_supplicant` package is provided for homelab and testing purposes only. 
 
 If you have [pro support](https://xcp-ng.com), ask there. As part of the support, additional supported packages - such as new drivers - may be provided. Else ask the community on the [forum](https://xcp-ng.org/forum/).
 
-## 🦮 How to install {#how-to-install}
+## :guide_dog: How to install {#how-to-install}
 
 Before doing any change, start keeping track somewhere of any change you bring to the system. This will help for:
 * support
@@ -140,13 +140,13 @@ EPEL 7 reached its end of life at the same time as CentOS 7, so installing addit
 
 And as usual make sure it won't overwrite existing packages...
 
-## 📦 Up to date additional packages {#up-to-date-additional-packages}
+## :package: Up to date additional packages {#up-to-date-additional-packages}
 
 If you installed from XCP-ng repositories, [they will be updated like the rest of the XCP-ng system](../../management/updates).
 
 If you installed from any other repository, including CentOS and EPEL, you need to update them (and their dependencies) manually
 
-## ♻️ System upgrade {#system-upgrade}
+## :recycle: System upgrade {#system-upgrade}
 
 See [upgrade section](../../installation/upgrade) for a discussion of the differences between "Installer upgrade" and "`yum`-style upgrade".
 
@@ -154,7 +154,7 @@ Installer upgrade will reinstall the system from scratch and just keep your conf
 
 An upgrade using `yum` directly will try to update or keep the packages that you installed. Packages installed from XCP-ng repositories should get updated seamlessly. Packages from other repositories will not get updated: they may be left in place (then you'll have to update them yourselves if needed), removed (due to package conflicts or because they are obsoleted by packages from the updated XCP-ng) or even make the upgrade fail until they are manually removed.
 
-## 📀 Supplemental packs {#supplemental-packs}
+## :dvd: Supplemental packs {#supplemental-packs}
 
 Supplemental packs are vendor-provided ISO images adding software or drivers to a host (management agents, GPU drivers...). They can be provided [at installation time](../installation/install-xcp-ng.md), or installed on a running host:
 

--- a/docs/management/backup.md
+++ b/docs/management/backup.md
@@ -2,7 +2,7 @@
 
 It's really important to backup your VMs. You have multiple options, but only Xen Orchestra is both **advanced, agentless, fully Open Source and officially supported** (tested for all XCP-ng releases).
 
-## 🛰️ Xen Orchestra {#xen-orchestra}
+## :artificial_satellite: Xen Orchestra {#xen-orchestra}
 
 Xen Orchestra is the most advanced backup solution and 100% integrated with XCP-ng. There is many different backup options:
 
@@ -35,7 +35,7 @@ All options are explained in the [official documentation](https://xen-orchestra.
 
 Alternatively, you can install and build it yourself [from the GitHub repository](https://github.com/vatesfr/xen-orchestra/).
 
-## 🛣️ 3rd party solutions {#3rd-party-solutions}
+## :motorway: 3rd party solutions {#3rd-party-solutions}
 
 There's 3rd party solutions officially compatible with XCP-ng to make VM backups. Please check our [ecosystem](https://docs.vates.tech/compatible-solutions/xcp-ng-ecosystem#vm-backup) page on the backup section.
 
@@ -45,7 +45,7 @@ Some popular backup solutions (like [VEEAM](https://www.veeam.com/)) can be used
 
 However, you'll lose the tight integration you have between XCP-ng and Xen Orchestra, both bundled of the [Vates Stack](https://vates.tech).
 
-## 🚑 Disaster recovery {#disaster-recovery}
+## :ambulance: Disaster recovery {#disaster-recovery}
 
 Disaster recovery (replicating VMs to a secondary site/pool and restarting them there when the primary is lost) is handled by Xen Orchestra: **Continuous Replication** keeps standby copies of your VMs on another pool's storage, ready to start; **Disaster Recovery** backup jobs do the same from backup files. See the [XO backup documentation](https://docs.xen-orchestra.com/xo5/backups) for the full picture (RPO, failover, failback).
 
@@ -57,7 +57,7 @@ What a DR plan needs on the XCP-ng side, whatever the tooling:
 * **A management plane that survives**: run Xen Orchestra (or be able to redeploy it from its config backup) outside the primary failure domain.
 * **Tests**: a failover you never exercised is a hypothesis, not a plan. XO can start replicated VMs on an isolated network for testing.
 
-## 🧰 Host and pool configuration backup {#host-and-pool-configuration-backup}
+## :toolbox: Host and pool configuration backup {#host-and-pool-configuration-backup}
 
 Besides VM data, the platform itself has state worth saving: the pool metadata (all your XAPI objects: VM configurations, SRs, networks...).
 

--- a/docs/management/cloud.md
+++ b/docs/management/cloud.md
@@ -7,7 +7,7 @@ You have multiple choices:
 1. Using Xen Orchestra Cloud features (ACLs, Self Service)
 2. Using CloudStack or OpenStack (adapted to very large deployments)
 
-## 🛰️ Xen Orchestra {#xen-orchestra}
+## :artificial_satellite: Xen Orchestra {#xen-orchestra}
 
 Some interesting "cloud-like" features are available in Xen Orchestra : ACLs and Self-service.
 
@@ -42,7 +42,7 @@ The self-service feature allows users to create new VMs within a **limited amoun
 ![XO dashboard of the available ressources to the devs group, with vCPUs, Memory and Storage, showing their usage and total available ressources.](../../static/img/xoself.png)
 </div>
 
-## ☁️ CloudStack {#cloudstack}
+## :cloud: CloudStack {#cloudstack}
 
 <div style={{textAlign: 'center'}}>
 ![The CloudStack logo.](../../static/img/cloudstack_logo.png)
@@ -54,7 +54,7 @@ Apache CloudStack is open source software designed to deploy and manage large ne
 
 See the [dedicated documentation](https://docs.cloudstack.apache.org/en/4.17.2.0/installguide/hypervisor/xenserver.html?highlight=xcp-ng) on how to install CloudStack on top of XCP-ng.
 
-## 📚 OpenStack {#openstack}
+## :books: OpenStack {#openstack}
 
 :::warning
 Unlike Cloudstack, we do not know the level of compatibility with OpenStack. Take time to ask OpenStack community about their support for XAPI-based hosts

--- a/docs/management/ha.md
+++ b/docs/management/ha.md
@@ -2,7 +2,7 @@
 
 In XCP-ng, high availability (or HA) is the ability to detect a failed host and automatically boot all the VMs that were running on this host to the other alive machines.
 
-## 📋 Introduction {#introduction}
+## :clipboard: Introduction {#introduction}
 
 Implementing VM High availability (HA) is a real challenge.
 
@@ -22,7 +22,7 @@ High availability requires **far more maintenance** and will create some traps i
 Before using it, **please think about it carefully**: do you **REALLY** need it? We've seen people having less uptime using HA than when not using it, because you **must understand** what you are doing every time you reboot or update a host.
 :::
 
-## 🎓 Concepts {#concepts}
+## :mortar_board: Concepts {#concepts}
 
 The pool concept allows hosts to exchange their data and status:
 
@@ -39,7 +39,7 @@ Here are the possible cases and how they are dealt with:
 * **Lost storage but not network**: if the host can contact a majority of pool members, it can stay alive. Indeed, in this scenario, there is no harm for the data (can't write to the VM disks). If the host is alone (i.e can't contact any other host or less than the majority), it goes for a reboot procedure.
 * **Lost network but not storage (worst case!)**: the host considers itself as problematic and starts a reboot procedure (hard power off and restart). This fencing procedure guarantees the sanity of your data.
 
-## ✅ Requirements {#requirements}
+## :white_check_mark: Requirements {#requirements}
 
 Enabling HA in XCP-ng requires thorough planning and validation of several prerequisites:
 
@@ -70,7 +70,7 @@ Use the `pif-plug` command in the CLI to activate VLAN and bond PIFs, ensuring t
 Additionally, the `xe diagnostic-vm-status` CLI command can help identify why a VM isn’t agile, allowing you to take corrective action as needed.
 
 
-## ⚙️ Configuration {#configuration}
+## :gear: Configuration {#configuration}
 
 ### Prepare the pool
 
@@ -175,7 +175,7 @@ The **default timeout is 60 seconds**, but you can adjust this value using the f
 xe pool-param-set uuid=<pool UUID> other-config:default_ha_timeout=<timeout in seconds>
 `}</Terminal>
 
-## 🔧 Updates/maintenance {#updatesmaintenance}
+## :wrench: Updates/maintenance {#updatesmaintenance}
 
 Before any update or host maintenance, planned reboot and so on, **ALWAYS** put your host in maintenance mode. If you don't do that, XAPI will think it's an unplanned failure, and will act accordingly.
 
@@ -186,7 +186,7 @@ If you have enough memory to put one host in maintenance (migrating all its VMs 
 - **Do NOT restart host toolstacks while high availability is enabled!** Attempting to restart the toolstack on an active host will cause the host to be immediately fenced and removed from the active liveset and pool. Always make sure that HA is disabled before restarting toolstacks.
 :::
 
-## ↔️ Behavior {#behavior}
+## :left_right_arrow: Behavior {#behavior}
 
 ### Halting the VM
 
@@ -260,7 +260,7 @@ Immediatly after fencing, **Minion 1** will be booted on the other host.
 
 Finally, the worst case: keep the storage operational, but "cut" the (management) network interface. Same procedure: unplug the cable physically and wait... Because **lab1** cannot contact any other host in the pool (in this case, **lab2**), it starts the fencing procedure. The result is exactly the same as the previous test. It's gone for the pool master, displayed as **Halted** until we re-plug the cable.
 
-## 🤓 Architecture {#architecture}
+## :nerd_face: Architecture {#architecture}
 
 ### General
 

--- a/docs/management/hosts-pools.md
+++ b/docs/management/hosts-pools.md
@@ -10,7 +10,7 @@ Day-to-day operations on your XCP-ng hosts and resource pools: creating a pool, 
 Almost everything on this page can be done in a few clicks from [Xen Orchestra](manage-at-scale/xo-web-ui.md), which is the recommended way to operate XCP-ng at scale. The `xe` commands are given so you can also work directly on a host, script operations, or troubleshoot when the orchestrator is not available.
 :::
 
-## 🎓 Concepts {#concepts}
+## :mortar_board: Concepts {#concepts}
 
 A **resource pool** is a group of up to 64 XCP-ng hosts managed as a single entity. One host is the **pool coordinator** (formerly called "pool master"): it exposes the XAPI endpoint for the whole pool, holds the pool database and forwards operations to the other members. All members keep a replicated copy of that database, which is why another host can take over the coordinator role if needed.
 
@@ -66,7 +66,7 @@ The requirements for pooling hosts (hardware, CPU vendor, versions…) are descr
 A standalone host is simply a pool of one: there's no special "pool creation" step. You create a pool by joining a second host to the first one.
 :::
 
-## 🏗️ Create a pool {#create-a-pool}
+## :building_construction: Create a pool {#create-a-pool}
 
 ### Name the pool
 
@@ -108,7 +108,7 @@ If the hosts differ in a way that blocks a regular join, you can force it, and t
 xe pool-join master-address=<coordinator> master-username=root master-password=<password> force=true
 `}</Terminal>
 
-## 🚪 Remove a host from a pool {#remove-a-host-from-a-pool}
+## :door: Remove a host from a pool {#remove-a-host-from-a-pool}
 
 From Xen Orchestra, use the host's **Detach** action. With `xe`:
 
@@ -128,7 +128,7 @@ xe host-forget uuid=<host-uuid>
 
 `host-forget` doesn't touch the (dead) host itself: if it ever comes back online, it will still believe it belongs to the pool, so reinstall it before reuse.
 
-## 👑 Change the pool coordinator {#change-the-pool-coordinator}
+## :crown: Change the pool coordinator {#change-the-pool-coordinator}
 
 ### Planned change
 
@@ -149,7 +149,7 @@ xe pool-recover-slaves
 
 The first command makes the local host the new coordinator; the second tells the remaining members to point at it. See also [HA troubleshooting](../troubleshooting/troubleshooting-ha.md) when high availability is involved.
 
-## 🔧 Maintenance mode {#maintenance-mode}
+## :wrench: Maintenance mode {#maintenance-mode}
 
 Before rebooting a host or working on its hardware, put it in maintenance mode: it stops accepting new VMs and evacuates the running ones (live migrating them to the other members).
 
@@ -174,7 +174,7 @@ xe host-enable uuid=<host-uuid>
 
 See also the dedicated guide about [rebooting or shutting down a host](../guides/host-reboot.md), and the [updates documentation](updates.md) for the recommended way to patch a whole pool (Rolling Pool Update in Xen Orchestra).
 
-## 🔑 Root password {#root-password}
+## :key: Root password {#root-password}
 
 The `root` password of the hosts is what XAPI clients (Xen Orchestra, XO Lite, `xe`…) use to authenticate. All members of a pool are meant to share the same root password (a joining host adopts the pool's credentials).
 
@@ -188,7 +188,7 @@ You can also use `xsconsole` (the text console you get on the host's physical/se
 
 Lost the root password? See the [reset procedure](../troubleshooting/common-problems.md#reset-xcp-ng-root-password) in the troubleshooting section.
 
-## ⏰ Time synchronization (NTP) {#time-synchronization-ntp}
+## :alarm_clock: Time synchronization (NTP) {#time-synchronization-ntp}
 
 Correct and consistent clocks across the pool matter more than on ordinary servers: XAPI coordination, live migration, HA heartbeats, logs correlation and Windows guests (which get their initial time from the host) all rely on it. NTP servers are normally configured at [installation time](../installation/install-xcp-ng.md).
 
@@ -201,7 +201,7 @@ chronyc sources
 
 On XCP-ng 8.2, the NTP daemon is `ntpd`: edit `/etc/ntp.conf`, then `systemctl restart ntpd` and check with `ntpq -p`. In both cases, `xsconsole` also offers an NTP configuration menu under **Network and Management Interface**.
 
-## 🔌 Remote host power-on {#remote-host-power-on}
+## :electric_plug: Remote host power-on {#remote-host-power-on}
 
 XCP-ng can power hosts back on remotely, using either Wake-on-LAN or the server's out-of-band controller. Configure the method per host:
 
@@ -217,7 +217,7 @@ xe host-power-on host=<host-uuid>
 
 This capability is also what allows [VM load balancing](vm-load-balancing.md) density plans to power hosts off and on according to the load.
 
-## 🤝 Pool-wide settings {#pool-wide-settings}
+## :handshake: Pool-wide settings {#pool-wide-settings}
 
 ### Rotate the pool secret
 
@@ -265,6 +265,6 @@ xe pool-param-set uuid=<pool-uuid> migration-compression=true
 
 The setting applies pool-wide to subsequent migrations; Xen Orchestra also exposes it in the pool's advanced settings.
 
-## 🩺 Pool database backup {#pool-database-backup}
+## :stethoscope: Pool database backup {#pool-database-backup}
 
 The pool database (all your XAPI objects: VMs, SRs, networks…) is replicated on every member, and can also be exported and restored: see the [backup page](backup.md) for pool metadata backup and restore procedures.

--- a/docs/management/infrastructure-as-code.md
+++ b/docs/management/infrastructure-as-code.md
@@ -9,14 +9,14 @@ You can use various 3rd party tools to manage your XCP-ng/XO stack "as code".
 | Terraform XO     | XO API   | Available      | [Link](https://registry.terraform.io/providers/vatesfr/xenorchestra/latest/docs)        |   |
 | Ansible XO       | XO API   | Available      | [Link](https://docs.ansible.com/ansible/latest/collections/community/general/xen_orchestra_inventory.html)
 
-## 📦 Packer {#packer}
+## :package: Packer {#packer}
 
 Packer is a free and open source tool for creating golden images for multiple platforms from a single source configuration. Combined with XCP-ng, you can create and regenerate templates for your own requirements or for your customers.
 
 Here is a tutorial to start with Packer and XCP-ng: https://xcp-ng.org/blog/2024/02/22/using-packer-with-xcp-ng/
 
 
-## 🌍 Terraform / OpenTofu {#terraform--opentofu}
+## :earth_africa: Terraform / OpenTofu {#terraform--opentofu}
 
 Terraform is an infrastructure as code software tool that enables you to safely and predictably create, change, and improve infrastructure. There's a series of blog posts to explain it in more details:
 
@@ -25,13 +25,13 @@ Terraform is an infrastructure as code software tool that enables you to safely 
 
 While Terraform used to be free and open-source, Hashicorp decided to relicense it. There is a free and open source fork called [OpenTofu](https://opentofu.org/) which can use Terraform's providers, though!
 
-## 🏷️ Ansible {#ansible}
+## :label: Ansible {#ansible}
 
 Ansible is a suite of software tools that enables infrastructure as code. It is open-source and the suite includes software provisioning, configuration management, and application deployment functionality
 
 https://xen-orchestra.com/blog/virtops3-ansible-with-xen-orchestra/
 
-## 🗃️ Netbox {#netbox}
+## :card_file_box: Netbox {#netbox}
 
 [NetBox](https://netbox.dev/) is the leading solution for modeling and documenting modern networks. By combining the traditional disciplines of IP address management (IPAM) and datacenter infrastructure management (DCIM) with powerful APIs and extensions, NetBox provides the ideal "source of truth" to power network automation. Available as open source software under the Apache 2.0 license, NetBox is employed by thousands of organizations around the world.
 

--- a/docs/management/manage-at-scale/xo-api.md
+++ b/docs/management/manage-at-scale/xo-api.md
@@ -8,7 +8,7 @@ There's two different APIs to manage XCP-ng at scale via Xen Orchestra:
 * a REST API, simple to use to read content
 * a JSON-RPC over websocket API, more complex but coming with all features
 
-## 📡 REST API {#rest-api}
+## :satellite: REST API {#rest-api}
 
 We developed XO original API to be used between the Web UI `xo-web` and the server backend, `xo-server`. That's why it's a JSON-RPC API connected via websockets, allowing us to update objects live in the browser. This is perfect for our usage, but a bit complicated for others.
 
@@ -265,7 +265,7 @@ $ curl \
 
 We are adding features and improving the REST API step by step. If you have interesting use cases or feedback, please ask directly at [the dedicated forum section](https://xcp-ng.org/forum/category/18/rest-api).
 
-## 🥋 JSON-RPC over websockets {#json-rpc-over-websockets}
+## :martial_arts_uniform: JSON-RPC over websockets {#json-rpc-over-websockets}
 
 This is the API used between Xen Orchestra web UI and the server part, `xo-server`. It's a bit harder to use than the REST API, but if you need a live subscription to events happening in your infrastructure, or to send advanced commands, this is the right one.
 

--- a/docs/management/manage-at-scale/xo-web-ui.md
+++ b/docs/management/manage-at-scale/xo-web-ui.md
@@ -35,7 +35,7 @@ Xen Orchestra is fully Open Source, and it comes in 2 "flavors":
 We advise to start using XOA by deploying it really easily in [few clicks on this page](https://vates.tech/deploy/). You can always decide later to build it yourself from GitHub.
 :::
 
-## 🚀 Deploy Xen Orchestra virtual Appliance {#deploy-xen-orchestra-virtual-appliance}
+## :rocket: Deploy Xen Orchestra virtual Appliance {#deploy-xen-orchestra-virtual-appliance}
 You can deploy Xen Orchestra from a web UI, using:
 * [Web deploy directly](https://vates.tech/deploy/) (fastest & recommended)
 * Using [XO Lite](../manage-locally/xo-lite.md)
@@ -54,7 +54,7 @@ From the CLI using a deploy script, by running this in your XCP-ng host:
 bash -c "$(wget -qO- https://xoa.io/deploy)"
 `}</Terminal>
 
-## 🪙 XOA vs XO from GitHub? {#xoa-vs-xo-from-github}
+## :coin: XOA vs XO from GitHub? {#xoa-vs-xo-from-github}
 
 XOA is meant to be used as the easiest way to test it, but also to use it in production: this is the version **professionally supported**, with an updater and a support tunnel mechanism.
 
@@ -64,7 +64,7 @@ If you are an individual, feel free to enjoy the version from [GitHub directly](
 XO from the sources doesn't have QA and there's no stable version. It's great for a home lab or to make tests, but not for production.
 :::
 
-## 🌐 Web UI {#web-ui}
+## :globe_with_meridians: Web UI {#web-ui}
 
 You have access to all XCP-ng possibilities (and more!) from a web UI:
 

--- a/docs/management/manage-locally/api.md
+++ b/docs/management/manage-locally/api.md
@@ -8,13 +8,13 @@ XAPI is requested by multiple **clients**, like Xen Orchestra or `xe` CLI. See [
 We strongly encourage to build applications on top of XO API and not XAPI. In fact, XAPI is made with very specific calls (close to the Xen logic), so it's a lot better to build a solution on top of a more global API, the one [provided by Xen Orchestra](https://xen-orchestra.com/docs/architecture.html#api). It will act as a central point for all your pools and you won't have to handle all the Xen specifics.
 :::
 
-## 📐 Architecture {#architecture}
+## :triangular_ruler: Architecture {#architecture}
 
 XAPI is using a database (Read/write on the master, replicated to slaves in read only). It's an XML file located at `/var/lib/xcp/state.db`. All the metadata and settings of your pool, hosts, VMs and so on are stored there.
 
 ![Diagram of the XAPI classes (too complex to describe here).](../../../static/img/xapiclasses.png)
 
-## 🧑‍⚕️ Troubleshooting {#troubleshooting}
+## :health_worker: Troubleshooting {#troubleshooting}
 
 ### Restarting the API
 

--- a/docs/management/manage-locally/cli.md
+++ b/docs/management/manage-locally/cli.md
@@ -6,7 +6,7 @@ The xe CLI can be used locally on any XCP-ng host, it's installed along with it.
 The complete set of all `xe` commands is available in the [Appendix section](../../../appendix/cli_reference).
 :::
 
-## ℹ️ Getting help with xe commands {#getting-help-with-xe-commands}
+## :information_source: Getting help with xe commands {#getting-help-with-xe-commands}
 
 Basic help is available for CLI commands on-host by typing the following:
 
@@ -36,7 +36,7 @@ Or a list of all xe commands is displayed if you type:
 xe help --all
 `}</Terminal>
 
-## 🪧 Basic xe syntax {#basic-xe-syntax}
+## :placard: Basic xe syntax {#basic-xe-syntax}
 
 The basic syntax of all XCP-ng xe CLI commands is:
 
@@ -96,7 +96,7 @@ After running this command, you no longer have to specify the remote XCP-ng serv
 
 Using the `XE_EXTRA_ARGS` environment variable also enables tab completion of xe commands when issued against a remote XCP-ng server, which is disabled by default.
 
-## 🀄 Special characters and syntax {#special-characters-and-syntax}
+## :mahjong: Special characters and syntax {#special-characters-and-syntax}
 
 To specify argument/value pairs on the xe command line, write: `argument=value`
 
@@ -110,7 +110,7 @@ When you use the CLI on your XCP-ng server, commands have a tab completion featu
 Tab completion does not normally work when executing commands on a remote XCP-ng server. However, if you set the `XE_EXTRA_ARGS` variable on the machine where you enter the commands, tab completion is enabled. For more information, see [Basic xe syntax](#basic-xe-syntax).
 :::
 
-## 🧮 Command types {#command-types}
+## :abacus: Command types {#command-types}
 
 The CLI commands can be split in two halves. Low-level commands are concerned with listing and parameter manipulation of API objects. Higher level commands are used to interact with VMs or hosts at a more abstract level.
 
@@ -172,7 +172,7 @@ Where class is one of:
 
 Not every value of class has the full set of class-param-action commands. Some values of class have a smaller set of commands.
 
-## 🧶 Parameter types {#parameter-types}
+## :yarn: Parameter types {#parameter-types}
 
 The objects that are addressed with the xe commands have sets of parameters that identify them and define their states.
 
@@ -205,7 +205,7 @@ xe vm-param-set uuid=VM-uuid other-config:foo=baa
 In previous releases, the hyphen character (-) was used to specify map parameters. This syntax still works but is deprecated.
 :::
 
-## 🔬 Low-level parameter commands {#low-level-parameter-commands}
+## :microscope: Low-level parameter commands {#low-level-parameter-commands}
 
 There are several commands for operating on parameters of objects: class-param-get, class-param-set, class-param-add, class-param-remove, class-param-clear, and class-param-list. Each of these commands takes a uuid parameter to specify the particular object. Since these commands are considered low-level commands, they must use the `UUID` and not the VM name label.
 
@@ -233,7 +233,7 @@ Removes either a key/value pair from a map, or a key from a set.
 
 Completely clears a set or a map.
 
-## 📜 Low-level list commands {#low-level-list-commands}
+## :scroll: Low-level list commands {#low-level-list-commands}
 
 The class-list command lists the objects of type class. By default, this type of command lists all objects, printing a subset of the parameters. This behavior can be modified in the following ways:
 
@@ -276,7 +276,7 @@ When scripting, a useful technique is passing `--minimal` on the command line, c
 a85d6717-7264-d00e-069b-3b1d19d56ad9,aaa3eec5-9499-bcf3-4c03-af10baea96b7, 42c044de-df69-4b30-89d9-2c199564581d
 ```
 
-## 🙊 Secrets {#secrets}
+## :speak_no_evil: Secrets {#secrets}
 
 XCP-ng provides a secrets mechanism to avoid passwords being stored in plaintext in command-line history or on API objects. XenCenter uses this feature automatically and it can also be used from the xe CLI for any command that requires a password.
 

--- a/docs/management/manage-locally/xo-lite.md
+++ b/docs/management/manage-locally/xo-lite.md
@@ -22,13 +22,13 @@ XO Lite uses a self-signed certificate. You need to accept the certificate (foll
 XO Lite is still a work in progress! However, it's meant to cover all basic actions you need to boostrap your infrastructure or just do basic operation on your VMs.
 :::
 
-## 🔐 Credentials {#credentials}
+## :closed_lock_with_key: Credentials {#credentials}
 
 XO Lite credentials are the same than the host (SSH credentials), usually `root` as user and the password chosen during the installation process.
 
 ![The XO Lite login page.](../../../static/img/xolitelogin.png)
 
-## 📊 Dashboard {#dashboard}
+## :bar_chart: Dashboard {#dashboard}
 
 Once logged, you can see the dashboard:
 
@@ -38,7 +38,7 @@ Once logged, you can see the dashboard:
 XO Lite isn't a multi-cluster orchestrator, it's just a local management console. If you want to orchestrate your VMs at scale (load balancing, backup, warm migration and so on), you MUST use [Xen Orchestra](../manage-at-scale/xo-web-ui.md)!
 :::
 
-## 🚫 Disabling XO Lite {#disabling-xo-lite}
+## :no_entry_sign: Disabling XO Lite {#disabling-xo-lite}
 
 First, let's emphasize that XO Lite is merely an XAPI client. While it is made readily available by the web server on XCP-ng, it actually runs entirely in your web browser. It does **not** increase the attack surface on XCP-ng servers. Additionally, in a properly configured XCP-ng deployment, the management interface resides on a dedicated network, accessible only to administrators.
 

--- a/docs/management/management.md
+++ b/docs/management/management.md
@@ -2,7 +2,7 @@
 
 You have multiple ways to manage your hosts and your pool: all of those are called **clients**.
 
-## 🔭 Local management {#local-management}
+## :telescope: Local management {#local-management}
 
 If you have one host or small pool (a cluster), you can use those following tools:
 
@@ -11,7 +11,7 @@ If you have one host or small pool (a cluster), you can use those following tool
 * [Xen API](manage-locally/api) (XAPI)
 * [*XCP-ng Center*](https://github.com/xcp-ng/xenadmin/) (Windows client, deprecated and **not supported** :warning:)
 
-## 🛰️ Manage at scale {#manage-at-scale}
+## :artificial_satellite: Manage at scale {#manage-at-scale}
 
 As soon you start to management multiple hosts and/or pools, you might need a single/central orchestrator. That's the point of Xen Orchestra, which can be used via a web UI, a CLI or its API:
 
@@ -24,7 +24,7 @@ As soon you start to management multiple hosts and/or pools, you might need a si
 Xen Orchestra is not just an XCP-ng orchestrator at scale: it's also a backup tool. See the [backup section](backup.md) for more details.
 :::
 
-## 🗺️ Common operations {#common-operations}
+## :world_map: Common operations {#common-operations}
 
 Whatever the client you use, the main operation guides are here:
 

--- a/docs/management/monitoring.md
+++ b/docs/management/monitoring.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 How to watch the health and performance of your hosts, VMs and storage, and get alerted before users notice a problem.
 
-## 🛰️ With Xen Orchestra {#with-xen-orchestra}
+## :artificial_satellite: With Xen Orchestra {#with-xen-orchestra}
 
 Xen Orchestra is the natural place to monitor a whole XCP-ng infrastructure:
 
@@ -17,7 +17,7 @@ Xen Orchestra is the natural place to monitor a whole XCP-ng infrastructure:
 
 See the [Xen Orchestra documentation](https://docs.xen-orchestra.com/) for the details of each feature.
 
-## 📊 Host-level metrics (RRDs) {#host-level-metrics-rrds}
+## :bar_chart: Host-level metrics (RRDs) {#host-level-metrics-rrds}
 
 Each host continuously records metrics (CPU, memory, network, storage, per-VM and per-host) in round-robin databases (RRDs), with several months of history at decreasing granularity. This is what powers the graphs in Xen Orchestra and XO Lite.
 
@@ -37,7 +37,7 @@ Individual data sources can be enabled or disabled (`xe host-data-source-record`
 
 The raw RRDs are also exposed over HTTP for external collectors: `https://<host>/rrd_updates?start=<unix-timestamp>&host=true` returns everything that changed since the given time, in XML. This endpoint is a simple way to feed XCP-ng metrics into your own tooling without installing anything in dom0.
 
-## 🖥️ Live view on the host {#live-view-on-the-host}
+## :desktop_computer: Live view on the host {#live-view-on-the-host}
 
 For an instant view directly on a host (SSH or console):
 
@@ -47,13 +47,13 @@ For an instant view directly on a host (SSH or console):
 
 High dom0 load, or dom0 running out of memory, degrades every VM on the host: see the [dom0 memory guide](../guides/dom0-memory.md).
 
-## 📡 Netdata {#netdata}
+## :satellite: Netdata {#netdata}
 
 For detailed real-time dashboards on a host, XCP-ng provides `netdata` packages, and Xen Orchestra Premium can install and integrate them in one click (host view, *Advanced* tab). Netdata gives you per-second metrics with a modern web UI, and can stream to a central Netdata parent if you have one.
 
 You can also install it manually as an [additional package](additional-packages.md), keeping in mind the general rule: dom0 is not a regular Linux box, keep extra software minimal.
 
-## 🔔 SNMP and external supervision {#snmp-and-external-supervision}
+## :bell: SNMP and external supervision {#snmp-and-external-supervision}
 
 If your organization has a central supervision system (Zabbix, Centreon, LibreNMS, Prometheus...), a few options:
 
@@ -74,7 +74,7 @@ systemctl enable --now snmpd
 Whatever you install, never let a monitoring agent modify dom0's configuration or update its packages: see the [additional packages rules](additional-packages.md#rules).
 :::
 
-## 🚨 What should I watch? {#what-should-i-watch}
+## :rotating_light: What should I watch? {#what-should-i-watch}
 
 A reasonable minimal set of alerts for an XCP-ng infrastructure:
 

--- a/docs/management/updates.md
+++ b/docs/management/updates.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 This page details how to keep your XCP-ng system updated (bug fixes and security fixes) between [upgrades](../../installation/upgrade).
 
-## ⚡ Quick start {#quick-start}
+## :zap: Quick start {#quick-start}
 
 If you want to manage your XCP-ng updates, we suggest that you use Xen Orchestra. It's the fastest & easiest way to keep your infrastructure up-to-date. See the [dedicated section](updates.md#from-xen-orchestra). If you want to learn more about Xen Orchestra, also check the [management section](management.md).
 
@@ -14,7 +14,7 @@ If you want to manage your XCP-ng updates, we suggest that you use Xen Orchestra
 Each update is covered by a dedicated blog post. Browse all update posts at https://xcp-ng.org/blog/tag/update/
 :::
 
-## ♻️ Support cycle {#support-cycle}
+## :recycle: Support cycle {#support-cycle}
 
 We maintain one or several releases in parallel:
 * LTS releases (currently `8.3`).
@@ -22,7 +22,7 @@ We maintain one or several releases in parallel:
 
 If your version is lower than `8.3`, it will not receive updates anymore. To keep benefiting from bugfixes and security fixes you need to [upgrade](../../installation/upgrade).
 
-## ℹ️ Prerequisites {#prerequisites}
+## :information_source: Prerequisites {#prerequisites}
 
 ### Access to the repository
 
@@ -63,7 +63,7 @@ In any case, installing extra packages from outside the XCP-ng repositories can 
 
 More at [Additional packages](../../management/additional-packages).
 
-## 💡 Get information about the updates {#get-information-about-the-updates}
+## :bulb: Get information about the updates {#get-information-about-the-updates}
 
 Every update is first tested and discussed on a forum thread dedicated to update candidates for a given XCP-ng release. We highly recommend to subscribe to these threads (activate e-mail notifications in your forum settings if you want to be notified of new messages). You will thus know about coming updates in advance and be able to help us validate them. No one would like updates to be delayed because of lack of feedback there.
 
@@ -89,7 +89,7 @@ XCP-ng 8.2 is EOL. This 8.2-specific information is retained solely to assist wi
 * [List of immediate **update candidates**](https://koji.xcp-ng.org/builds?inherited=0&tagID=89&order=-build_id&latest=1)
 * [List of **testing** packages prepared for a future update](https://koji.xcp-ng.org/builds?inherited=0&tagID=43&order=-build_id&latest=1)
 
-## 🚸 Precautions {#precautions}
+## :children_crossing: Precautions {#precautions}
 
 :::warning
 **Always update the pool master first. Other pool members must never run a higher version than the master.**
@@ -106,7 +106,7 @@ If you update any other host before the pool master, **it will lose the ability 
 *Some people systematically run `xe vm-cd-eject --multiple` to eject all virtual CDs/DVDs from the VMs before updating and/or migrating.*
 * Do not update from an interactive shell that was directly started from the XCP-ng console (`xsconsole`), nor from the host's remote console that is available through the VNC protocol in Xen Orchestra or XCP-ng Center. The update process may restart those, kill the current shell and thus kill the update process which would leave the system in an unclean state (duplicate RPMs).
 
-## 🦮 How to apply the updates {#how-to-apply-the-updates}
+## :guide_dog: How to apply the updates {#how-to-apply-the-updates}
 
 ### From command line
 
@@ -239,7 +239,7 @@ You can see hosts that will require a reboot via a small blue triangle:
 We do NOT recommend to install updates to individual hosts. Obviously except if they are alone in their own pool. Running hosts in the same pool with different level of updates should be avoided as possible. We leave that option in case you have a specific need, but again, we discourage that usage as possible. Note that even a host alone in its pool can be updated via the "Pool update" button!
 :::
 
-## 🏁 When to reboot? {#when-to-reboot}
+## :checkered_flag: When to reboot? {#when-to-reboot}
 
 There is currently no way for XCP-ng to automatically tell you if a reboot is required.
 
@@ -253,7 +253,7 @@ Else base your decision on an educated guess. Look at the list of the updated pa
 
 All updates are announced on the [XCP-ng Blog](https://xcp-ng.org/blog/tag/update/) along with information about what steps are required after installing the update (reboot, toolstack restart, service restart...).
 
-## 🔥 XCP-ng 7.5/7.6 and live migrations {#xcp-ng-7576-and-live-migrations}
+## :fire: XCP-ng 7.5/7.6 and live migrations {#xcp-ng-7576-and-live-migrations}
 
 Since the component that handles live migrations in XenServer is closed-source, we had to write our own. However, it took several tries before we reached a fully functional replacement, that's why only hosts that have had the latest updates of the `xcp-emu-manager` package have the fully working replacement. Previous versions will or will not manage to migrate your VMs, depending on various contextual factors, including the VM's load.
 

--- a/docs/management/users-permissions.md
+++ b/docs/management/users-permissions.md
@@ -6,7 +6,7 @@ sidebar_position: 7
 
 Who can access your XCP-ng infrastructure, and with which rights.
 
-## 🎓 The model in short {#the-model-in-short}
+## :mortar_board: The model in short {#the-model-in-short}
 
 There are two distinct layers:
 
@@ -15,7 +15,7 @@ There are two distinct layers:
 
 In other words: XCP-ng authenticates *management planes*, Xen Orchestra authenticates *people*.
 
-## 🔑 Host level: the root account {#host-level-the-root-account}
+## :key: Host level: the root account {#host-level-the-root-account}
 
 * Change the password with `xe user-password-change` or `xsconsole`: see [root password management](hosts-pools.md#root-password).
 * All pool members share the same root password.
@@ -26,7 +26,7 @@ In other words: XCP-ng authenticates *management planes*, Xen Orchestra authenti
 XAPI historically supports external authentication (Active Directory) and role-based access control at the host level. In XCP-ng this path is deprecated (see the [8.3 release notes](../releases/release-8-3.md#active-directory-in-xcp-ng)) and not recommended: user management is done in Xen Orchestra, which offers much more flexibility without touching dom0.
 :::
 
-## 👥 Xen Orchestra: users, groups and ACLs {#xen-orchestra-users-groups-and-acls}
+## :busts_in_silhouette: Xen Orchestra: users, groups and ACLs {#xen-orchestra-users-groups-and-acls}
 
 What Xen Orchestra provides on top of your pools:
 
@@ -37,7 +37,7 @@ What Xen Orchestra provides on top of your pools:
 
 See the Xen Orchestra documentation for details: [users](https://docs.xen-orchestra.com/xo5/users), [ACLs](https://docs.xen-orchestra.com/xo5/users#acls), [self-service](https://docs.xen-orchestra.com/xo5/users#self-service-portal).
 
-## 🧭 Recommended setup {#recommended-setup}
+## :compass: Recommended setup {#recommended-setup}
 
 For a team of any size:
 

--- a/docs/management/vm-load-balancing.md
+++ b/docs/management/vm-load-balancing.md
@@ -1,6 +1,6 @@
 # VM Load balancing
 
-## 📋 Introduction {#introduction}
+## :clipboard: Introduction {#introduction}
 
 A generic definition (from Wikipedia), is:
 
@@ -12,7 +12,7 @@ In the case of virtualization, you have multiple physical hosts, which runs your
 Maybe you already heard about VMWare DRS (Distributed Resource Scheduler): that's the same principle here, but for XCP-ng.
 :::
 
-## 🎓 Concepts {#concepts}
+## :mortar_board: Concepts {#concepts}
 So the first objective is to adapt your VM placement in live (without service interruption), depending of the load. Because [Xen Orchestra](../manage-at-scale/xo-web-ui) is connected to multiple pools and XCP-ng supports live storage motion, we can perform load balancing on a **whole XCP-ng infrastructure** (even between remote datacenters). A load balancing policy is called a "**plan**".
 
 Let's take a simple example, with these 2 hosts running 6 VMs:
@@ -41,7 +41,7 @@ But it's not the only way to see this: there is multiple possibilities to "optim
 
 Those ways can be also called modes: "performance" for 1, "density" for number 2 and "mixed" for the last.
 
-## 🔧 Configure a plan {#configure-a-plan}
+## :wrench: Configure a plan {#configure-a-plan}
 
 In this coming new view, you'll be able to configure a new load balancing plan, or edit an existing one.
 
@@ -98,7 +98,7 @@ The global situation (resource usage) is examined **every minute**.
 TODO: more details to come here
 :::
 
-## ↔️ VM anti-affinity {#vm-anti-affinity}
+## :left_right_arrow: VM anti-affinity {#vm-anti-affinity}
 
 VM anti-affinity is a feature that prevents VMs with the same user tags from running on the same host. This functionality is available directly in the load-balancer plugin.
 This way, you can avoid having pairs of redundant VMs or similar running on the same host.

--- a/docs/networking/networking.md
+++ b/docs/networking/networking.md
@@ -12,7 +12,7 @@ XCP-ng hosts **MUST NOT** have a public IP address assigned to their management 
 This is even more important when using XOSTOR: see the related warning in the [XOSTOR documentation](../xostor/#how-does-it-work).
 :::
 
-## 🎓 Concepts {#concepts}
+## :mortar_board: Concepts {#concepts}
 
 This section describes the general concepts of networking in XCP-ng. For a deeper dive, check the [Network Architecture section](../../project/architecture/#network).
 
@@ -81,7 +81,7 @@ Non-standard MTUs are supported on **storage interfaces**. However, jumbo frames
 
 While these limitations may be addressed in future updates, **stick to default MTU settings on management interfaces** to ensure **operational stability**.
 
-## 🏷️ VLANs {#vlans}
+## :label: VLANs {#vlans}
 
 VLANs, as defined by the IEEE 802.1Q standard, allow a single physical network to support multiple logical networks. XCP-ng hosts support VLANs in multiple ways.
 
@@ -143,7 +143,7 @@ In this configuration, when a VM sends a 9000-byte packet on the VLAN, it arrive
 
 **Solution:** Raise the physical interface's MTU to at least match the VLAN network's MTU before creating the VLAN network with jumbo frames.
 
-## 🔗 Bonds {#bonds}
+## :link: Bonds {#bonds}
 
 A bond aggregates 2 to 4 physical NICs into one logical interface, for redundancy (a cable, NIC or switch failure doesn't cut traffic) and, depending on the mode, more total bandwidth. Bonds work for VM traffic, management and storage alike, with or without VLANs on top.
 
@@ -188,7 +188,7 @@ xe bond-destroy uuid=<bond-uuid>
 
 The member NICs come back as individual PIFs. If the management interface was on the bond, it moves back to the primary member.
 
-## 🎯 Dedicated storage NIC {#dedicated-storage-nic}
+## :dart: Dedicated storage NIC {#dedicated-storage-nic}
 
 To keep storage (or backup) traffic away from the management and VM networks, give a spare NIC its own IP and use that subnet for your NFS/iSCSI targets:
 
@@ -202,7 +202,7 @@ From Xen Orchestra: host → **Network** tab, edit the PIF's IP configuration di
 
 The host routes storage traffic through that NIC simply because the storage target's IP belongs to its subnet, so use a dedicated subnet (and ideally a dedicated VLAN) for storage. This also composes with [multipathing](../storage/multipathing.md), which uses several such NICs on separate paths.
 
-## 🧭 Management interface {#management-interface}
+## :compass: Management interface {#management-interface}
 
 The management interface is the PIF carrying XAPI traffic (pool communication, Xen Orchestra connections, migrations by default...). A few operations around it:
 
@@ -235,7 +235,7 @@ xe host-set-hostname-live host-uuid=<host-uuid> host-name=<new-hostname>
 
 DNS is part of the management PIF's IP configuration (`DNS=` in `pif-reconfigure-ip` above, comma-separated). For DNS *search domains*, see [DNS search domains](#dns-search-domains).
 
-## 🚦 Limit a VM's network bandwidth (QoS) {#limit-a-vms-network-bandwidth-qos}
+## :vertical_traffic_light: Limit a VM's network bandwidth (QoS) {#limit-a-vms-network-bandwidth-qos}
 
 An outgoing rate limit can be set per virtual interface:
 
@@ -245,7 +245,7 @@ xe vif-param-set uuid=<vif-uuid> qos_algorithm_type=ratelimit qos_algorithm_para
 
 (here about 10 MB/s). Unplug/replug the VIF, or restart the VM, to apply. Remove it by setting `qos_algorithm_type=""`. This limits what the VM can *send*; incoming traffic shaping is a job for your physical network.
 
-## 📛 Restrict what a VM can send (switch port locking) {#switch-port-locking}
+## :name_badge: Restrict what a VM can send (switch port locking) {#switch-port-locking}
 
 By default, a VM can emit any traffic on its networks. You can lock a virtual interface down to its expected addresses (anti-spoofing), or block it entirely. Useful when you don't fully trust what runs inside the VMs, e.g. in hosting scenarios.
 
@@ -260,7 +260,7 @@ xe vif-param-set uuid=<vif-uuid> locking-mode=disabled
 
 A network-wide default can be set for all VIFs that stay in `default` mode: `xe network-param-set uuid=<network-uuid> default-locking-mode=disabled` (or `unlocked`). Changes on a running VM need a VIF replug or a VM restart. See the [CLI reference](../appendix/cli_reference.md#vif-commands) for the full parameter list.
 
-## 🚛 NBD backup network {#nbd-backup-network}
+## :articulated_lorry: NBD backup network {#nbd-backup-network}
 
 Xen Orchestra's NBD-enabled backups read disk data over the NBD protocol (port 10809), on networks you have explicitly allowed. To dedicate a network (for example your storage or a backup network) to that traffic:
 
@@ -270,7 +270,7 @@ xe network-param-add uuid=<network-uuid> param-name=purpose param-key=nbd
 
 The network needs an IP on each host (a [dedicated NIC](#dedicated-storage-nic) works perfectly). See the [backup page](../management/backup.md) for the XO side.
 
-## 🌐 Manage physical NICs {#manage-physical-nics}
+## :globe_with_meridians: Manage physical NICs {#manage-physical-nics}
 
 ### Add a new NIC
 
@@ -377,7 +377,7 @@ xe pif-forget uuid=<PIF UUID>
 
 The `<PIF UUID>` can be obtained with either `xe pif-list` or with Xen Orchestra. This command only needs to be ran once on the pool. 
 
-## 🛞 SDN controller {#sdn-controller}
+## :wheel: SDN controller {#sdn-controller}
 
 An SDN controller is provided by a [Xen Orchestra](../management#manage-at-scale) plugin. Thanks to that, you can enjoy advanced network features.
 
@@ -443,7 +443,7 @@ It means the TLS certificate, used to identify an SDN controller, on the host do
 
 The issue should be fixed.
 
-## 🚏 Static routes {#static-routes}
+## :busstop: Static routes {#static-routes}
 
 Sometimes you need to add extra routes to an XCP-ng host. It can be done manually with an `ip route add 10.88.0.0/14 via 10.88.113.193` (for example). But it won't persist after a reboot.
 
@@ -479,7 +479,7 @@ A toolstack restart is needed as before, on all hosts in the pool.
 XAPI might not remove the already-installed route until the host is rebooted. If you need to remove it ASAP,  you can use `ip route del 10.88.0.0/14 via 10.88.113.193`. Check that it's gone with `route -n`.
 :::
 
-## 🕸️ Full mesh network {#full-mesh-network}
+## :spider_web: Full mesh network {#full-mesh-network}
 
 This page describes how to configure a three node meshed network ([see Wikipedia](https://en.wikipedia.org/wiki/Mesh_networking)) which is a very cheap approach to create a 3 node HA cluster, that can be used to host a Ceph cluster, or similar clustered solutions that require 3 nodes in order to operate with full high-availability.
 
@@ -572,7 +572,7 @@ This setup will save you costs of 2 network switches you would otherwise have to
 * Forum post: [https://xcp-ng.org/forum/topic/1897/mesh-network](https://xcp-ng.org/forum/topic/1897/mesh-network)
 * Proxmox wiki: [https://pve.proxmox.com/wiki/Full_Mesh_Network_for_Ceph_Server](https://pve.proxmox.com/wiki/Full_Mesh_Network_for_Ceph_Server)
 
-## 🔎 DNS Search Domains {#dns-search-domains}
+## :mag_right: DNS Search Domains {#dns-search-domains}
 
 When XCP-ng is configured for static IP configuration there are no DNS search domains added. It is possible to add search domains into `/etc/resolv.conf`, however those won't persist across reboots. Use `xe pif-param-set` to add search domains that should persist across reboots.
 
@@ -595,7 +595,7 @@ xe pif-param-set uuid=76608ca2-e099-9344-af36-5b63c0022913 other-config:domain=s
 
 This procedure has to be done for all hosts in the same pool.
 
-## 👷 Network Troubleshooting {#network-troubleshooting}
+## :construction_worker_man: Network Troubleshooting {#network-troubleshooting}
 
 ### Network corruption
 

--- a/docs/project/about.md
+++ b/docs/project/about.md
@@ -1,6 +1,6 @@
 # About XCP-ng
 
-## 🌱 The origin {#the-origin}
+## :seedling: The origin {#the-origin}
 
 XCP-ng stands as more than a mere product-it's a dynamic project fostered by an engaged community. Originating from the free [Xen Cloud Platform](https://wiki.xen.org/wiki/XCP_Overview) (XCP) and its commercial counterpart, Citrix XenServer, the landscape shifted when Citrix made XenServer open source, leading to the discontinuation of XCP.
 
@@ -12,7 +12,7 @@ XCP-ng was conceived as a friendly fork of XenServer, characterized by an approa
 
 You can now read more details about the [origin of the project on Wikipedia!](https://en.wikipedia.org/wiki/XCP-ng)
 
-## 💬 Community {#community}
+## :speech_balloon: Community {#community}
 
 Most of the community is on [XCP-ng Forum](https://xcp-ng.org/forum). Feel free go there and ask anything! We also have a [Discord server](https://discord.gg/Hr98F6wRvx) for live chat, or even on [Reddit](https://www.reddit.com/r/xcpng/) (however, the forum is the most active place).
 
@@ -24,7 +24,7 @@ You can also find us on many social networks:
 * IRC on OFTC at #xcp-ng
 
 
-## 📜 History of XCP-ng {#history-of-xcp-ng}
+## :scroll: History of XCP-ng {#history-of-xcp-ng}
 
 Here is a video recorded at FOSDEM19:
 

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -2,7 +2,7 @@
 
 This page contains advanced info regarding XCP-ng architecture.
 
-## 💽 Storage {#storage}
+## :minidisc: Storage {#storage}
 
 ### Virtual disks on HVMs and PV guests
 
@@ -87,7 +87,7 @@ For each read/write in the VM disk, requests pass through an emulated driver, th
 The process described above is used for HVMs and also for PV guests (at startup, PV drivers are not loaded).
 After starting a PV guest, the emulated driver in the VM is replaced by `blkfront` (a PV driver) which allows to communicate directly with `tapdisk` using a protocol: `blkif`; `blktap` and `qemu-dm` then become useless to handle devices requests. Note that system calls are used with two drivers: `eventchn dev` and `gntdev` to map VM memory pages in the user space of the host. Thus a shared ring can be used to receive requests directly from `tapdisk` in host user space instead of using the kernel space.
 
-## ↕️ Components for VDI I/O {#components-for-vdi-io}
+## :arrow_up_down: Components for VDI I/O {#components-for-vdi-io}
 
 ### XenStore
 
@@ -471,7 +471,7 @@ The persistent grants are not used in `tapdisk`.
 
 The read steps are similar, the main difference is that we must copy from the `Dom0` VHD file to the `guest` buffer.
 
-## 📡 API {#api}
+## :satellite: API {#api}
 
 XCP-ng uses **XAPI** as main API. This API is used by all clients. For more details go to [XAPI website](https://xapi-project.github.io/).
 
@@ -822,7 +822,7 @@ XCP-ng is meant to use XAPI. Don't use it with `xl` or anything else!
 </svg>
 </Schema>
 
-## 🕸️ Network {#network}
+## :spider_web: Network {#network}
 
 ### Overview
 

--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -4,7 +4,7 @@ How to contribute to XCP-ng? There are many ways of contributing:
 * by giving some of your time to work on the project. Code isn't the only way! Community support, translation, documentation, testing…
 * with money, by subscribing to [Pro Support](https://vates.tech), which funds further developments.
 
-## 💁 Help others {#help-others}
+## :tipping_hand_woman: Help others {#help-others}
 
 You don't have to be a programmer/IT-nerd to help at this project. Just ask or offer your help:
 
@@ -14,17 +14,17 @@ You don't have to be a programmer/IT-nerd to help at this project. Just ask or o
 
 We are happy about every helping hand!
 
-## 🌍 Translations {#translations}
+## :earth_africa: Translations {#translations}
 
 [Help us translate the built-in web interface (XO Lite) in more languages!](http://translate.vates.tech/engage/xen-orchestra/)
 
-## ✍️ Write documentation {#write-documentation}
+## :writing_hand: Write documentation {#write-documentation}
 
-Contribute to our documentation with pull requests modifying the files in this very documentation. At the bottom of each page (including this one!), you can find a "🖊️ Edit this page" link. Click on it and contribute!
+Contribute to our documentation with pull requests modifying the files in this very documentation. At the bottom of each page (including this one!), you can find a ":pen: Edit this page" link. Click on it and contribute!
 
-## 🧑‍🔬 Test {#test}
+## :scientist: Test {#test}
 
-It's important to test XCP-ng on many different platforms and devices. You have gear laying around or access to some special devices? -> be a tester and test all the features of XCP-ng 🚀
+It's important to test XCP-ng on many different platforms and devices. You have gear laying around or access to some special devices? -> be a tester and test all the features of XCP-ng :rocket:
 
 Your results are very welcome in our [Hardware Compatibility List (HCL)](../../installation/hardware)!
 
@@ -37,7 +37,7 @@ Most community testing is organized on the forum, on dedicated threads.
 
 You can also read [this](../development-process/tests) for test ideas.
 
-## 🧑‍💻 Develop {#develop}
+## :technologist: Develop {#develop}
 
 You are a developer and want to code with us? Cool!
 
@@ -49,17 +49,17 @@ There are many components, in various languages: C, ocaml, python and more.
     * Forum -> Development Corner: [https://xcp-ng.org/forum/category/7/development](https://xcp-ng.org/forum/category/7/development)
 * Read [this introduction](../development-process/development). The rest of the [Development Process Tour](../../category/development-process) is also of interest for anyone who wants to help on development.
 
-## 📦 Package {#package}
+## :package: Package {#package}
 
 Development is one thing, but for your changes to reach actual users, they need to be packaged into RPMs.
 
 See the [Development Process Tour](../../category/development-process) for an introduction about the packaging process, and useful tips (like: [how to rebuild a RPM for XCP-ng locally](../development-process/local-rpm-build)).
 
-## 📣 Talk about us {#talk-about-us}
+## :mega: Talk about us {#talk-about-us}
 
 Another valuable way to help is by talking about XCP-ng to people you know or to your audience.
 
-## 🪪 Developer Certificate of Origin (DCO) {#developer-certificate-of-origin-dco}
+## :identification_card: Developer Certificate of Origin (DCO) {#developer-certificate-of-origin-dco}
 
 As a member of the Linux Foundation, XCP-ng asks that every contributor certifies that they are allowed to contribute the code or documentation they submit to us. This is done with a simple
 ```

--- a/docs/project/development-process/ISO-modification.md
+++ b/docs/project/development-process/ISO-modification.md
@@ -10,7 +10,7 @@ This page aims at guiding you through the modification of the installation ISO i
 
 Obviously, a modified installation image is not an official installation image anymore, so it's harder to provide support for that. However, it can still be useful in some cases and we also hope that letting you know how to modify the installer will help getting useful contributions on its [code base](https://github.com/xcp-ng/host-installer).
 
-## 📤 Extract an existing ISO image {#extract-an-existing-iso-image}
+## :outbox_tray: Extract an existing ISO image {#extract-an-existing-iso-image}
 
 <Terminal shell title="Extract an existing ISO image">{`
 mkdir tmpmountdir/
@@ -27,7 +27,7 @@ For example:
 chmod a+w iso/ -R
 `}</Terminal>
 
-## 🗂️ Contents of the installation ISO image {#contents-of-the-installation-iso-image}
+## :card_index_dividers: Contents of the installation ISO image {#contents-of-the-installation-iso-image}
 
 We'll only list the files that are used during an installation or upgrade. The other files in the ISO are documentation or additional tools.
 
@@ -38,11 +38,11 @@ We'll only list the files that are used during an installation or upgrade. The o
 * `repodata/`: yum metadata about the RPMs
 * `.treeinfo`: often forgotten when one copies the contents of the ISO for network installation, this hidden file contains necessary metadata about XCP-ng and its version
 
-## 🤖 Create a fully automated installation image {#create-a-fully-automated-installation-image}
+## :robot: Create a fully automated installation image {#create-a-fully-automated-installation-image}
 
 [A guide is available in the *Installation* page](../../../installation/install-xcp-ng#unattended-installation-with-a-custom-iso-image).
 
-## 🛠️ Modify the installer itself {#modify-the-installer-itself}
+## :hammer_and_wrench: Modify the installer itself {#modify-the-installer-itself}
 
 The steps to modify the installer are:
 * (extract the ISO image, see above)
@@ -124,7 +124,7 @@ rm install/ -rf # as root too. Or move it somewhere else. We don't want it in th
 
 Then you can either read the next section or jump to "Build a new ISO image with your changes".
 
-## 📦 Change the list of installed RPMs {#change-the-list-of-installed-rpms}
+## :package: Change the list of installed RPMs {#change-the-list-of-installed-rpms}
 
 You may want the installer to install more packages, or updated packages.
 
@@ -139,7 +139,7 @@ To achieve this:
   createrepo_c . -o .
   ```
 
-## 💿 Build a new ISO image with your changes {#build-a-new-iso-image-with-your-changes}
+## :cd: Build a new ISO image with your changes {#build-a-new-iso-image-with-your-changes}
 
 From the `iso/` directory:
 ```

--- a/docs/project/development-process/build-system.md
+++ b/docs/project/development-process/build-system.md
@@ -14,7 +14,7 @@ What follows is important if you want to understand how our official RPMs are bu
 However, for local builds meant for testing your changes (e.g. add a few patches to see how the component behaves with them), check the [Local RPM build](../local-rpm-build) section.
 :::
 
-## 🏭 Enter Koji {#enter-koji}
+## :factory: Enter Koji {#enter-koji}
 
 When building RPMs, many things can and must be automated. This is what a build system is for. Ours is [Koji](https://koji.xcp-ng.org/), which [comes from the Fedora project](https://pagure.io/koji).
 
@@ -30,7 +30,7 @@ And with a bit of scripting or additional components:
 * GPG signing of RPMs.
 * Creation of RPM repositories.
 
-## 🎓 Koji's concepts {#kojis-concepts}
+## :mortar_board: Koji's concepts {#kojis-concepts}
 
 (see also [https://pagure.io/docs/koji/](https://pagure.io/docs/koji/) though its howto is very Fedora-centric)
 
@@ -109,7 +109,7 @@ Another (fictitious) example:
 
 This is just to show that build tag and destination tag **can** be different. Build dependencies will be pulled from `v8.x-testing` and the result will be put in `v8.x-sandbox`. This means that builds to the sandbox will never use packages that are already in the sandbox as build dependencies. Why would we do that? To guarantee that builds made in the sandbox are never influenced by other builds made there, possibly by other users. This is a fictitious situation, just to illustrate the concepts of build tag and destination tag.
 
-## 🪜 Build and release process {#build-and-release-process}
+## :ladder: Build and release process {#build-and-release-process}
 Here's how to update a package in XCP-ng, step by step. This process requires writing rights on the git repository corresponding to the package at [https://github.com/xcp-ng-rpms/](https://github.com/xcp-ng-rpms/) and submit rights in Koji. Others are invited to fork one the repositories at [https://github.com/xcp-ng-rpms/](https://github.com/xcp-ng-rpms/), [build RPMs locally in our build container](../local-rpm-build), and then create pull requests. Reading the steps below will still be useful to you to help make appropriate changes.
 
 This applies only to packages that we build in Koji. There are also packages that are not built in Koji. Most packages from CentOS, for example, are imported directly from CentOS into our Koji instance.
@@ -161,19 +161,19 @@ Then, if it is an **update candidate** for an existing package:
     * What to test.
     * Is a reboot required…
 
-## 🆕 Special case: new packages {#special-case-new-packages}
+## :new: Special case: new packages {#special-case-new-packages}
 Importing new packages requires extra steps.
 
 **TODO**
 
-## 🤝 Special case: packages not built by us {#special-case-packages-not-built-by-us}
+## :handshake: Special case: packages not built by us {#special-case-packages-not-built-by-us}
 Most packages imported from CentOS or EPEL are not built by our Koji instance. We import the source RPM and the built RPMs directly.
 
 **TODO**
 
 Bits of information can be inferred from [Import-RPM-build-dependencies-from-CentOS-and-EPEL](https://github.com/xcp-ng/xcp/wiki/Import-RPM-build-dependencies-from-CentOS-and-EPEL)
 
-## 🏷️ Other tags {#other-tags}
+## :label: Other tags {#other-tags}
 In a previous section, I've tried to explain what tags are used for in Koji. We use them also for something else. We probably even misuse them.
 
 Once a day, we run a job that makes sure every *build* in our Koji instance is tagged with one of the following tags:
@@ -190,10 +190,10 @@ Example: [https://koji.xcp-ng.org/buildinfo?buildID=655](https://koji.xcp-ng.org
 
 All those tags have no purpose in Koji's workflow. They are just useful pieces of information for us.
 
-## ✍️ RPM signing {#rpm-signing}
+## :writing_hand: RPM signing {#rpm-signing}
 We automatically sign the RPMs built by or imported to Koji before exporting them towards the RPM repositories.
 
 [More information about RPM signing](../../../project/mirrors#security).
 
-## 🗃️ Repository generation {#repository-generation}
+## :card_file_box: Repository generation {#repository-generation}
 Handled by a cron job on koji's server. Then the repository is synchronised to [https://updates.xcp-ng.org/](https://updates.xcp-ng.org/).

--- a/docs/project/development-process/commit-message-conventions.md
+++ b/docs/project/development-process/commit-message-conventions.md
@@ -6,13 +6,13 @@ sidebar_position: 11
 
 Our conventions on commit messages.
 
-## 📖 Foreword {#foreword}
+## :open_book: Foreword {#foreword}
 
 XCP-ng and Xen Orchestra are made of many different projects and components. This document is an attempt at defining a minimal, common set of rules for git commit messages we want to follow in the context of those projects. They should be generic and consensual enough that we can follow them for our internal commits, but also when contributing upstream (while following the upstream project's rules, of course).
 
 Individual projects part of XCP-ng or Xen Orchestra can also define additional rules and exceptions. For example, Xen Orchestra developers follow [additional rules coming from the AngularJS guidelines](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y).
 
-## 🎯 Goals {#goals}
+## :dart: Goals {#goals}
 
 The main goals behind the commit message rules are:
 
@@ -24,7 +24,7 @@ The main goals behind the commit message rules are:
 
 There could be more goals, but they are not covered by the minimal set of rules in this document. For example: permitting scripting changelog generation, with a separation between security fixes, features and bug fixes. This is left for each individual project to define.
 
-## 🧱 Structure of a commit message {#structure-of-a-commit-message}
+## :brick: Structure of a commit message {#structure-of-a-commit-message}
 
 The widely accepted structure is:
 
@@ -40,7 +40,7 @@ changes
 Footer
 ```
 
-## ✏️ First line: short subject {#first-line-short-subject}
+## :pencil2: First line: short subject {#first-line-short-subject}
 
 Here's a challenge: it must remain really short (50 characters is the convention, but in this minimal set of rules we'll allow up to 70 characters), but also ideally answer three essential questions:
 
@@ -64,11 +64,11 @@ On the other side, here's an example of a commit subject that doesn't follow a s
 
 When there's no structured convention, ask yourself: are the type, the scope and the change obvious in the subject I wrote?
 
-## ⬜ Second line: blank {#second-line-blank}
+## :white_large_square: Second line: blank {#second-line-blank}
 
 Nothing on that line. Period. No exceptions.
 
-## 📝 Message body: commit description {#message-body-commit-description}
+## :memo: Message body: commit description {#message-body-commit-description}
 
 This part gets easily forgotten, but it's really important. You don't know who will read your commit, when (could be in ten years from now), what knowledge they will have about the project or about the code. Maybe they're someone from the support that has only minimal knowledge in the programming language. Maybe they're a project manager. Maybe it's a developer who took over this component after you left. And often enough, it will just be yourself scratching your head and asking yourself: "Why the h\*\*\* did I make this change???".
 
@@ -93,7 +93,7 @@ For good examples, go look at the commit history [from the Xen project](http://x
 
 Verbs that describe what you did are in the imperative form. Lines should not be longer than 70 characters.
 
-## 🦶 Message footer {#message-footer}
+## :foot: Message footer {#message-footer}
 
 ### Referencing issues
 

--- a/docs/project/development-process/development.md
+++ b/docs/project/development-process/development.md
@@ -8,17 +8,17 @@ How XCP-ng is developed.
 
 Development in the context of the XCP-ng project means either to contribute to existing upstream projects, such as the Xen API ([XAPI](https://github.com/xapi-project/xen-api/), the [Xen project](https://xenproject.org/) and many other components of XCP-ng, or to develop new software specifically for the XCP-ng project.
 
-## ⬆️ Contribution to upstream projects {#contribution-to-upstream-projects}
+## :arrow_up: Contribution to upstream projects {#contribution-to-upstream-projects}
 Development (as in "write code") in XCP-ng project is mostly made of contributions to upstream projects such as [https://github.com/xapi-project/](https://github.com/xapi-project/), [https://wiki.xenproject.org/wiki/Submitting_Xen_Project_Patches](https://wiki.xenproject.org/wiki/Submitting_Xen_Project_Patches) or [https://github.com/xenserver/](https://github.com/xenserver/).
 
 For some pieces of upstream software, we have GitHub "forks" at [https://github.com/xcp-ng](https://github.com/xcp-ng). For others we contribute directly without a GitHub fork and apply the patches directly on the RPMs at [https://github.com/xcp-ng-rpms/](https://github.com/xcp-ng-rpms/).
 
-## 🌱 Components we **are** the upstream for {#components-we-are-the-upstream-for}
+## :seedling: Components we **are** the upstream for {#components-we-are-the-upstream-for}
 Components for which we are the main developers.
 
 Our policy is to upstream everything if possible. However, there are some exceptions:
 * Components that have no "upstream" open source equivalent. `xcp-emu-manager` ([https://github.com/xcp-ng/xcp-emu-manager](https://github.com/xcp-ng/xcp-emu-manager)) is such a component that we had to write from scratch because the corresponding component in XenServer, `emu-manager`, is closed-source.
 * Bits specific to the act of building XCP-ng (various scripts, branding stuff...). The main example is [https://github.com/xcp-ng/xcp](https://github.com/xcp-ng/xcp).
 
-## 🤝 How to help at development {#how-to-help-at-development}
+## :handshake: How to help at development {#how-to-help-at-development}
 It all depends on your skills and areas of interest so it's hard to tell specifically in advance. It usually starts with a feature that you want, or a bug that is annoying you. Alternatively, having a look at the open GitHub issues and picking one ([https://github.com/xcp-ng/xcp/issues](https://github.com/xcp-ng/xcp/issues)) can be a way to get started. Even if you don't know where to start, just come and talk with us (see [Where discussion happens](../release-process-overview#where-discussion-happens) above).

--- a/docs/project/development-process/kernel-module-policy.md
+++ b/docs/project/development-process/kernel-module-policy.md
@@ -8,12 +8,12 @@ Our policy regarding kernel modules.
 
 In XCP-ng, there is only one version of the kernel that is supported at a given time. There's also an [alternate kernel](../../../installation/hardware#alternate-kernel) available for troubleshooting. The policy differs whether the kernel modules are for XCP-ng's supported kernel or for an alternate kernel.
 
-## 🎓 What are kernel modules? {#what-are-kernel-modules}
+## :mortar_board: What are kernel modules? {#what-are-kernel-modules}
 See [https://en.wikipedia.org/wiki/Loadable_kernel_module](https://en.wikipedia.org/wiki/Loadable_kernel_module)
 
 They can be loaded (or unloaded) dynamically into the kernel to provide more functionality: device drivers, filesystem drivers, etc.
 
-## 📚 Definitions: supported modules, alternate modules, additional modules {#definitions-supported-modules-alternate-modules-additional-modules}
+## :books: Definitions: supported modules, alternate modules, additional modules {#definitions-supported-modules-alternate-modules-additional-modules}
 
 A base installation of XCP-ng comes with:
 * a Linux kernel (the `kernel` RPM), including lots of modules already,
@@ -24,7 +24,7 @@ Through our RPM repositories (configured by default on the hosts for `yum` to in
 * **alternate modules**, which are alternate versions of the officially supported modules. The supported modules can either be built-in kernel modules or modules provided through supported separate RPMs such as the `qlogic-netxtreme2` RPM. Their name is usually the same as the package they override, with an added `-alt` suffix (example: `broadcom-bnxt-en-alt`). Alternate versions can be installed for better support of recent hardware or in the hope that bugs in the supported drivers have been fixed in newer versions. They won't remove the supported drivers from the system, but the kernel will load the alternate ones instead. **Warning**: *they receive less testing than the supported modules*.
 * **additional (or "extra") modules** for **additional features** (can be experimental). Example: `kmod-zfs-4.4.0+10` for ZFS support in the `4.4.0+10` kernel, or `ceph-module` for CephFS support. To know whether such a module is experimental or is fully supported, read its description or search the wiki.
 
-## ♻️ Module Updates {#module-updates}
+## :recycle: Module Updates {#module-updates}
 
 This section discusses the kind of updates kernel modules can receive during the maintenance cycle of a given release of XCP-ng (e.g. XCP-ng 8.2). For information about the general update process, see [Updates Howto](../../../management/updates).
 
@@ -34,7 +34,7 @@ Updates for *alternate modules* are offered only if the given alternate modules 
 
 Updates for *additional modules* are offered only if the given additional modules are installed on the host. We may update them to a newer version of the module at any time - more likely if the module is considered experimental, less likely if it's supported officially.
 
-## 🏷️ Module package naming conventions {#module-package-naming-conventions}
+## :label: Module package naming conventions {#module-package-naming-conventions}
 
 We'll now discuss naming conventions for packages that provide kernel modules. This is mostly targeted at packagers, but can also be useful to users who wish to understand the naming schemes. We've tried to make it simple and to use meaningful naming conventions, but legacy and the variety of situations led to a mixed result, so hold on!
 
@@ -80,7 +80,7 @@ Examples:
 * `broadcom-bnxt-en-alt`
 * `tn40xx-module-alt` (fictitious)
 
-## 🔢 Versioning of the RPMs {#versioning-of-the-rpms}
+## :1234: Versioning of the RPMs {#versioning-of-the-rpms}
 
 Since we only support one version of the kernel, we don't need to include the kernel version in the package name in addition to the module version. So the `Version` tag of the RPM is that of the module.
 
@@ -92,7 +92,7 @@ Example `ceph-module-4.4.176` is a version of the `ceph` module extracted from k
 
 Exceptions: the abovementioned `kmod`-packages such as `kmod-zfs-4.4.0+10-0.7.11-1.el7.centos.x86_64.rpm` include the kernel version in the name. In this example the kernel version is `4.4.0+10` and the module version is `0.7.11`.
 
-## 📍 Where the modules are installed on the system {#where-the-modules-are-installed-on-the-system}
+## :round_pushpin: Where the modules are installed on the system {#where-the-modules-are-installed-on-the-system}
 
 Intended mostly for packagers, this section can also be useful to users.
 
@@ -132,7 +132,7 @@ search override updates extra built-in weak-updates
 
 This makes `depmod` search in the `override` module directory before trying other module directories, for all modules.
 
-## 🦮 How to use alternate or additional modules {#how-to-use-alternate-or-additional-modules}
+## :guide_dog: How to use alternate or additional modules {#how-to-use-alternate-or-additional-modules}
 
 First, a warning: alternate modules and additional modules are provided as a convenience, but they do not get the same amount of testing as the modules that are installed by default or through updates. So keep that in mind, test, and be ready to uninstall them if any issue arises.
 
@@ -211,7 +211,7 @@ In the case of an alternate module, we have made it so that you can simply unins
 
 In the case of an additional module, uninstalling the RPM will simply leave your system without that module, but shouldn't remove it from the currently loaded modules until next reboot or until you unload it.
 
-## 🚒 Kernel modules for alternate kernels {#kernel-modules-for-alternate-kernels}
+## :fire_engine: Kernel modules for alternate kernels {#kernel-modules-for-alternate-kernels}
 
 The policy for [alternate kernels](../../../installation/hardware#alternate-kernel) is simpler, because there are no alternate modules (with the meaning of *alternate modules* as described earlier). There's just the kernel's built-in modules and possibly additional or updated modules in `/lib/modules/{kernel_version}/updates`. This means that when an alternate kernel is updated, people who have installed it will get the update through the standard updates process. There's no support for cherry-picking specific versions of previous packages we may have released in the past. If there's a bug, please open a bug report. To avoid bugs, please take part in the testing phase.
 

--- a/docs/project/development-process/koji-initial-setup.md
+++ b/docs/project/development-process/koji-initial-setup.md
@@ -6,7 +6,7 @@ sidebar_position: 14
 
 How to configure Koji as a user.
 
-## 🪪 Certificates {#certificates}
+## :identification_card: Certificates {#certificates}
 
 Once accepted as a proven packager or as an apprentice, you will receive your connection certificate as well as the server's CA public certificate:
 
@@ -25,7 +25,7 @@ You may also receive a browser certificate for the connection to Koji's web inte
 ```
 You need to import it into your web browser's certificate store and then use it when you log in to [https://koji.xcp-ng.org/](https://koji.xcp-ng.org/)
 
-## 📥 Installing koji {#installing-koji}
+## :inbox_tray: Installing koji {#installing-koji}
 The preferred, distro-independent way is to install it from PyPi with `pip`, `uv` or your preferred tool. Alternatively, your distro might provide the `koji` client as a package you can install from its repositories. You could also run it from a Fedora container, but that's mostly a last resort option if anything else fails for some reason.
 
 Example on Ubuntu 24.04+:
@@ -37,7 +37,7 @@ sudo apt install -y build-essential python3-dev libkrb5-dev krb5-user libssl-dev
 pipx install koji
 ```
 
-## ⚙️ Configuring koji {#configuring-koji}
+## :gear: Configuring koji {#configuring-koji}
 Put this in `~/.koji/config`:
 ```
 [koji]
@@ -68,10 +68,10 @@ authtype = ssl
 
 In some cases (with older versions of koji), we've found that the `cert` directive in `~/.koji/config ` was not used if there was no such directive in `/etc/koji.conf`. Workaround: add a `cert = ~/.koji/client.crt` to `/etc/koji.conf`, or possibly even `cp ~/.koji/config /etc/koji.conf`.
 
-## 🧪 Test your connection {#test-your-connection}
+## :test_tube: Test your connection {#test-your-connection}
 `koji moshimoshi`. If it greats you (in any language), then your connection to the server works.
 
-## 🔑 Get more permissions {#get-more-permissions}
+## :key: Get more permissions {#get-more-permissions}
 After your first connection, your user gets added by koji to its database. Now you need permissions to be able to tag builds. Ask an administrator for the `build` permission.
 
 You can verify the permissions for a given user `$USER` with:
@@ -81,7 +81,7 @@ koji list-users # Check if $USER is listed
 koji list-permissions --user=$USER # Adapt $USER if needed
 `}</Terminal>
 
-## 🐳 Koji in Docker container {#koji-in-docker-container}
+## :whale: Koji in Docker container {#koji-in-docker-container}
 
 This used to be useful when our koji server was a bit too old for recent crypto, but now **installing from `PyPi` is probably the best choice**.
 
@@ -108,7 +108,7 @@ This command does the same as above, but relies on docker caching the result of 
 docker run -it --rm -v$HOME/.koji:/root/.koji:ro $(docker build -q - <<<$'FROM fedora:41\nRUN dnf install -qy koji') koji moshimoshi
 ```
 
-## 🧰 Useful commands {#useful-commands}
+## :toolbox: Useful commands {#useful-commands}
 
 Just a quick list. Make sure to have read and understood our [development process tour](../../../category/development-process).
 

--- a/docs/project/development-process/local-rpm-build.md
+++ b/docs/project/development-process/local-rpm-build.md
@@ -8,10 +8,10 @@ How to build RPMs locally.
 
 Koji, the build system, is used only for official builds or update candidates. For daily development or community builds, we provide a simpler build environment using docker.
 
-## 📦 `xcp-ng-build-env` {#xcp-ng-build-env}
+## :package: `xcp-ng-build-env` {#xcp-ng-build-env}
 We provide a build environment that can run locally on your computer: [https://github.com/xcp-ng/xcp-ng-build-env](https://github.com/xcp-ng/xcp-ng-build-env). It revolves around docker containers and a few convenience scripts. This is what we use for development, before we send the actual changes to our official build system, `koji`.
 
-## 🦮 Guide to local RPM rebuild {#guide-to-local-rpm-rebuild}
+## :guide_dog: Guide to local RPM rebuild {#guide-to-local-rpm-rebuild}
 With some prior knowledge about development and RPM packaging, the documentation of [https://github.com/xcp-ng/xcp-ng-build-env](https://github.com/xcp-ng/xcp-ng-build-env) should be enough to get you started. However, in what follows, we provide a step by step guide for anyone to become accustomed to the process.
 
 ### Requirements
@@ -68,7 +68,7 @@ We can't cover every situation here, so we will address a simple case: add patch
 
 Then follow the same steps as before to build the RPM.
 
-## 🖥️ An XCP-ng host as a build environment {#an-xcp-ng-host-as-a-build-environment}
+## :desktop_computer: An XCP-ng host as a build environment {#an-xcp-ng-host-as-a-build-environment}
 You can also turn any XCP-ng host (preferrably installed in a VM. Don't sacrifice a physical host for that) into a build environment: all the tools and build dependencies are available from the default RPM repositories for XCP-ng, or from CentOS and EPEL repositories.
 
 You won't benefit from the convenience scripts from [xcp-ng-build-env](https://github.com/xcp-ng/xcp-ng-build-env) though.

--- a/docs/project/development-process/performance-tests.md
+++ b/docs/project/development-process/performance-tests.md
@@ -10,7 +10,7 @@ Basic ways to test XCP-ng performances.
 - compare speed of interfaces in the old and in the new release
 - (add more here...)
 
-## 💽 Example Storage Performance Tests Using fio {#example-storage-performance-tests-using-fio}
+## :minidisc: Example Storage Performance Tests Using fio {#example-storage-performance-tests-using-fio}
 
 ### Random write test for IOP/s, i.e. lots of small files
 
@@ -37,14 +37,14 @@ sync;fio --randrepeat=1 --ioengine=libaio --direct=1 --gtod_reduce=1 --name=test
 sync;fio --randrepeat=1 --ioengine=libaio --direct=1 --gtod_reduce=1 --name=test --filename=test --bs=4M --iodepth=64 --size=4G --readwrite=read --ramp_time=4
 ```
 
-## 📤 VM Export / Import {#vm-export--import}
+## :outbox_tray: VM Export / Import {#vm-export--import}
 
 * Export using ZSTD compression
 * Import using ZSTD compression
 * Export using gzip compression
 * Import using gzip compression
 
-## 🛠️ Guest tools and drivers {#guest-tools-and-drivers}
+## :hammer_and_wrench: Guest tools and drivers {#guest-tools-and-drivers}
 
 * Linux VM created on an older pool, with older guest tools not updated
 * Update existing Linux guest tools

--- a/docs/project/development-process/release-process-overview.md
+++ b/docs/project/development-process/release-process-overview.md
@@ -8,7 +8,7 @@ How we make a release process.
 
 Let's first discuss the RPM repository structure and define stable and development releases. Then we'll see development and packaging aspects.
 
-## 🗃️ XCP-ng's RPM repositories {#xcp-ngs-rpm-repositories}
+## :card_file_box: XCP-ng's RPM repositories {#xcp-ngs-rpm-repositories}
 *A new repository structure has been introduced with XCP-ng 8.0, which is what this section will cover. For the structure used in XCP-ng 7.5 and 7.6, see [https://xcp-ng.org/forum/topic/185/structure-of-the-rpm-repositories](https://xcp-ng.org/forum/topic/185/structure-of-the-rpm-repositories).*
 
 First, the *goals* behind the RPM repository structure are:
@@ -64,12 +64,12 @@ Note that having lots of additional packages in `base` and `updates` does not me
 * if you voluntarily install them (`yum install ...`),
 * or when pulled as a dependency of another update (in which case we do want that).
 
-## ⚖️ Stable release vs development release {#stable-release-vs-development-release}
+## :balance_scale: Stable release vs development release {#stable-release-vs-development-release}
 This is very common: released stable versions only get non-disruptive updates during their support lifetime: bug fixes and security fixes. Those are first published to the `testing` RPM repository and then moved to the `updates` RPM repository so that it is offered to all users (see [Updates Howto](../../../management/updates)). We also allow ourselves to add features to an existing stable version as optional packages, or as updates to existing packages provided that we can do it without creating risks of regression. Example: we added support for `zstd` compression for VM exports to an already released XCP-ng 7.6.
 
 On the contrary, the development version (aka the next stable release) can get any kind of breaking change until the day of release. Packages are then usually directly pushed to the `base` repository.
 
-## 🏭 How a RPM package is built for XCP-ng {#how-a-rpm-package-is-built-for-xcp-ng}
+## :factory: How a RPM package is built for XCP-ng {#how-a-rpm-package-is-built-for-xcp-ng}
 There are two sides of the coin: **development** and **RPM packaging**. For a given RPM package that does not come from CentOS or EPEL, we always provide packaging work. We can also provide development work, depending on the package, either as contributors to an upstream project, or as our own upstream.
 
 Here are the usual steps. We will expand on them afterwards:
@@ -83,7 +83,7 @@ Here are the usual steps. We will expand on them afterwards:
   * **Publish the build** to the appropriate RPM repository (`testing` for stable releases, `base` for development release of XCP-ng)
 * **Installer ISO image generation**: in the case of a development release of XCP-ng, when all the above has been done for all the RPMs, generate an ISO image with the installer and the required RPMs.
 
-## 💬 Where discussion happens {#where-discussion-happens}
+## :speech_balloon: Where discussion happens {#where-discussion-happens}
 Usually discussion will happen:
 * On [GitHub issues](https://github.com/xcp-ng/xcp/issues).
 * In [the forum](https://xcp-ng.org/forum/).

--- a/docs/project/development-process/rpm-packaging.md
+++ b/docs/project/development-process/rpm-packaging.md
@@ -6,7 +6,7 @@ sidebar_position: 5
 
 Creating packages that can be installed on the user's system is called **packaging**.
 
-## 🎓 Introduction to RPM {#introduction-to-rpm}
+## :mortar_board: Introduction to RPM {#introduction-to-rpm}
 RPM is the package format used by Fedora, Red Hat, CentOS, Mageia, OpenSUSE and other Linux distributions. It is also what we use in XCP-ng. A RPM package contains the files to be installed, metadata such as version and dependencies, and various scripts executed during installation, upgrade, uninstallation or other events.
 
 A RPM is built from a source RPM (SRPM), which is usually made of:
@@ -22,13 +22,13 @@ More about RPM:
 * [https://en.wikipedia.org/wiki/RPM_Package_Manager](https://en.wikipedia.org/wiki/RPM_Package_Manager)
 * [https://rpm.org/documentation.html](https://rpm.org/documentation.html)
 
-## 📍 Where to find our source RPMs {#where-to-find-our-source-rpms}
+## :round_pushpin: Where to find our source RPMs {#where-to-find-our-source-rpms}
 Two places.
 
 1. As SRPM files (`.src.rpm`), they are all available in our RPM repositories at [https://updates.xcp-ng.org/](https://updates.xcp-ng.org/). Example: [https://updates.xcp-ng.org/8/8.2/base/Source/SPackages/](https://updates.xcp-ng.org/8/8.2/base/Source/SPackages/).
 
 2. All RPMs built by us have been built from one of the git repositories at [https://github.com/xcp-ng-rpms/](https://github.com/xcp-ng-rpms/), containing the spec file and sources. The name of the repository matches that of the source package. `git-lfs` is required for cloning from and committing to them, because we use it to store the source tarballs.
 
-## 📐 Packaging guidelines {#packaging-guidelines}
+## :triangular_ruler: Packaging guidelines {#packaging-guidelines}
 
 See [RPM Packaging guidelines](https://github.com/xcp-ng/xcp/wiki/RPM-Packaging-guidelines).

--- a/docs/project/development-process/tags-maintenance-branches-in-our-code.md
+++ b/docs/project/development-process/tags-maintenance-branches-in-our-code.md
@@ -16,7 +16,7 @@ The objectives of the branch and tag naming conventions are:
 
 The first question to ask ourselves is: **who is the upstream for the software**?
 
-## ⬆️ 1. We are upstream {#1-we-are-upstream}
+## :arrow_up: 1. We are upstream {#1-we-are-upstream}
 
 We decide when to release a new version, and we decide the versioning.
 
@@ -41,7 +41,7 @@ Special case: if VERSION and XCPNGVERSION are always the same (example: `xcp-ng-
 * Tags: `vXCPNGVERSIONFULL` (`v8.2.0`)
 * Maintenance branch if needed: `XCPNGVERSION` (`8.2`)
 
-## ⬇️ 2. We are downstream {#2-we-are-downstream}
+## :arrow_down: 2. We are downstream {#2-we-are-downstream}
 
 We do not decide how and when new versions and released, and how they are numbered. So we need to somewhat mix the upstream versioning with our own branch names and versioning. For maintenance branches and tags related to an XCP-ng release, notably.
 

--- a/docs/project/development-process/tests.md
+++ b/docs/project/development-process/tests.md
@@ -18,7 +18,7 @@ If anything goes wrong, try to isolate [the logs](../../troubleshooting/log-file
 
 Give priority to tests on actual hardware, but if you don't have any hardware available for those, then [testing in a nested environment](../../compute.md#nested-virtualization) is useful too.
 
-## ✅ Basic tests {#basic-tests}
+## :white_check_mark: Basic tests {#basic-tests}
 
 - verify installation
 - verify connectivity with your interfaces
@@ -33,7 +33,7 @@ Give priority to tests on actual hardware, but if you don't have any hardware av
 - [check your logs](../../troubleshooting/log-files.md) for uncommon info or warnings.
 - (add more here...)
 
-## 💿 Installer {#installer}
+## :cd: Installer {#installer}
 
 * installation, upgrade
 * net-install with GPG check on
@@ -41,7 +41,7 @@ Give priority to tests on actual hardware, but if you don't have any hardware av
 * compatibility with driver disks from Citrix?
 * backup restore
 
-## 🚚 Live migration tests {#live-migration-tests}
+## :truck: Live migration tests {#live-migration-tests}
 
 Live migration needs to be tested, with or without storage motion (ie. moving the VM disk data to another storage repository). It is both a very important feature and something that can break in subtle ways, especially across different versions of XenServer or XCP-ng.
 
@@ -101,7 +101,7 @@ Some bugs detected in the past during our tests when migrating from old versions
 
 We try to overcome these whenever possible, but bugs that require patching the old host cannot be fixed.
 
-## 🧊 Cold migration tests {#cold-migration-tests}
+## :ice_cube: Cold migration tests {#cold-migration-tests}
 
 Live migration is important, but let's not forget to test "cold" migration (migration of shutdown VMs).
 
@@ -134,7 +134,7 @@ and
 * cross-pool migration, same versions
 * migration from earlier releases, cross-pool
 
-## 🐼 Test the Xen hypervisor itself {#test-the-xen-hypervisor-itself}
+## :panda_face: Test the Xen hypervisor itself {#test-the-xen-hypervisor-itself}
 
 The Xen hypervisor, which is at the core of XCP-ng, will benefit from being tested on a wide range of hardware. There exist test suites for this. You don't need to run them on every host you own if they are truly identical, but it's good to run them on as wide a range of hardware as possible.
 

--- a/docs/project/gitrepo.md
+++ b/docs/project/gitrepo.md
@@ -2,18 +2,18 @@
 
 Here is a complete list of repositories used by this project.
 
-## 📚 Main repositories {#main-repositories}
+## :books: Main repositories {#main-repositories}
 
 * [https://github.com/xcp-ng/](https://github.com/xcp-ng/)
 
-## 📦 Spec files and sources for RPMs {#spec-files-and-sources-for-rpms}
+## :package: Spec files and sources for RPMs {#spec-files-and-sources-for-rpms}
 
 * [https://github.com/xcp-ng-rpms/](https://github.com/xcp-ng-rpms/)
 
-## 🖥️ XCP-ng Center {#xcp-ng-center}
+## :desktop_computer: XCP-ng Center {#xcp-ng-center}
 
 * [https://github.com/xcp-ng/xenadmin](https://github.com/xcp-ng/xenadmin)
 
-## 🪟 Windows Guest Tools {#windows-guest-tools}
+## :window: Windows Guest Tools {#windows-guest-tools}
 
 * [https://github.com/xcp-ng/win-pv-drivers](https://github.com/xcp-ng/win-pv-drivers) - Windows Guest Tools installer and releases

--- a/docs/project/mirrors.md
+++ b/docs/project/mirrors.md
@@ -6,13 +6,13 @@ Like a Linux distribution, XCP-ng's installation images and RPM repositories can
 
 XCP-ng uses [mirrorbits](https://github.com/etix/mirrorbits) to redirect download requests to an appropriate mirror based on their update status and geographical position.
 
-## 🏢 Original mirror {#original-mirror}
+## :office: Original mirror {#original-mirror}
 
 `mirrors.xcp-ng.org` is the base for all download links, either downloads of installation ISO images, or RPM repositories used by `yum` to download updates.
 
 Previous versions of XCP-ng used to download files directly from `https://updates.xcp-ng.org`, which since then has becomes one mirror among others (and a fallback in case of files missing from other mirrors).
 
-## 📋 List of mirrors {#list-of-mirrors}
+## :clipboard: List of mirrors {#list-of-mirrors}
 
 You can check our live list of mirrors at this URL: [https://mirrors.xcp-ng.org/?mirrorstats](https://mirrors.xcp-ng.org/?mirrorstats)
 
@@ -20,7 +20,7 @@ You can check our live list of mirrors at this URL: [https://mirrors.xcp-ng.org/
 If loading this page fails due to too many redirections, just go to [https://xcp-ng.org](https://xcp-ng.org) once, then try again)
 :::
 
-## 📥 Add your mirror {#add-your-mirror}
+## :inbox_tray: Add your mirror {#add-your-mirror}
 
 Anyone or any entity can submit a mirror to our approval so that we add it to the list used by mirrorbits. It is a way to contribute to the XCP-ng project!
 
@@ -105,7 +105,7 @@ Main contact: John Doe <john.doe@...>
 
 Feel free to ask any question in your application message.
 
-## 🔒 Security {#security}
+## :lock: Security {#security}
 
 ### Context
 

--- a/docs/project/roadmap.md
+++ b/docs/project/roadmap.md
@@ -14,7 +14,7 @@ The goal of this document is to give you a hint of what's next. However, since a
 
 If you have any suggestion, feel free to ask on our [community forum](https://xcp-ng.org/forum/category/1/feedback-and-requests).
 
-## 🏗️ In tech preview {#in-tech-preview}
+## :building_construction: In tech preview {#in-tech-preview}
 
 _Technology that is here, but not officially released for production usage._
 
@@ -25,7 +25,7 @@ _Technology that is here, but not officially released for production usage._
 * SPDK-based `blkif` backend (platform)
 * SMAPIv3 evolution (storage)
 
-## 👷 In progress {#in-progress}
+## :construction_worker_man: In progress {#in-progress}
 
 _Things we started to work on, but are not usable or visible yet._
 
@@ -40,14 +40,14 @@ _Things we started to work on, but are not usable or visible yet._
 
 * LACP support during install (platform)
 
-## 🥼 Spec/Design/PoC {#specdesignpoc}
+## :labcoat: Spec/Design/PoC {#specdesignpoc}
 
 _Features that are being discussed or designed, but not even partly coded._
 
 * [xenopsd-ng](https://github.com/xcp-ng/xenopsd-ng) (Xen)
 * Virtio support (platform)
 
-## 🏁 Done {#done}
+## :checkered_flag: Done {#done}
 
 * SMAPIv3 full ZFS driver
 * Faster Xen Motion (compression in `xenops`?)
@@ -79,7 +79,7 @@ _Features that are being discussed or designed, but not even partly coded._
 * Upgrade detection and upgrade with updater plugin (2018)
 * Extra package repo (2018)
 
-## 🗃️ Backlog {#backlog}
+## :card_file_box: Backlog {#backlog}
 
 _This is a kind of wish list, without any priorities, where we try to put some ideas._
 

--- a/docs/project/security.md
+++ b/docs/project/security.md
@@ -6,7 +6,7 @@ We are using Xen as our core hypervisor engine, which is a huge collaboration pr
 
 Because XCP-ng is made of a lot of various components, we are relying on multiple sources to improve the security and fixing flaws.
 
-## 🐼 Xen Project security {#xen-project-security}
+## :panda_face: Xen Project security {#xen-project-security}
 
 XCP-ng project is member of the Xen Predisclosure list since 2018, which is including a lot of huge cloud players, but also companies working in critical IT security, industries and so on. The whole list is public and [available here](https://xenproject.org/developers/security-policy/#organizations-on-the-pre-disclosure-list), where you can see our name.
 
@@ -36,12 +36,12 @@ XSAs are "Xen Security Advisory". They are -in general- linked to a CVE. You can
 ![Xen Fu Panda, sitting, with a straw hat and a bamboo stick.](../../assets/img/xenpanda.png)
 </div>
 
-## 🚀 Platform security {#platform-security}
+## :rocket: Platform security {#platform-security}
 
 XCP-ng code base is close to Citrix Hypervisor, and for that reason, we are integrating Citrix security patches very quickly into XCP-ng. We are also posting very often updates and explanation on each security patches available. You can see this list at this place: [https://xcp-ng.org/blog/tag/security/](https://xcp-ng.org/blog/tag/security/)
 
 However, it's more and more plausible that flaws might be discovered first on XCP-ng instead of Citrix Hypervisor. In that case, please see below.
 
-## 🔒 Report a security flaw {#report-a-security-flaw}
+## :lock: Report a security flaw {#report-a-security-flaw}
 
 To ensure an efficient security process for XCP-ng, we are open to security reports with our dedicated email: security at this domain name.

--- a/docs/releases/release-8-1.md
+++ b/docs/releases/release-8-1.md
@@ -12,7 +12,7 @@ XCP-ng 8.1 is EOL (End Of Life) since 2021. Please check the [currently supporte
 
 SHA256 checksums, GPG signatures and net-install ISO are available [here](http://mirrors.xcp-ng.org/isos/8.1/).
 
-## ℹ️ Release information {#release-information}
+## :information_source: Release information {#release-information}
 
 * Released on 2020-03-31.
 * Based on Citrix Hypervisor 8.1.
@@ -20,10 +20,10 @@ SHA256 checksums, GPG signatures and net-install ISO are available [here](http:/
 * [Xen 4.13](https://wiki.xenproject.org/wiki/Xen_Project_4.13_Feature_List).
 * Kernel 4.19, with patches. Latest kernel hotfix from CH 8.1 at the date of release included in the release.
 
-## 💿 Install {#install}
+## :cd: Install {#install}
 See [Installation](../../installation/install-xcp-ng).
 
-## ⬆️ Upgrade from previous releases {#upgrade-from-previous-releases}
+## :arrow_up: Upgrade from previous releases {#upgrade-from-previous-releases}
 
 Since XCP-ng 8.1.0 is a minor release, both upgrade methods are supported:
 * From the installation ISO
@@ -31,7 +31,7 @@ Since XCP-ng 8.1.0 is a minor release, both upgrade methods are supported:
 
 Refer to the [Upgrade Howto](../../installation/upgrade).
 
-## ✨ What changed since 8.0 {#what-changed-since-80}
+## :sparkles: What changed since 8.0 {#what-changed-since-80}
 
 ### Highlight from Citrix Hypervisor changes
 
@@ -107,7 +107,7 @@ However we have updated the [documentation about the guest tools](../../../vms),
 
 * Fixed netxtreme drivers (`bnx2x` module) that crashed with some models.
 
-## ⛑️ Misc {#misc}
+## :rescue_worker_helmet: Misc {#misc}
 
 ### Announcement about our former experimental ext4 SR driver
 
@@ -154,7 +154,7 @@ See "Destroy and re-create a local SR" below.
     * Example: `xe sr-create type=ext name-label="Local EXT storage" host-uuid=c9800783-5202-4ccb-87fd-ff8ced6c935f device-config:device=/dev/sdb`
 * When you have handled all the servers of the pool, then for each host, if you had installed the `sm-additional-drivers` package, remove it (unless you also have XFS SRs): `yum remove sm-additional-drivers xfsprogs`.
 
-## 🐞 Known issues {#known-issues}
+## :beetle: Known issues {#known-issues}
 
 ### Host unreachable - NVIDIA GPU
 

--- a/docs/releases/release-8-2.md
+++ b/docs/releases/release-8-2.md
@@ -18,7 +18,7 @@ SHA256 checksums, GPG signatures and net-install ISO are available [here](https:
 LTS means **Long Term Support**: more information in [this section](../#lts-releases).
 :::
 
-## ℹ️ Release information {#release-information}
+## :information_source: Release information {#release-information}
 
 * Released on 2020-11-18
 * Based on Citrix Hypervisor 8.2
@@ -27,11 +27,11 @@ LTS means **Long Term Support**: more information in [this section](../#lts-rele
 * Kernel 4.19 + patches
 * Supported until 2025-09-16 (The initial EOL date was 2025-06-05, and we extended it to provide more time to upgrade to XCP-ng 8.3 LTS)
 
-## 💿 Install {#install}
+## :cd: Install {#install}
 
 See [Installation](../../../installation/install-xcp-ng).
 
-## ⬆️ Upgrade from previous releases {#upgrade-from-previous-releases}
+## :arrow_up: Upgrade from previous releases {#upgrade-from-previous-releases}
 
 Despite being an LTS, you can upgrade from previous releases. Both upgrade methods are supported:
 * From the installation ISO
@@ -39,7 +39,7 @@ Despite being an LTS, you can upgrade from previous releases. Both upgrade metho
 
 Refer to the [Upgrade Howto](../../../installation/upgrade).
 
-## ✨ What changed since 8.1 {#what-changed-since-81}
+## :sparkles: What changed since 8.1 {#what-changed-since-81}
 
 ### Highlight from Citrix Hypervisor changes
 
@@ -161,7 +161,7 @@ Plans are laid out for simpler installation and maintenance of Windows guest too
 
 Using the Windows guest tools is [documented here](/vms#windows-guest-tools).
 
-## 🆕 Update: what's new in XCP-ng 8.2.1 {#update-whats-new-in-xcp-ng-821}
+## :new: Update: what's new in XCP-ng 8.2.1 {#update-whats-new-in-xcp-ng-821}
 
 XCP-ng 8.2.1 was released as a maintenance update for XCP-ng 8.2 LTS, which has its own version number because it also comes with updated installation images.
 
@@ -171,7 +171,7 @@ The update brought a few enhancements such as [Guest Secure Boot](../../guides/g
 
 They are detailed in the [Release announcement for XCP-ng 8.2.1](https://xcp-ng.org/blog/2022/02/28/xcp-ng-8-2-1-update/).
 
-## 🐞 Known issues {#known-issues}
+## :beetle: Known issues {#known-issues}
 
 ### `yum update` from within a VNC console
 

--- a/docs/releases/release-8-3.md
+++ b/docs/releases/release-8-3.md
@@ -13,7 +13,7 @@ SHA256 checksums, GPG signatures, and the net-install ISO are available [here](h
 LTS means **Long Term Support**: more information in [this section](../#lts-releases).
 :::
 
-## 🗺️ Structure of the document {#structure-of-the-document}
+## :world_map: Structure of the document {#structure-of-the-document}
 
 * [Release information](#release-information)
 * [What's new](#whats-new)
@@ -22,7 +22,7 @@ LTS means **Long Term Support**: more information in [this section](../#lts-rele
 * [Attention points](#attention-points) - Highly recommended read before upgrading.
 * [Known issues](#known-issues)
 
-## ℹ️ Release information {#release-information}
+## :information_source: Release information {#release-information}
 
 For this release, the product lifecycle has changed:
 * A longer preview phase, enabling broad user feedback, now ended.
@@ -38,11 +38,11 @@ Key details:
 * LTS since 2025-06-16.
 * Supported until 2028-11-30.
 
-## 💿 Install {#install}
+## :cd: Install {#install}
 
 See [Installation](../../../installation/install-xcp-ng).
 
-## ⬆️ Upgrade from previous releases {#upgrade-from-previous-releases}
+## :arrow_up: Upgrade from previous releases {#upgrade-from-previous-releases}
 
 Upgrading to XCP-ng 8.3 is possible from:
 - An up-to-date XCP-ng 8.2.1 (recommended)
@@ -62,7 +62,7 @@ Refer to the [Upgrade How-to](../../../installation/upgrade) for the exact upgra
 Users who installed a prerelease of XCP-ng 8.3 must upgrade to the final 8.3.0 version using the installation ISO image. The only exception is for users who installed XCP-ng 8.3 RC2 or have already upgraded to RC2 using the installation ISO image. These users can simply [update their system](../../management/updates) without needing the ISO image.
 :::
 
-## ✨ What's new {#whats-new}
+## :sparkles: What's new {#whats-new}
 
 XCP-ng 8.3 is the result of years of development on XCP-ng, XenServer, and common open-source foundations such as the Xen Project.
 
@@ -297,7 +297,7 @@ This feature was enabled through API enhancements and is already functional in t
 
 ### Enhanced coalesce detection [XS + Xen Orchestra]
 
-Thanks to improvements in the storage API reporting, Xen Orchestra can now display more details, such as whether an SR is performing a coalesce operation (Gear⚙️ icon).
+Thanks to improvements in the storage API reporting, Xen Orchestra can now display more details, such as whether an SR is performing a coalesce operation (Gear:gear: icon).
 
 ![XO storage tab showing a coalesce in progress by a gear icon next to the SR.](../assets/img/xo-coalesce.png)
 
@@ -349,11 +349,11 @@ We've also invested heavily in test automation to improve coverage. Nevertheless
 
 - [Alternate kernel](../../installation/hardware#alternate-kernel) updated to version 4.19.316 (as of XCP-ng 8.3 release).
 - New [alternate driver packages](../../installation/hardware#alternate-drivers): `intel-i40e-alt`, `intel-ice-alt`, `tg3-module-alt`, and `mlx4-modules-alt`. Various other alternate driver packages were also updated. See [XCP-ng Drivers](https://github.com/xcp-ng/xcp/wiki/Drivers).
-- `zfs` updated to version 2.1.15. ⚠️ Existing ZFS pools may need to be upgraded using `zpool upgrade`. Check ZFS documentation.
+- `zfs` updated to version 2.1.15. :warning: Existing ZFS pools may need to be upgraded using `zpool upgrade`. Check ZFS documentation.
 - `netdata` updated to version 1.44.3.
 - `lsscsi` added to the XCP-ng repositories.
 
-## 🗄️ Status of XOSTOR in XCP-ng 8.3 {#status-of-xostor-in-xcp-ng-83}
+## :file_cabinet: Status of XOSTOR in XCP-ng 8.3 {#status-of-xostor-in-xcp-ng-83}
 
 As of the initial release, XOSTOR (our hyperconverged storage solution based on LINSTOR) was available in XCP-ng 8.3 but was still considered **beta**.
 
@@ -361,7 +361,7 @@ Since 2025-06-16, XOSTOR is officially supported on XCP-ng 8.3, as long as it is
 
 A [specific upgrade process](../../xostor/#upgrade) is available for pools running XCP-ng 8.2.1 with XOSTOR.
 
-## 🗑️ Deprecations and removals {#deprecations-and-removals}
+## :wastebasket: Deprecations and removals {#deprecations-and-removals}
 
 ### PV virtualization mode
 
@@ -438,7 +438,7 @@ So here it's not really a removal. XenServer replaced the component used for Act
 
 We deleted the old, unsupported since XCP-ng 8.1, experimental EXT4 driver, superseded by the regular EXT driver (which also uses `ext4`). We're talking about an old experimental driver that you never used unless you installed the experimental packages in the XCP-ng 7.x era, so this removal is painless for the vast majority of XCP-ng users, if not all!
 
-## ⚠️ Attention points {#attention-points}
+## :warning: Attention points {#attention-points}
 
 Important changes or adjustments that may affect how you use the product. Be sure to review these to avoid unexpected behavior.
 
@@ -489,7 +489,7 @@ You will also need to disable Secure Boot in the VM settings if it was enforced.
 
 See [Active Directory in XCP-ng](#active-directory-in-xcp-ng).
 
-## 🐞 Known issues {#known-issues}
+## :beetle: Known issues {#known-issues}
 
 ### IPv6-related issues
 

--- a/docs/releases/releases.md
+++ b/docs/releases/releases.md
@@ -1,6 +1,6 @@
 # Releases
 
-## 📜 XCP-ng Release History {#xcp-ng-release-history}
+## :scroll: XCP-ng Release History {#xcp-ng-release-history}
 
 | Version                   | Released   | Status               | Support until                                | Release notes                        |
 | ---                       | ---        | ---                  | ---                                          | ---                                  |
@@ -14,7 +14,7 @@
 
 (*) Support for XCP-ng 8.2 LTS was extended for a short period to ensure a three-month gap between the official LTS release of XCP-ng 8.3 and the end of support for XCP-ng 8.2 LTS.
 
-## 🟢 LTS Releases {#lts-releases}
+## :green_circle: LTS Releases {#lts-releases}
 
 *Latest LTS: [XCP-ng 8.3](release-8-3.md)*
 
@@ -47,7 +47,7 @@ gantt
     XCP-ng 8.2 LTS         :2024-08-30, 1y
 ```
 
-## 🟡 Standard Release {#standard-release}
+## :yellow_circle: Standard Release {#standard-release}
 
 *Latest: [XCP-ng 8.3](release-8-3.md) (somehow)*
 
@@ -68,7 +68,7 @@ XCP-ng 9.0 might follow the same path.
 :::
 
 
-## 🔴 Pre Releases {#pre-releases}
+## :red_circle: Pre Releases {#pre-releases}
 
 Using a pre-release is relevant only for testing purposes. Check [the `Release` tag on our blog](https://xcp-ng.org/blog/tag/release/) for (pre-)release announcements.
 

--- a/docs/storage/manage-srs.md
+++ b/docs/storage/manage-srs.md
@@ -10,7 +10,7 @@ Everyday operations on storage repositories (SRs) and virtual disks (VDIs): rena
 All of these operations are available from [Xen Orchestra](../management/manage-at-scale/xo-web-ui.md) with a few clicks (SR view and VM → Disks tab). The `xe` commands are given for scripting, troubleshooting, or when you work directly on a host.
 :::
 
-## 🎓 Quick recap of the objects {#quick-recap-of-the-objects}
+## :mortar_board: Quick recap of the objects {#quick-recap-of-the-objects}
 
 * **SR** (Storage Repository): where virtual disks live.
 * **VDI** (Virtual Disk Image): one virtual disk.
@@ -67,7 +67,7 @@ All of these operations are available from [Xen Orchestra](../management/manage-
 
 More details in the [storage overview](storage.md) and in the [architecture page](../project/architecture.md#storage).
 
-## 📇 SR operations {#sr-operations}
+## :card_index: SR operations {#sr-operations}
 
 ### Rename an SR
 
@@ -150,7 +150,7 @@ xe sr-probe type=nfs device-config:server=<ip>
 
 The command answers in XML, listing what to feed into the next step (or into `sr-introduce` when [reattaching](#reattach-a-forgotten-sr)).
 
-## 💾 VDI operations {#vdi-operations}
+## :floppy_disk: VDI operations {#vdi-operations}
 
 ### Find your disks
 
@@ -211,7 +211,7 @@ xe vdi-import uuid=<destination-vdi-uuid> filename=disk.vhd format=vhd
 
 (For `vdi-import`, create the destination VDI first, at least as big as the source.)
 
-## 🧹 Reclaim space {#reclaim-space}
+## :broom: Reclaim space {#reclaim-space}
 
 Deleting VMs, disks and snapshots frees space:
 
@@ -225,7 +225,7 @@ xe host-call-plugin host-uuid=<host-uuid> plugin=trim fn=do_trim args:sr_uuid=<s
 
 If space doesn't come back after deleting snapshots, the coalesce process probably hasn't finished (or is stuck): see the [coalesce section](storage.md#coalesce) to check its status.
 
-## ⚙️ Disk I/O tuning {#disk-io-tuning}
+## :gear: Disk I/O tuning {#disk-io-tuning}
 
 The dom0 I/O scheduler used for an SR's physical devices can be changed if you have a specific workload profile (default is fine for most cases):
 

--- a/docs/storage/multipathing.md
+++ b/docs/storage/multipathing.md
@@ -16,7 +16,7 @@ Do not attempt to enable multipathing on a production pool with existing and act
 You can activate it on the "fly", per XCP-ng host (Advanced tab), but it is recommended to do so with XCP-ng hosts that have no VMs running.
 :::
 
-## 🌐 iSCSI {#iscsi}
+## :globe_with_meridians: iSCSI {#iscsi}
 
 ### Requirements
 * Two different network interfaces.
@@ -41,8 +41,8 @@ This could have an impact on expected performance.
 #### Configuration example
 | Path | Vlan | Subnet | XCP-ng Host PIF address | Storage Controller 1 address | Storage Controller 2 address |
 | :---: | :---: | :---: | :---: | :---: | :---: |
-| 🔵 | 421 | 10.42.1.0/24 | 10.42.1.11 | 10.42.1.101 | 10.42.1.102 |
-| 🟢 | 422 | 10.42.2.0/24 | 10.42.2.11 | 10.42.2.101 | 10.42.2.102 |
+| :large_blue_circle: | 421 | 10.42.1.0/24 | 10.42.1.11 | 10.42.1.101 | 10.42.1.102 |
+| :green_circle: | 422 | 10.42.2.0/24 | 10.42.2.11 | 10.42.2.101 | 10.42.2.102 |
 
 #### Target architecture diagram
 
@@ -155,7 +155,7 @@ If this is not the case:
 #### 3. Configure the SR
 Proceed with the iSCSI SR configuration as indicated in the [storage documentation](../../storage/#iscsi).
 
-## 🧵 Fibre Channel (HBA) {#fibre-channel-hba}
+## :thread: Fibre Channel (HBA) {#fibre-channel-hba}
 ### Requirements
 * Check that the Fibre Channel cards model(s) is supported via the [HCL](../../installation/hardware/#hardware-compatibility-list-hcl).
 * Two different Fibre Channel ports.
@@ -272,7 +272,7 @@ If this is not the case:
 Proceed with the HBA SR configuration as indicated in the [storage documentation](../../storage/#hba).
 
 
-## 🔧 Maintenance operations {#maintenance-operations}
+## :wrench: Maintenance operations {#maintenance-operations}
 ### Add a new XCP-ng host to an existing multipathing pool
 
 :::warning
@@ -283,7 +283,7 @@ Do not add the new XCP-ng host to the pool without completing these steps.
 2. Ensure that the iSCSI PIF configuration is completed if you are using iSCSI.
 3. Add the new XCP-ng host to the pool.
 
-## 🧑‍⚕️ Troubleshooting {#troubleshooting}
+## :health_worker: Troubleshooting {#troubleshooting}
 
 ### Verify multipathing
 You can use the command ```multipath -ll``` to check if multipathing is active.

--- a/docs/storage/qcow2_faq.md
+++ b/docs/storage/qcow2_faq.md
@@ -4,11 +4,11 @@ sidebar_position: 4
 
 # QCOW2 FAQ
 
-## 🎓 What’s QCOW2? {#whats-qcow2}
+## :mortar_board: What’s QCOW2? {#whats-qcow2}
 
 QCOW2 is the name of a virtual disk image format coming from the open source QEMU project. Contrarily to the VHD disk image format, historically used by XCP-ng, QCOW2 is not limited to 2 TiB per disk.
 
-## ⚡ Quick summary {#quick-summary}
+## :zap: Quick summary {#quick-summary}
 
 For those who will only read this.
 
@@ -18,13 +18,13 @@ For those who will only read this.
 - Not needed to create a new SR to create QCOW2 disks. A SR can have QCOW2 and VHD co-existing.
 - VHD stays the default for now, a QCOW2 disk will automatically be created when asking for the creation of a VDI bigger than 2040GiB.
 
-## 📚 Glossary {#glossary}
+## :books: Glossary {#glossary}
 
 - VDI: Virtual Disk Image. This is a VM’s disk, seen from the hypervisor.
 - SR: Storage Repository. Storage space managed by XCP-ng to store VDIs.
 - image format: there exist several formats to store a VM disk’s data. VHD, QCOW2 and VMDK are all such image formats. Historically, XCP-ng only supported the VHD image format (as well as raw data, which means no image format). It now supports a new image format in addition to VHD: QCOW2.
 
-## 🖼️ About image formats {#about-image-formats}
+## :framed_picture: About image formats {#about-image-formats}
 
 Before entering the FAQ itself, let's talk about image formats.
 
@@ -60,7 +60,7 @@ In order to unplug the PBD, any VMs with a VDI on the SR will have to be stopped
 This operation will not affect the contents of the SR. The PDB object represents the connection to the SR, not its contents.
 
 
-## ❓ FAQ {#faq}
+## :question: FAQ {#faq}
 
 Now let's enter the FAQ itself.
 

--- a/docs/storage/storage.md
+++ b/docs/storage/storage.md
@@ -22,7 +22,7 @@ Please take into consideration, that Xen API (XAPI) via their storage module (`S
 We encourage people to use file based SR (local ext, NFS, XOSTOR…) because it's easier to deal with. If you want to know more, read the rest.
 :::
 
-## 📑 Storage types {#storage-types}
+## :bookmark_tabs: Storage types {#storage-types}
 
 There are two types of storage:
 
@@ -452,7 +452,7 @@ yum install moosefs-client
 :::tip
 - By default, the `moosefs` storage driver is not enabled and must be whitelisted in XAPI's configuration.
 - The list of accepted storage drivers is defined in `/etc/xapi.conf` but we must *never* modify this file directly. Instead, copy the `sm-plugins` definition from it, add `moosefs` to the line, and write the resulting line to a new `/etc/xapi.conf.d/99-enable-moosefs.conf` file.
-- ⚠️ XAPI only takes the last definition of `sm-plugins` it reads into account. Files are read in alphabetical order. If there's already a configuration file in `/etc/xapi.conf.d` (to enable another additional storage driver), take it into consideration when you write your new definition of `sm-plugins`.
+- :warning: XAPI only takes the last definition of `sm-plugins` it reads into account. Files are read in alphabetical order. If there's already a configuration file in `/etc/xapi.conf.d` (to enable another additional storage driver), take it into consideration when you write your new definition of `sm-plugins`.
 :::
 
 Now when the MooseFS client is installed you can connect to an existing [MooseFS cluster](https://moosefs.com/support/#documentation) and create a shared SR for all hosts in the pool.
@@ -659,7 +659,7 @@ xe sr-create host-uuid=<host UUID> type=largeblock content-type=user name-label=
 The largeblock SR creates a translation layer to align the device on 512 sector size using a loop device and creates a EXT SR on this emulated device.
 It's needed to work around an issue with VHD alignment that creates an error on VHD creation on the native 4KiB device.
 
-## 💿 ISO SR {#iso-sr}
+## :cd: ISO SR {#iso-sr}
 
 You might be wondering how to upload an ISO. Unlike other solutions, you need to create a dedicated "space" for these, a specific ISO SR. To create an ISO SR, you have 2 possibilities:
 - Shared: A shared ISO SR is on a VM or on a dedicated storage server. It's accessible with an IP address, like 192.168.1.100 via SMB or NFS.
@@ -717,7 +717,7 @@ That's it!
 Don't forget to rescan your SR after adding, changing, or deleting ISO files. Rescan is done automatically every 10 minutes otherwise.
 :::
 
-## 📡 Storage API {#storage-api}
+## :satellite: Storage API {#storage-api}
 
 Current storage stack on XCP-ng is called `SMAPIv1`. The VHD format is used, which has a maximum file size limitation of 2TiB. This means that when using this format your VM disk can't be larger than 2TiB.
 
@@ -756,7 +756,7 @@ You won't be able to live migrate storage on this disk or snapshot it anymore. O
 
 Also, the storage API is far more agnostic and the code is better. So what's the catch? Problem is there's no Open Source implementation of `SMAPIv3`, also the current API state isn't really complete (doesn't support a lot of features). However, XCP-ng team is working on it too, because it's clearly the future!
 
-## 🪄 Coalesce {#coalesce}
+## :magic_wand: Coalesce {#coalesce}
 
 Coalesce process is an operation happening in your hosts as soon a snapshot is removed.
 
@@ -793,7 +793,7 @@ But more than that, Xen Orchestra is also able to show you uncoalesced disk in t
 
 More about this exclusive feature on [https://xen-orchestra.com/blog/xenserver-coalesce-detection-in-xen-orchestra/](https://xen-orchestra.com/blog/xenserver-coalesce-detection-in-xen-orchestra/)
 
-## 🦮 How to modify an existing SR connection {#how-to-modify-an-existing-sr-connection}
+## :guide_dog: How to modify an existing SR connection {#how-to-modify-an-existing-sr-connection}
 
 The link between a host and an SR is called the `PBD`. A PBD basically stores **how** to access a storage repository (like the path to the drive or to an NFS share).
 

--- a/docs/troubleshooting/advanced.md
+++ b/docs/troubleshooting/advanced.md
@@ -2,7 +2,7 @@
 
 Techniques for the hard cases: a host that doesn't boot, kernel or hypervisor crashes, and getting diagnostics out of a machine you can barely reach. For everyday issues, start with the [3-Step-Guide](troubleshooting.md) and the [log files page](log-files.md).
 
-## 🧵 Serial console access {#serial-console-access}
+## :thread: Serial console access {#serial-console-access}
 
 When the network is down or the host hangs at boot, a serial console is often the only way in. Most servers expose it through the BMC (Serial-over-LAN with iDRAC, iLO, IPMI `ipmitool sol activate`...), which makes it usable remotely.
 
@@ -24,7 +24,7 @@ systemctl enable --now serial-getty@hvc0.service
 
 `xen-cmdline` edits the boot configuration for both BIOS and UEFI installs, so you don't have to touch `grub.cfg` by hand.
 
-## ⚙️ Xen boot options {#xen-boot-options}
+## :gear: Xen boot options {#xen-boot-options}
 
 The same `xen-cmdline` tool manages the hypervisor's boot parameters:
 
@@ -36,7 +36,7 @@ The same `xen-cmdline` tool manages the hypervisor's boot parameters:
 
 Raising `loglvl`/`guest_loglvl` to `all` is the classic first step when chasing hypervisor-level problems: it makes `xl dmesg` much more talkative. Only add options you understand (or that support/developers asked for): a wrong hypervisor parameter can make the host unbootable, which is exactly what the serial console above is for.
 
-## 🔍 Reading the hypervisor state {#reading-the-hypervisor-state}
+## :mag: Reading the hypervisor state {#reading-the-hypervisor-state}
 
 * `xl dmesg`: the Xen hypervisor's own log ring (distinct from dom0's `dmesg`). Hardware issues, IOMMU errors and guest faults often show up only here.
 * `xl info`: hypervisor version, memory, capabilities.
@@ -48,7 +48,7 @@ xl debug-keys m     # dump memory information
 xl debug-keys h     # list all available keys in xl dmesg
 `}</Terminal>
 
-## 💥 Host crashes and crash dumps {#host-crashes-and-crash-dumps}
+## :boom: Host crashes and crash dumps {#host-crashes-and-crash-dumps}
 
 If the host crashes at the kernel or hypervisor level, a crash dump is saved in `/var/crash` at the following reboot (see [kernel crash logs](log-files.md#kernel-crash-logs)). List them also via XAPI:
 
@@ -58,13 +58,13 @@ xe host-crashdump-list
 
 When reporting such a crash (forum or support), provide the crash dump contents along with a [status report](log-files.md#produce-a-status-report). Crash dumps live on the boot disk: don't let them accumulate, `xe host-crashdump-destroy uuid=<uuid>` cleans them up once analyzed.
 
-## 🥾 When the host doesn't boot {#when-the-host-doesnt-boot}
+## :hiking_boot: When the host doesn't boot {#when-the-host-doesnt-boot}
 
 1. At the boot menu, try the **fallback entries** (previous kernel version) if an update or driver change preceded the failure. See also [after upgrade troubleshooting](after-upgrade.md).
 2. Watch the boot on the serial console (above) or the BMC's remote screen: the last messages usually name the culprit (storage driver, network driver...).
 3. You can boot the [installation ISO](installation-upgrade.md) and use its shell for repairs: your root filesystem can be mounted from there (the installer's rescue capabilities are also usable over [remote access during installation](installation-upgrade.md#getting-remote-access-to-host-during-installation)).
 4. For RAID-related boot failures, see [software RAID issues](storage/disk-failure-software-RAID.md).
 
-## 🆘 Produce a status report {#produce-a-status-report}
+## :sos: Produce a status report {#produce-a-status-report}
 
 When asking for help, generate a status report archive containing logs and configuration: see [the procedure](log-files.md#produce-a-status-report). Mention exactly what you changed last: most "impossible" host issues follow a recent change.

--- a/docs/troubleshooting/after-upgrade.md
+++ b/docs/troubleshooting/after-upgrade.md
@@ -1,6 +1,6 @@
 # After Upgrade
 
-## 🔧 The Server stays in Maintenance Mode {#the-server-stays-in-maintenance-mode}
+## :wrench: The Server stays in Maintenance Mode {#the-server-stays-in-maintenance-mode}
 
 ### Causes and Solutions
 * You enabled the maintenance mode and forgot about it.
@@ -14,7 +14,7 @@
 
 ***
 
-## 🙅 Some of my VMs do not start {#some-of-my-vms-do-not-start}
+## :no_good_woman: Some of my VMs do not start {#some-of-my-vms-do-not-start}
 
 With the following error: "This operation cannot be performed because the specified virtual disk could not be found."
 
@@ -26,7 +26,7 @@ Eject the ISO on those VMs.
 
 ***
 
-## 💔 Missing scripts/tools after upgrade {#missing-scriptstools-after-upgrade}
+## :broken_heart: Missing scripts/tools after upgrade {#missing-scriptstools-after-upgrade}
 
 ### Cause
 
@@ -39,7 +39,7 @@ To access the backup (with all your tools and modifications) just mount the back
 
 ***
 
-## 🐛 After upgrading my XCP-ng host is unstable, network card freezes, kernel errors, etc. {#after-upgrading-my-xcp-ng-host-is-unstable-network-card-freezes-kernel-errors-etc}
+## :bug: After upgrading my XCP-ng host is unstable, network card freezes, kernel errors, etc. {#after-upgrading-my-xcp-ng-host-is-unstable-network-card-freezes-kernel-errors-etc}
 
 ### Causes and Solutions
 

--- a/docs/troubleshooting/common-problems.md
+++ b/docs/troubleshooting/common-problems.md
@@ -4,7 +4,7 @@ Here is a list of common problems.
 
 ---
 
-## 🖥️ Blank screen (on a Linux VM) {#blank-screen-on-a-linux-vm}
+## :desktop_computer: Blank screen (on a Linux VM) {#blank-screen-on-a-linux-vm}
 
 ### Cause
 
@@ -32,7 +32,7 @@ Blacklist the problematic driver ([source](https://xcp-ng.org/forum/post/1707)):
 
 ---
 
-## 🧬 Initrd is missing after an update {#initrd-is-missing-after-an-update}
+## :dna: Initrd is missing after an update {#initrd-is-missing-after-an-update}
 
 ### Cause
 
@@ -52,7 +52,7 @@ Here is an example of `dracut` command on a 8.3 host: `dracut -f /boot/initrd-4.
 
 ---
 
-## 🔌 VM not in expected power state {#vm-not-in-expected-power-state}
+## :electric_plug: VM not in expected power state {#vm-not-in-expected-power-state}
 
 ### Cause
 
@@ -64,7 +64,7 @@ Restart toolstack on CLI with the command `xe-toolstack-restart`. This just rest
 
 ---
 
-## 🪪 Host and Pool have incompatible Licenses {#host-and-pool-have-incompatible-licenses}
+## :identification_card: Host and Pool have incompatible Licenses {#host-and-pool-have-incompatible-licenses}
 
 ### Cause
 
@@ -76,7 +76,7 @@ To solve this, simply get your pool "coherent" and do not mix products. Ensure a
 
 ---
 
-## 🔄 Rebooting hangs the server {#rebooting-hangs-the-server}
+## :arrows_counterclockwise: Rebooting hangs the server {#rebooting-hangs-the-server}
 
 ### Cause
 
@@ -92,7 +92,7 @@ Try these steps:
 
 ---
 
-## ⏰ Server loses time on 14th gen Dell hardware {#server-loses-time-on-14th-gen-dell-hardware}
+## :alarm_clock: Server loses time on 14th gen Dell hardware {#server-loses-time-on-14th-gen-dell-hardware}
 
 ### Cause
 
@@ -119,7 +119,7 @@ chmod +x /etc/rc.d/rc.local
 
 ---
 
-## 🐌 Async Tasks/Commands Hang or Execute Extremely Slowly {#async-taskscommands-hang-or-execute-extremely-slowly}
+## :snail: Async Tasks/Commands Hang or Execute Extremely Slowly {#async-taskscommands-hang-or-execute-extremely-slowly}
 
 ### Cause
 
@@ -135,7 +135,7 @@ This symptom can be caused by a variety of issues including RAID degradation, ag
 
 ---
 
-## 🌐 TCP Offload checksum errors {#tcp-offload-checksum-errors}
+## :globe_with_meridians: TCP Offload checksum errors {#tcp-offload-checksum-errors}
 
 ### Cause
 
@@ -168,7 +168,7 @@ The PIF UUID can be found by executing:
 
 ---
 
-## 🐢 TCP Segmentation Offload (TSO) decreasing performances {#tcp-segmentation-offload-tso-decreasing-performances}
+## :turtle: TCP Segmentation Offload (TSO) decreasing performances {#tcp-segmentation-offload-tso-decreasing-performances}
 
 ### Cause
 
@@ -195,7 +195,7 @@ xe pif-plug uuid=$PIFUUID
 If working on a pool, you can set this for all the PIFs of the pool from a single host as `xe pif-list` will show all the PIFs of the pool. You can then do a "Rolling Pool Reboot" in XO from your pool page, in the advanced tab.
 :::
 
-## 🔑 Reset XCP-ng root password {#reset-xcp-ng-root-password}
+## :key: Reset XCP-ng root password {#reset-xcp-ng-root-password}
 
 ### Cause
 
@@ -213,7 +213,7 @@ After the password has been set, please place a copy somewhere safe and delete t
 
 ---
 
-## 🗄️ XenStore related issues {#xenstore-related-issues}
+## :file_cabinet: XenStore related issues {#xenstore-related-issues}
 
 ### Cause
 
@@ -227,7 +227,7 @@ The `XENSTORED_TRACE` being enabled might give useful information.
 
 ---
 
-## 🥾 Ubuntu 18.04 boot issue {#ubuntu-1804-boot-issue}
+## :hiking_boot: Ubuntu 18.04 boot issue {#ubuntu-1804-boot-issue}
 
 ### Cause
 
@@ -245,7 +245,7 @@ Alternatively, in a fresh Ubuntu 18.04 install, you can switch to UEFI and you w
 
 ---
 
-## 📋 Missing templates when creating a new VM {#missing-templates-when-creating-a-new-vm}
+## :clipboard: Missing templates when creating a new VM {#missing-templates-when-creating-a-new-vm}
 
 ### Cause
 
@@ -263,7 +263,7 @@ This should recreate all the templates.
 
 ---
 
-## ♻️ The updater plugin is busy {#the-updater-plugin-is-busy}
+## :recycle: The updater plugin is busy {#the-updater-plugin-is-busy}
 
 ### Cause
 
@@ -282,7 +282,7 @@ Remove `/var/lib/xcp-ng-xapi-plugins/updater.py.lock` and that should fix it.
 
 ---
 
-## 🚚 Unable to live migrate VDI between SRs {#unable-to-live-migrate-vdi-between-srs}
+## :truck: Unable to live migrate VDI between SRs {#unable-to-live-migrate-vdi-between-srs}
 
 ### Cause
 
@@ -309,7 +309,7 @@ To know more about certificates in XAPI, check out the [XAPI documentation](http
 
 ---
 
-## ⌨️ Installation hanging at "Select Keymap" {#installation-hanging-at-select-keymap}
+## :keyboard: Installation hanging at "Select Keymap" {#installation-hanging-at-select-keymap}
 
 ### Issue
 

--- a/docs/troubleshooting/installation-upgrade.md
+++ b/docs/troubleshooting/installation-upgrade.md
@@ -2,7 +2,7 @@
 
 Upgrade here designates an upgrade using the installation ISO
 
-## 💥 If the installer starts booting up then crashes or hangs {#if-the-installer-starts-booting-up-then-crashes-or-hangs}
+## :boom: If the installer starts booting up then crashes or hangs {#if-the-installer-starts-booting-up-then-crashes-or-hangs}
 
 * First of all check the integrity of the ISO image you downloaded, using the provided checksum
 * Try the other boot options
@@ -35,7 +35,7 @@ Stricter memory map verification rules introduced in modern Xen/Dom0 kernels cla
    * Set **Lower Memory Mapped I/O Base** to `Enabled` (or `512GB`).
 3. **Clear NVRAM Cruft:** Go into the **UEFI Boot Settings** -> **UEFI Boot Sequence** and delete any dead, duplicated, or orphaned boot entries from past OS installations to free up firmware space.
 
-## 🚧 During installation or upgrade {#during-installation-or-upgrade}
+## :construction: During installation or upgrade {#during-installation-or-upgrade}
 
 You can reach a shell with ALT+F2 (or ALT+RIGHT) and a logs console with ALT+F3 (or ALT+RIGHT twice).
 
@@ -73,7 +73,7 @@ You can specify an interface name such as `eth1` instead of `all` if necessary, 
 
 The ssh server will be available once the network is up. If you are unsure which DHCP address was obtained, you can use the shell console as described above to look it up using `ip a`. You can then connect as `root` using the password you provided on the commandline.
 
-## 💽 The installer reports "No Disks" but the machine has a drive {#the-installer-reports-no-disks-but-the-machine-has-a-drive}
+## :minidisc: The installer reports "No Disks" but the machine has a drive {#the-installer-reports-no-disks-but-the-machine-has-a-drive}
 
 **Cause**
 
@@ -102,7 +102,7 @@ Reach a shell with `ALT` + `F2` (see [During installation or upgrade](#during-in
 The fix above applies only when the cause is the RAID/RST controller mode. A drive can also be hidden by a storage controller whose driver is missing from the install ISO (for example some MegaRAID or `mpi3mr` adapters). That is a different problem with a different fix: load a driver disk at install time, or use an updated installer that includes the driver. A BIOS change does not help there.
 :::
 
-## 🙅 The ISO installer does not offer to upgrade the existing install (XCP-ng or XenServer) {#the-iso-installer-does-not-offer-to-upgrade-the-existing-install-xcp-ng-or-xenserver}
+## :no_good_woman: The ISO installer does not offer to upgrade the existing install (XCP-ng or XenServer) {#the-iso-installer-does-not-offer-to-upgrade-the-existing-install-xcp-ng-or-xenserver}
 
 :::note
 This section details how to deal with the most frequent causes for the installer not detecting your current installation. There can be other, rarer cases which are not detailed here.  In all cases the detailed reason for an inability to upgrade will always be possible to find in the installer log file. See [During installation or upgrade](#during-installation-or-upgrade) to access the log file.
@@ -186,12 +186,12 @@ Probe of /dev/nvme0n1 found boot=(True, '/dev/nvme0n1p4') root=(1, '/dev/nvme0n1
 
 The `/etc/xensource-inventory` file is critical to the upgrade process. This is one of the cases where the log will exhibit "A problem occurred whilst scanning for existing installations:" followed by more details.
 
-## 📜 Installation logs {#installation-logs}
+## :scroll: Installation logs {#installation-logs}
 
 On the installed system, installer logs are kept in `/var/log/installer/`.
 
 The main log file is `/var/log/installer/install-log`.
 
-## 🐛 Debugging the installer {#debugging-the-installer}
+## :bug: Debugging the installer {#debugging-the-installer}
 
 You can [build your own installer](../../project/development-process/ISO-modification).

--- a/docs/troubleshooting/log-files.md
+++ b/docs/troubleshooting/log-files.md
@@ -2,25 +2,25 @@
 
 On a XCP-ng host, like in most Linux/UNIX systems, the logs are located in `/var/log`. XCP-ng does not use `journald` for logs, so everything is in `/var/log` directly.
 
-## 📜 General log {#general-log}
+## :scroll: General log {#general-log}
 
 `/var/log/daemon.log`
 
 Output of various running daemons involved in XCP-ng's tasks. Examples: output of `xenopsd` which handles the communication with the VMs, of executables involved in live migration and storage motion, and more...
 
-## 📡 XAPI's log {#xapis-log}
+## :satellite: XAPI's log {#xapis-log}
 
 `/var/log/xensource.log`
 
 Contains the output of the XAPI toolstack.
 
-## 💽 Storage related (eg. coalescing snapshots) {#storage-related-eg-coalescing-snapshots}
+## :minidisc: Storage related (eg. coalescing snapshots) {#storage-related-eg-coalescing-snapshots}
 
 `/var/log/SMlog`
 
 Contains the output of the storage manager.
 
-## 🐧 Kernel messages {#kernel-messages}
+## :penguin: Kernel messages {#kernel-messages}
 
 For hardware related issues or system crashes.
 
@@ -28,11 +28,11 @@ For hardware related issues or system crashes.
 
 All kernel logs since last boot: type `dmesg`.
 
-## 💥 Kernel crash logs {#kernel-crash-logs}
+## :boom: Kernel crash logs {#kernel-crash-logs}
 
 In case of a host crash, if it is kernel-related, you should find logs in `/var/crash`
 
-## 📋 Produce a status report {#produce-a-status-report}
+## :clipboard: Produce a status report {#produce-a-status-report}
 
 To help someone else identify an issue or reproduce a bug, you can generate a full status report containing all log files, details about your configuration and more.
 
@@ -43,19 +43,19 @@ xen-bugtool --yestoall
 Then upload the resulting archive somewhere. It may contain sensitive information about your setup, so it may be better to upload it to a private area and give the link only to those you trust to analyze it.
 
 
-## 🪟 XCP-ng Center {#xcp-ng-center}
+## :window: XCP-ng Center {#xcp-ng-center}
 
 You can display the log files via menu `Help` -> `View XCP-ng Center Log Files`.
 
 The log files are located in `C:\Users\<user>\AppData\Roaming\XCP-ng\XCP-ng Center\logs`.
 
-## 🖥️ Windows VM {#windows-vm}
+## :desktop_computer: Windows VM {#windows-vm}
 
 ### (PV-)Driver install log
 `C:\Windows\INF\setupapi.dev.log`
 
 
-## 🔍 Useful data for debugging {#useful-data-for-debugging}
+## :mag: Useful data for debugging {#useful-data-for-debugging}
 
 ### DMAR/IVRS ACPI tables
 

--- a/docs/troubleshooting/storage/disk-failure-software-RAID.md
+++ b/docs/troubleshooting/storage/disk-failure-software-RAID.md
@@ -6,7 +6,7 @@ title: 'Software RAID issues'
 
 This page regroups the common issues you might deal with regarding software RAID.
 
-## ⏏️ Disk replacement with software RAID {#disk-replacement-with-software-raid}
+## :eject_button: Disk replacement with software RAID {#disk-replacement-with-software-raid}
 
 If XCP-ng has been installed with a *software RAID 1 full disk mirror* method, a disk failure can be fixed with a disk replacement. Here's how:
 

--- a/docs/troubleshooting/storage/iscsi-troubleshooting.md
+++ b/docs/troubleshooting/storage/iscsi-troubleshooting.md
@@ -2,7 +2,7 @@
 
 This page is dedicated to common issues you might have with iSCSI.
 
-## 🎓 Basic iSCSI commands {#basic-iscsi-commands}
+## :mortar_board: Basic iSCSI commands {#basic-iscsi-commands}
 
 Discover available targets from a discovery portal:
 
@@ -46,7 +46,7 @@ Rescan a volume after expanding a LUN:
 iscsiadm -m node -p <IP_address> --rescan
 `}</Terminal>
 
-## 💓 iSCSI in storage-cluster environment {#iscsi-in-storage-cluster-environment}
+## :heartbeat: iSCSI in storage-cluster environment {#iscsi-in-storage-cluster-environment}
 
 This apply to setup using DRBD/Corosync/Pacemaker.
 

--- a/docs/troubleshooting/troubleshooting-ha.md
+++ b/docs/troubleshooting/troubleshooting-ha.md
@@ -8,7 +8,7 @@ To know more on high availability in general and how to set it up with XCP-ng, s
 
 ---
 
-## 🔄 My host rebooted. Why did it reboot? {#my-host-rebooted-why-did-it-reboot}
+## :arrows_counterclockwise: My host rebooted. Why did it reboot? {#my-host-rebooted-why-did-it-reboot}
 
 If a host configured for high availability reboots unexpectedly, it might have: 
 
@@ -17,7 +17,7 @@ If a host configured for high availability reboots unexpectedly, it might have:
 
 Check the host's logs to verify if any of these events happened, in particular `/var/log/xha.log`.
 
-## 🚨 I can't reach my host! {#i-cant-reach-my-host}
+## :rotating_light: I can't reach my host! {#i-cant-reach-my-host}
 
 ### Disabling HA
 

--- a/docs/troubleshooting/troubleshooting.md
+++ b/docs/troubleshooting/troubleshooting.md
@@ -2,18 +2,18 @@
 
 If you have a problem or a question on XCP-ng, there's 2 options: community support (mostly on [XCP-ng Forum](https://xcp-ng.org/forum)) or [pro support](https://xcp-ng.com).
 
-## 🪜 The 3-Step-Guide {#the-3-step-guide}
+## :ladder: The 3-Step-Guide {#the-3-step-guide}
 Here is our handy **3-Step-Guide**:
 
 1. Check the [logs](log-files). Check your settings. Check all the articlesbelow here. If you already did, proceed to Step 2.
 2. Get help at our [Forum](https://xcp-ng.org/forum) or get help [on Discord](https://discord.gg/Hr98F6wRvx) or [on IRC](irc://irc.oftc.net/#xcp-ng) and provide as much information as you can:
-    * ☑️ What did you **exactly** do to expose the bug?
-    * 🚀 XCP-ng Version
-    * 🖥️ Hardware
-    * 🏭 Infrastructure
-    * 📰 Logs
-    * 📺 Screenshots
-    * 🛑 Error messages
+    * :ballot_box_with_check: What did you **exactly** do to expose the bug?
+    * :rocket: XCP-ng Version
+    * :desktop_computer: Hardware
+    * :factory: Infrastructure
+    * :newspaper: Logs
+    * :tv: Screenshots
+    * :stop_sign: Error messages
 3. Share your solution on the [forum](https://xcp-ng.org/forum), others can benefit from your experience.
 
 :::tip

--- a/docs/troubleshooting/windows-pv-tools.md
+++ b/docs/troubleshooting/windows-pv-tools.md
@@ -2,7 +2,7 @@
 
 Common issues and topics related to Windows Guest Tools.
 
-## 🐌 Low storage performance on Windows {#low-storage-performance-on-windows}
+## :snail: Low storage performance on Windows {#low-storage-performance-on-windows}
 
 ### Cause
 
@@ -20,7 +20,7 @@ Consult your motherboard manual for details; for example, on Dell systems with i
 </div>
 
 
-## 🥾 Windows fails to boot (hangs, `INACCESSIBLE_BOOT_DEVICE`) {#windows-fails-to-boot-hangs-inaccessible_boot_device}
+## :hiking_boot: Windows fails to boot (hangs, `INACCESSIBLE_BOOT_DEVICE`) {#windows-fails-to-boot-hangs-inaccessible_boot_device}
 
 In some situations (failed uninstallation, major Windows version upgrades), Xen PV drivers (whether Citrix or XCP-ng) may cause Windows to fail to start (hanging at boot, BSOD with Stop code `INACCESSIBLE_BOOT_DEVICE`).
 The XenBootFix utility included with XCP-ng Windows Guest Tools 9.0 and above helps you disable any active Xen PV drivers and get your system to a bootable state before running XenClean.
@@ -54,7 +54,7 @@ Below is a procedure for using XenBootFix to recover a non-booting VM:
 7. Type `exit` to close Command Prompt. If using Windows RE, choose **Continue** to boot into Windows. Windows should now start normally.
 8. **You must immediately run XenClean from within Windows to remove the remaining Xen drivers**. See instructions above.
 
-## 🧵 Connecting to guests using serial console {#connecting-to-guests-using-serial-console}
+## :thread: Connecting to guests using serial console {#connecting-to-guests-using-serial-console}
 
 In some situations, you might want to expose a VM's serial console to network for troubleshooting purposes (e.g. Windows kernel debugging).
 You can use the following procedure:
@@ -73,7 +73,7 @@ You can use the following procedure:
   Connect using [WinDbg](https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/) using the `Attach to kernel` option with a connection string: `com:ipport=7001,port=<host IP>`
 * To undo the changes and remove the serial setting, use `xe vm-param-remove uuid=<uuid> param-name=platform param-key=hvm_serial`
 
-## 💙 BSOD 0x3B (SYSTEM_SERVICE_EXCEPTION) or 0x7E (SYSTEM_THREAD_EXCEPTION_NOT_HANDLED) on newer Intel CPUs {#bsod-0x3b-system_service_exception-or-0x7e-system_thread_exception_not_handled-on-newer-intel-cpus}
+## :blue_heart: BSOD 0x3B (SYSTEM_SERVICE_EXCEPTION) or 0x7E (SYSTEM_THREAD_EXCEPTION_NOT_HANDLED) on newer Intel CPUs {#bsod-0x3b-system_service_exception-or-0x7e-system_thread_exception_not_handled-on-newer-intel-cpus}
 
 ### Cause
 
@@ -88,7 +88,7 @@ Stop the VM, run the following command on the host then restart the VM:
 xe vm-param-add uuid=<VM's UUID> param-name=platform msr-relaxed=true
 `}</Terminal>
 
-## 💥 BSOD 0x109 (CRITICAL_STRUCTURE_CORRUPTION) after migrating VMs on Intel platforms {#bsod-0x109-critical_structure_corruption-after-migrating-vms-on-intel-platforms}
+## :boom: BSOD 0x109 (CRITICAL_STRUCTURE_CORRUPTION) after migrating VMs on Intel platforms {#bsod-0x109-critical_structure_corruption-after-migrating-vms-on-intel-platforms}
 
 ### Cause
 
@@ -110,7 +110,7 @@ Focus on the following settings (naming depends on BIOS vendor):
 - Power and thermal controls
 - Event counters
 
-## ♻️ Windows fails to boot after updating {#windows-fails-to-boot-after-updating}
+## :recycle: Windows fails to boot after updating {#windows-fails-to-boot-after-updating}
 
 ### Cause
 
@@ -126,7 +126,7 @@ bcdboot C:\Windows
 
 After exiting to Windows, your system should boot successfully.
 
-## 🤐 Windows Server 2019 crashes on AMD Zen without BSOD {#windows-server-2019-crashes-on-amd-zen-without-bsod}
+## :zipper_mouth_face: Windows Server 2019 crashes on AMD Zen without BSOD {#windows-server-2019-crashes-on-amd-zen-without-bsod}
 
 First, try disabling Viridian from Xen Orchestra. Note that this value may reset itself after reboot.
 
@@ -134,7 +134,7 @@ If this fixes the problem, remove the Registry value `Enabled` at `HKLM\SYSTEM\C
 
 You can now enable Viridian again for better VM performance.
 
-## 💾 Data drives showing as removable in Windows {#data-drives-showing-as-removable-in-windows}
+## :floppy_disk: Data drives showing as removable in Windows {#data-drives-showing-as-removable-in-windows}
 
 Follow the instructions in the Citrix KB entry [CTX583997: In XenServer, fixed data drives show as removable data drives to BitLocker](https://support.citrix.com/s/article/CTX583997-in-xenserver-fixed-data-drives-show-as-removable-data-drives-to-bitlocker).
 
@@ -151,7 +151,7 @@ Next, set each VBD's property to non-unpluggable:
 xe vbd-param-set uuid=<vbd-uuid> unpluggable=false
 `}</Terminal>
 
-## 🚫 XenServer VM Tools not upgrading drivers after installation {#xenserver-vm-tools-not-upgrading-drivers-after-installation}
+## :no_entry_sign: XenServer VM Tools not upgrading drivers after installation {#xenserver-vm-tools-not-upgrading-drivers-after-installation}
 
 This can be due to the "Manage Citrix PV drivers via Windows Update" feature being enabled on that VM.
 
@@ -159,7 +159,7 @@ If this feature is enabled, XenServer VM Tools will automatically uncheck the "I
 
 Make sure to either check this checkbox, specify `ALLOWDRIVERINSTALL=YES` on the Msiexec command line (if installing via command line) or install driver updates via Windows Update.
 
-## 🔄 XenServer drivers not receiving updates via Windows Update {#xenserver-drivers-not-receiving-updates-via-windows-update}
+## :arrows_counterclockwise: XenServer drivers not receiving updates via Windows Update {#xenserver-drivers-not-receiving-updates-via-windows-update}
 
 ### Cause
 
@@ -191,7 +191,7 @@ See the [XenClean guide](/vms/#fully-removing-xen-pv-drivers-with-xenclean) for 
 You will need to reinstall the management agent.
 :::
 
-## 🩺 Malfunctioning XenServer PV drivers {#malfunctioning-xenserver-pv-drivers}
+## :stethoscope: Malfunctioning XenServer PV drivers {#malfunctioning-xenserver-pv-drivers}
 
 ### Symptoms
 
@@ -213,7 +213,7 @@ XenServer drivers require multiple reboots after an update.
 Reboot your VMs manually, or set the [Autoreboot Registry value](https://support.citrix.com/external/article/CTX292687/setting-automatic-reboots-when-updating.html) to force the VM to automatically reboot after a driver update.
 You can also disable automatic updating of XenServer drivers and update them during a dedicated maintenance window.
 
-## 🧊 Windows Server 2025 hangs randomly with 0% CPU {#windows-server-2025-hangs-randomly-with-0-cpu}
+## :ice_cube: Windows Server 2025 hangs randomly with 0% CPU {#windows-server-2025-hangs-randomly-with-0-cpu}
 
 ### Cause
 
@@ -231,7 +231,7 @@ bcdedit /deletevalue "{current}" useplatformclock
 bcdedit /deletevalue "{current}" useplatformtick
 ```
 
-## 🧠 How to gather kernel memory dumps for in-depth troubleshooting {#how-to-gather-kernel-memory-dumps-for-in-depth-troubleshooting}
+## :brain: How to gather kernel memory dumps for in-depth troubleshooting {#how-to-gather-kernel-memory-dumps-for-in-depth-troubleshooting}
 
 In situations where your VM stops responding, we may need to gather kernel memory dumps to help troubleshoot the situation.
 Follow this procedure to configure and gather a memory dump:

--- a/docs/vms/advanced.md
+++ b/docs/vms/advanced.md
@@ -6,7 +6,7 @@ sidebar_position: 7
 
 Less common VM-level settings and behaviors: boot options, vTPM, time handling.
 
-## 🥾 Boot options {#boot-options}
+## :hiking_boot: Boot options {#boot-options}
 
 ### Boot device order
 
@@ -31,7 +31,7 @@ xe vm-param-get uuid=<vm-uuid> param-name=platform param-key=device-model
 
 See also [how to check UEFI/Secure Boot status](../guides/guest-UEFI-Secure-Boot.md#misc).
 
-## 🔐 vTPM {#vtpm}
+## :closed_lock_with_key: vTPM {#vtpm}
 
 Starting with XCP-ng 8.3, VMs can have a **virtual TPM 2.0**, required for Windows 11 and Windows Server 2025, and usable by Linux guests too.
 
@@ -48,7 +48,7 @@ Notes:
 * If the guest uses the TPM for disk encryption (e.g. BitLocker), **keep your recovery keys safe**: losing the vTPM state means the guest can't unseal its keys.
 * Suspending or checkpointing (RAM snapshot) a vTPM-equipped VM is not supported.
 
-## ⏰ Time in VMs {#time-in-vms}
+## :alarm_clock: Time in VMs {#time-in-vms}
 
 Guests get their initial clock from the host, then keep time themselves. Recommendations:
 
@@ -56,7 +56,7 @@ Guests get their initial clock from the host, then keep time themselves. Recomme
 * Run an NTP client **in each guest** (chrony, systemd-timesyncd, Windows Time). Time drifts after live migrations, suspend/resume or snapshots revert are then corrected automatically.
 * **Windows** stores local time in the RTC by default. XCP-ng exposes a UTC clock, so either keep Windows' own time service active (default, recommended) or make Windows use UTC. If a Windows VM shows a fixed offset after boot, check the timezone settings in the guest.
 
-## 🚫 Blocking operations on a VM {#blocking-operations-on-a-vm}
+## :no_entry_sign: Blocking operations on a VM {#blocking-operations-on-a-vm}
 
 Any XAPI operation can be administratively blocked per VM (deletion, but also start, shutdown, migration…):
 
@@ -66,7 +66,7 @@ xe vm-param-set uuid=<vm-uuid> blocked-operations:migrate_send=true
 
 See [protecting a VM against accidental deletion](vm-lifecycle.md#protect-a-vm-against-accidental-deletion) for the most common use.
 
-## 🧠 VM memory {#vm-memory}
+## :brain: VM memory {#vm-memory}
 
 A VM's memory is defined by four values: static min/max (the hard bounds, changed only while the VM is halted) and dynamic min/max (the range the VM can be ballooned within, at runtime). When dynamic min = dynamic max, the VM simply owns that amount: this is the recommended setup for predictable performance, and the [caution about Dynamic Memory Control](vms.md#dynamic-memory) explains why.
 

--- a/docs/vms/import-export.md
+++ b/docs/vms/import-export.md
@@ -10,13 +10,13 @@ Moving VMs in and out of XCP-ng as files: full VMs (XVA, OVA) or individual disk
 Coming from VMware, Hyper-V, KVM or another hypervisor? There's a dedicated page: [migrate to XCP-ng](../installation/migrate-to-xcp-ng.md), including XO's V2V tool for live VMware conversions.
 :::
 
-## 📦 Formats {#formats}
+## :package: Formats {#formats}
 
 * **XVA**: the native format. A single streamable file containing the VM's metadata *and* its disks. Best fidelity (everything is preserved), best performance, and works between any XCP-ng/XAPI-based hosts. Use it whenever both sides are XCP-ng.
 * **OVA/OVF**: the interchange format, when the other side is *not* XCP-ng. An OVA is an archive with the disks and a hardware description; interpretation varies between vendors, so expect to double-check VM settings after import.
 * **Disk images** (VHD, VMDK, raw): import/export a single disk rather than a whole VM. Attach the imported disk to a VM you create yourself.
 
-## 📥 Import {#import}
+## :inbox_tray: Import {#import}
 
 ### XVA
 
@@ -36,7 +36,7 @@ From Xen Orchestra: **New** → **Import** accepts `.ova` files directly, shows 
 
 From Xen Orchestra: **New** → **Import** → **Disk** imports a VHD or VMDK file into an SR of your choice; then attach it to a VM ([how](../storage/manage-srs.md#create-and-attach-a-new-disk-to-a-vm)). With `xe`, see [vdi-import](../storage/manage-srs.md#export--import-a-single-disk).
 
-## 📤 Export {#export}
+## :outbox_tray: Export {#export}
 
 ### XVA
 
@@ -60,7 +60,7 @@ From Xen Orchestra: VM → **Export** and choose the OVA format. Use it only whe
 
 From Xen Orchestra, each disk in the VM's Disks tab has an export button (VHD). See also [exporting VDIs with xe](../storage/manage-srs.md#export--import-a-single-disk).
 
-## 🔁 Not what you're looking for? {#not-what-youre-looking-for}
+## :repeat: Not what you're looking for? {#not-what-youre-looking-for}
 
 * Moving a VM between two **connected** pools? Use [live migration](vm-migration.md), no intermediate file needed.
 * Recurring exports for safety? That's a backup job. See [backup](../management/backup.md): Xen Orchestra does scheduled full/delta backups, replication and more.

--- a/docs/vms/snapshots.md
+++ b/docs/vms/snapshots.md
@@ -10,7 +10,7 @@ A snapshot captures the state of a VM at a point in time: its disks, and optiona
 Snapshots are **not backups**: they live on the same SR as the VM. If the storage is lost, snapshots are lost with it. For real backups (full, delta, replicated, off-site…), use [Xen Orchestra backup](../management/backup.md).
 :::
 
-## 🎓 How they work {#how-they-work}
+## :mortar_board: How they work {#how-they-work}
 
 XCP-ng disks are copy-on-write: taking a snapshot freezes the current disk state as a read-only parent, and the VM continues writing into a new child disk. This makes snapshot creation almost instant, but it has consequences:
 
@@ -50,7 +50,7 @@ XCP-ng disks are copy-on-write: taking a snapshot freezes the current disk state
 * Snapshots consume space on the SR (on thick-provisioned SRs like LVM/iSCSI/HBA, a snapshot can reserve up to the full disk size).
 * Deleting a snapshot doesn't free space immediately: the [coalesce process](../storage/storage.md#coalesce) has to merge the chain in the background first.
 
-## 📸 Take a snapshot {#take-a-snapshot}
+## :camera_flash: Take a snapshot {#take-a-snapshot}
 
 Two flavors:
 
@@ -68,7 +68,7 @@ xe vm-checkpoint vm="my-vm" new-name-label="before-upgrade-with-ram"
 In Xen Orchestra you can exclude specific disks from snapshots (and backups) by naming convention: putting `[NOSNAP]` (snapshots) or `[NOBAK]` (backups and their snapshots) in the disk's name. Very useful for large scratch/data disks. On XCP-ng 8.3, disk exclusion is supported natively by the snapshot API, which XO uses.
 :::
 
-## ⏪ Revert to a snapshot {#revert-to-a-snapshot}
+## :rewind: Revert to a snapshot {#revert-to-a-snapshot}
 
 Reverting replaces the VM's current state with the snapshot's state. **Everything written since the snapshot is lost.**
 
@@ -81,7 +81,7 @@ xe snapshot-revert snapshot-uuid=<snapshot-uuid>
 
 After reverting, the VM is halted (or suspended for a RAM snapshot; resume it to continue exactly where it was). The snapshot itself survives the revert, so you can revert again later.
 
-## 🗑️ Delete a snapshot {#delete-a-snapshot}
+## :wastebasket: Delete a snapshot {#delete-a-snapshot}
 
 From Xen Orchestra: Snapshots tab → delete. With `xe`:
 
@@ -91,11 +91,11 @@ xe snapshot-uninstall snapshot-uuid=<snapshot-uuid>
 
 Space is reclaimed asynchronously by the [coalesce process](../storage/storage.md#coalesce): expect a delay (and storage I/O activity) before the SR usage drops. If space never comes back, check that coalesce isn't stuck.
 
-## 🔁 Scheduled (rolling) snapshots {#scheduled-rolling-snapshots}
+## :repeat: Scheduled (rolling) snapshots {#scheduled-rolling-snapshots}
 
 Use Xen Orchestra's **Rolling Snapshot** backup jobs: take a snapshot of selected VMs on a schedule and keep the N most recent ones. This gives you automatic short-term rollback points at near-zero cost. See the [XO backup documentation](https://docs.xen-orchestra.com/xo5/rolling_snapshots) for details, and remember the warning above: schedule real backups too.
 
-## 🧰 Other things you can do with a snapshot {#other-things-you-can-do-with-a-snapshot}
+## :toolbox: Other things you can do with a snapshot {#other-things-you-can-do-with-a-snapshot}
 
 * [Create a template](templates.md#create-a-custom-template) from it (golden image without stopping the source VM).
 * Create a full VM from it: `xe snapshot-copy snapshot-uuid=<uuid> new-name-label="restored-vm"` (or from Xen Orchestra, "create VM from snapshot").

--- a/docs/vms/templates.md
+++ b/docs/vms/templates.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 Templates are the blueprint VMs are created from: they define the virtual hardware (firmware type, devices, memory defaults…) and, optionally, pre-installed disk content.
 
-## 🎓 Two kinds of templates {#two-kinds-of-templates}
+## :mortar_board: Two kinds of templates {#two-kinds-of-templates}
 
 * **Built-in templates**: shipped with XCP-ng, one per supported guest OS family. They contain **no disk content**: they only carry the right virtual hardware settings and optimizations for that OS (device model, boot mode, memory defaults…). You install the OS yourself from an ISO or network. Always create a VM from the template matching its OS: this is what guarantees the best defaults.
 * **Custom templates**: created by you from an existing VM or snapshot. They include the **disks' content**, so new VMs start as exact copies. This is the classic "golden image" workflow.
@@ -21,7 +21,7 @@ xe template-list params=name-label
 If built-in templates are missing (e.g. after an incomplete upgrade), see [this troubleshooting entry](../troubleshooting/common-problems.md#missing-templates-when-creating-a-new-vm).
 :::
 
-## 📸 Create a custom template {#create-a-custom-template}
+## :camera_flash: Create a custom template {#create-a-custom-template}
 
 ### From a VM
 
@@ -42,7 +42,7 @@ xe snapshot-export-to-template snapshot-uuid=<snapshot-uuid> filename=my-templat
 xe vm-import filename=my-template.xva preserve=true
 `}</Terminal>
 
-## 🧼 Prepare the source before templating {#prepare-the-source-before-templating}
+## :soap: Prepare the source before templating {#prepare-the-source-before-templating}
 
 New VMs created from a custom template are clones: anything unique to the source machine gets duplicated. Before converting a source VM into a template:
 
@@ -51,7 +51,7 @@ New VMs created from a custom template are clones: anything unique to the source
 
 A full worked example (cloud image → prepared VM → template → new VMs) is in the [Ubuntu custom templates guide](../guides/create-use-custom-xcpng-ubuntu-templates.md).
 
-## 🚀 Create VMs from a template {#create-vms-from-a-template}
+## :rocket: Create VMs from a template {#create-vms-from-a-template}
 
 From Xen Orchestra: **New** → **VM** and pick your template: custom templates appear alongside built-in ones. With `xe`:
 
@@ -61,7 +61,7 @@ xe vm-install template="my-golden-image" new-name-label="new-vm" sr-uuid=<sr-uui
 
 For repeated or automated deployments, drive this with [Terraform/OpenTofu, Packer or Ansible](../management/infrastructure-as-code.md).
 
-## 📦 Move templates around {#move-templates-around}
+## :package: Move templates around {#move-templates-around}
 
 Templates export and import like VMs, in XVA format, which is handy to copy a golden image to another pool:
 
@@ -72,7 +72,7 @@ xe vm-import filename=my-template.xva preserve=true
 
 Or from Xen Orchestra, export/import from the template's view (see [import and export](import-export.md)).
 
-## 🗑️ Delete a custom template {#delete-a-custom-template}
+## :wastebasket: Delete a custom template {#delete-a-custom-template}
 
 In Xen Orchestra, from the templates list (Home → VMs → templates filter). With `xe`:
 

--- a/docs/vms/vm-lifecycle.md
+++ b/docs/vms/vm-lifecycle.md
@@ -10,7 +10,7 @@ Creating, cloning and deleting virtual machines on XCP-ng.
 The most comfortable way to create and manage VMs is [Xen Orchestra](../management/manage-at-scale/xo-web-ui.md) (or [XO Lite](../management/manage-locally/xo-lite.md) directly from your host, for simple cases). The `xe` commands below are useful for scripting and automation. See also [infrastructure as code](../management/infrastructure-as-code.md) for Terraform/OpenTofu, Packer and Ansible.
 :::
 
-## 🏗️ Create a VM {#create-a-vm}
+## :building_construction: Create a VM {#create-a-vm}
 
 ### From a template + ISO
 
@@ -49,7 +49,7 @@ See [clone or copy](#clone-or-copy-a-vm) below: cloning an installed and prepare
 
 Import an existing VM (XVA, OVA, or disks from another hypervisor): see [import and export](import-export.md) and [migrate to XCP-ng](../installation/migrate-to-xcp-ng.md).
 
-## 🐑 Clone or copy a VM {#clone-or-copy-a-vm}
+## :sheep: Clone or copy a VM {#clone-or-copy-a-vm}
 
 Two different operations:
 
@@ -67,7 +67,7 @@ The source VM must be halted (or use a [snapshot](snapshots.md) of a running VM 
 Clones inherit everything from the source, including hostname, SSH host keys, and machine IDs. For anything you plan to clone repeatedly, prepare the source first (for Linux: reset `/etc/machine-id`, SSH host keys, static IPs; for Windows: use `sysprep`). Details in the [templates page](templates.md).
 :::
 
-## ⚡ Start, stop, reboot {#start-stop-reboot}
+## :zap: Start, stop, reboot {#start-stop-reboot}
 
 From Xen Orchestra or XO Lite, use the VM's action buttons. With `xe`:
 
@@ -82,7 +82,7 @@ A clean shutdown/reboot requires working [guest tools](vms.md#guest-tools) in th
 
 To start VMs automatically when the host boots, see the [autostart guide](../guides/autostart-vm.md). To choose *which host* a VM should preferably run on, set its affinity host (`xe vm-param-set uuid=<vm-uuid> affinity=<host-uuid>`). See [VM load balancing](../management/vm-load-balancing.md) for dynamic placement.
 
-## 🛡️ Protect a VM against accidental deletion {#protect-a-vm-against-accidental-deletion}
+## :shield: Protect a VM against accidental deletion {#protect-a-vm-against-accidental-deletion}
 
 You can block specific operations on any VM, including deletion:
 
@@ -96,7 +96,7 @@ Anyone (or any script) trying to delete the VM will get an error until the block
 xe vm-param-remove uuid=<vm-uuid> param-name=blocked-operations param-key=destroy
 `}</Terminal>
 
-## 🧺 VM groups with a start order (vApps) {#vapps}
+## :basket: VM groups with a start order (vApps) {#vapps}
 
 XAPI can group VMs into an *appliance* (also called vApp): a set of VMs started together, in a defined order, with delays between them. Typical use: bring a database up before the application servers. The group is also what [HA](../management/ha.md) and DR tooling can recover as a unit.
 
@@ -108,7 +108,7 @@ xe appliance-start uuid=<appliance-uuid>
 
 See the [appliance commands](../appendix/cli_reference.md#appliance-commands) in the CLI reference.
 
-## 🗑️ Delete a VM {#delete-a-vm}
+## :wastebasket: Delete a VM {#delete-a-vm}
 
 From Xen Orchestra, deleting a VM lets you choose whether to also remove its disks and snapshots. With `xe`:
 

--- a/docs/vms/vm-migration.md
+++ b/docs/vms/vm-migration.md
@@ -6,14 +6,14 @@ sidebar_position: 5
 
 Moving VMs between hosts, SRs and pools, live when possible.
 
-## 🎓 The different migration types {#the-different-migration-types}
+## :mortar_board: The different migration types {#the-different-migration-types}
 
 * **Live migration** (same pool, shared storage): only the VM's memory and execution state move to another host. Takes seconds to minutes, no service interruption beyond a sub-second switchover.
 * **Live migration with storage** ("storage motion"): additionally copies the VM's disks: between SRs, between hosts using only local storage, or **between pools**. Much longer (the whole disk is streamed), still without stopping the VM.
 * **Warm migration**: a Xen Orchestra feature for cases where live migration isn't possible (very different source and destination versions, CPU incompatibility…): the VM is replicated while running, then briefly suspended and switched over. See [migrating from older releases](../installation/upgrade.md#migrate-vms-from-older-xenserverxcp-ng).
 * **Cold migration**: the VM is halted; only disks move. Most robust, works across anything. See [moving disks](../storage/manage-srs.md#move-a-disk-to-another-sr) and [export/import](import-export.md).
 
-## ✅ Requirements and limitations {#requirements-and-limitations}
+## :white_check_mark: Requirements and limitations {#requirements-and-limitations}
 
 * **CPU compatibility**: within a pool, [CPU leveling](../management/hosts-pools.md#heterogeneous-pools) guarantees live migration works between members. Across pools, the destination CPUs must be the same vendor and offer the features the VM currently uses (moving to a newer CPU generation usually works; the reverse may not).
 * **Memory**: the destination host needs enough free RAM for the VM.
@@ -25,7 +25,7 @@ Moving VMs between hosts, SRs and pools, live when possible.
 On XCP-ng 8.3, you can speed up migrations on constrained networks by enabling [migration compression](../management/hosts-pools.md#migration-compression), and choose which network migrations use (Xen Orchestra: pool advanced settings → default migration network).
 :::
 
-## 🚀 Migrate within a pool {#migrate-within-a-pool}
+## :rocket: Migrate within a pool {#migrate-within-a-pool}
 
 From Xen Orchestra: VM → **Migrate** action (or drag and drop the VM onto a host in the Home view). With `xe`:
 
@@ -39,7 +39,7 @@ If the disks are on local storage (or you want to change SR at the same time), a
 xe vm-migrate vm="my-vm" host=<destination-host> vdi:<vdi-uuid>=<destination-sr-uuid> live=true
 `}</Terminal>
 
-## 🌍 Migrate to another pool {#migrate-to-another-pool}
+## :earth_africa: Migrate to another pool {#migrate-to-another-pool}
 
 From Xen Orchestra, the same **Migrate** dialog lets you pick any connected pool as destination, with per-disk SR mapping and per-interface network mapping. With `xe`:
 
@@ -53,7 +53,7 @@ xe vm-migrate vm="my-vm" remote-master=<destination-coordinator-ip> \
 
 Cross-pool migration is a disk copy under the hood: plan for the transfer time, and avoid concurrent backup jobs on the same VM.
 
-## 🧑‍⚕️ When something blocks the migration {#when-something-blocks-the-migration}
+## :health_worker: When something blocks the migration {#when-something-blocks-the-migration}
 
 * `xe host-get-vms-which-prevent-evacuation uuid=<host-uuid>` explains why VMs can't leave a host (used by [maintenance mode](../management/hosts-pools.md#maintenance-mode)).
 * "Not enough memory": free RAM on the destination, or lower the VM's [dynamic memory](vms.md#dynamic-memory).

--- a/docs/vms/vms.md
+++ b/docs/vms/vms.md
@@ -13,7 +13,7 @@ This page covers guest OS support and guest tools. The other pages of this secti
 * [Advanced VM settings](advanced.md): boot options, vTPM, memory, time
 * [Windows VMs](windows.md): creation, sysprep, in-place upgrades
 
-## 🧩 Supported guest operating systems {#supported-guest-operating-systems}
+## :jigsaw: Supported guest operating systems {#supported-guest-operating-systems}
 
 XCP-ng can run virtually any x86 operating system that works in a Xen HVM guest, far beyond any official list. In practice, three things define how well a guest is supported:
 
@@ -23,7 +23,7 @@ XCP-ng can run virtually any x86 operating system that works in a Xen HVM guest,
 
 If you rely on professional support, the commercially supported guest OS list is maintained on the [Vates documentation](https://docs.vates.tech/). For everything else, the [forum](https://xcp-ng.org/forum) is full of reports about less common guests.
 
-## 🛠️ Guest Tools {#guest-tools}
+## :hammer_and_wrench: Guest Tools {#guest-tools}
 
 XCP-ng needs guest tools to be installed in the VMs in order to communicate with the guest operating system. This brings better performance and is required for various features.
 
@@ -37,7 +37,7 @@ Linux: see [Linux Guest Tools](#linux-guest-tools) \
 Windows: see [Windows Guest Tools](#windows-guest-tools) \
 FreeBSD, OpenBSD and some appliances based on them: see [*BSD Guest Tools](#bsd-guest-tools)
 
-## 🏘️ All VMs {#all-vms}
+## :houses: All VMs {#all-vms}
 
 ### Dynamic Memory
 
@@ -105,7 +105,7 @@ vncviewer localhost:<LOCAL_PORT>
 Certain applications, such as Oracle ASM, require a unique identifier for disk drives known as a WWID (World Wide Identifier). In a Linux environment, this can be achieved by utilizing the `ID_PART_ENTRY_UUID` or `ID_PART_ENTRY_NAME` variables. These identifiers can be set in the udev rules file located at `/etc/udev/rules.d/99-asm.rules`. For detailed instructions on configuring disk devices manually for Oracle ASM using WWID, refer to [this guide](https://alexzy.blogspot.com/2018/02/configuring-disk-devices-manually-for.html).
 
 
-## 🪟 Windows VMs {#windows-vms}
+## :window: Windows VMs {#windows-vms}
 
 ### Windows Guest Tools
 
@@ -428,7 +428,7 @@ Once done with Linux, shut down the VM and restore the parameter to its original
 xe vm-param-set uuid=VM-UUID platform:device_id=0002
 `}</Terminal>
 
-## 🐧 Linux VMs {#linux-vms}
+## :penguin: Linux VMs {#linux-vms}
 
 ### Linux Guest Tools
 
@@ -583,7 +583,7 @@ The default Ubuntu installation includes a package named `linux-modules-extra` c
 
 For more details, the problem comes from `Ubuntu` kernels that don't have the `efi-framebuffer` driver compiled in. This driver should be used if the `bochs` driver isn't present and it is just not selected in the `Ubuntu` kernel build config. To be more precise, `Ubuntu` kernels try to use a driver called `simple-framebuffer` for which there seems to be an incompatibility with the way the OVMF UEFI bios initializes the VGA card, causing the distorted display.
 
-## 😈 *BSD VMs {#bsd-vms}
+## :smiling_imp: *BSD VMs {#bsd-vms}
 
 ### *BSD Guest Tools
 

--- a/docs/vms/windows.md
+++ b/docs/vms/windows.md
@@ -6,7 +6,7 @@ sidebar_position: 8
 
 The Windows-specific parts of a VM's life on XCP-ng: creation choices, golden images with sysprep, in-place Windows upgrades, and where to go when something breaks. The [guest tools themselves are covered in detail here](vms.md#windows-guest-tools).
 
-## 🏗️ Creating a Windows VM {#creating-a-windows-vm}
+## :building_construction: Creating a Windows VM {#creating-a-windows-vm}
 
 Follow the [normal VM creation workflow](vm-lifecycle.md), with these Windows-specific points:
 
@@ -15,7 +15,7 @@ Follow the [normal VM creation workflow](vm-lifecycle.md), with these Windows-sp
 * The firmware type (BIOS/UEFI) [cannot be changed after installation](advanced.md#bios-vs-uefi-firmware), so don't create new Windows VMs in BIOS mode unless you have a specific reason.
 * Install the [Windows guest tools](vms.md#windows-guest-tools) right after the OS installation, and read that section first: the choice between XCP-ng and XenServer tools, and the Windows Update behavior around drivers, matter.
 
-## 🧼 Golden image with sysprep {#golden-image-with-sysprep}
+## :soap: Golden image with sysprep {#golden-image-with-sysprep}
 
 Windows machines carry a unique identity. To build a [template](templates.md) you'll clone many VMs from:
 
@@ -31,7 +31,7 @@ C:\Windows\System32\Sysprep\sysprep.exe /generalize /oobe /shutdown
 
 The guest tools survive sysprep: install them before generalizing, not after cloning.
 
-## ⬆️ Upgrading Windows in place {#upgrading-windows-in-place}
+## :arrow_up: Upgrading Windows in place {#upgrading-windows-in-place}
 
 Upgrading the Windows version *inside* an existing VM (e.g. Windows Server 2019 to 2022) works like on physical hardware, with these precautions:
 
@@ -44,11 +44,11 @@ Upgrading the Windows version *inside* an existing VM (e.g. Windows Server 2019 
 An upgrade to **Windows 11** has hardware requirements (UEFI, Secure Boot, TPM) that a VM created in BIOS mode cannot meet, since the [firmware can't be switched](advanced.md#bios-vs-uefi-firmware) after installation. For those, create a fresh UEFI + vTPM VM and migrate the data instead.
 :::
 
-## 🖥️ Console access {#console-access}
+## :desktop_computer: Console access {#console-access}
 
 The console in Xen Orchestra/XO Lite works from the first boot, with no guest configuration. For day-to-day use, enable Remote Desktop inside the guest and connect with your usual RDP client; the XO console remains your out-of-band access when the network is down. About resolution tuning, see [managing screen resolution](vms.md#manage-screen-resolution).
 
-## 🧑‍⚕️ When Windows misbehaves {#when-windows-misbehaves}
+## :health_worker: When Windows misbehaves {#when-windows-misbehaves}
 
 * Boot failures, BSODs, storage performance, drivers not updating: see the dedicated [Windows guest tools troubleshooting](../troubleshooting/windows-pv-tools.md) page, including [how to gather kernel memory dumps](../troubleshooting/windows-pv-tools.md#how-to-gather-kernel-memory-dumps-for-in-depth-troubleshooting) for support cases.
 * Automating PV driver updates through Group Policy: see [this guide](../guides/winpv-update.md).

--- a/docs/xostor/xostor.md
+++ b/docs/xostor/xostor.md
@@ -1,7 +1,7 @@
 
 # XOSTOR documentation
 
-## 🎓 LINSTOR/DRBD global documentation in the context of XCP-ng {#linstordrbd-global-documentation-in-the-context-of-xcp-ng}
+## :mortar_board: LINSTOR/DRBD global documentation in the context of XCP-ng {#linstordrbd-global-documentation-in-the-context-of-xcp-ng}
 
 ### What is LINSTOR?
 
@@ -310,9 +310,9 @@ ExecStop=/opt/xensource/libexec/safe-umount /var/lib/linstor
 RemainAfterExit=true
 ```
 
-## ❓ Howto and Questions {#howto-and-questions}
+## :question: Howto and Questions {#howto-and-questions}
 
-## 📥 Installation {#installation}
+## :inbox_tray: Installation {#installation}
 
 ### Prerequisites
 
@@ -334,11 +334,11 @@ Changing the replication factor after creating XOSTOR is not possible, as it can
 The maximum number of machines per pool is 7.
 :::
 
-## ♻️ Update {#update}
+## :recycle: Update {#update}
 
 See this documentation: [RPU](/management/updates/#rolling-pool-update-rpu).
 
-## ⬆️ Upgrade {#upgrade}
+## :arrow_up: Upgrade {#upgrade}
 
 If you are reading this documentation, we assume that you want to upgrade a pool on which XOSTOR is deployed, i.e. change the version of XCP-ng, for example from 8.2 to 8.3.
 For updates that don't change the version number of XCP-ng (bugfixes, security fixes), see [the update section](#update).
@@ -437,7 +437,7 @@ systemctl restart linstor-satellite
 
 - In case of a bad node (missing, without storage pool or inaccessible via `linstor n l`/`linstor sp l`) due to a failed upgrade or if the documentation was not followed correctly, you can read this [documentation](#how-to-add-a-new-host-or-fix-a-badly-configured-host) to recover.
 
-## 💬 Global questions {#global-questions}
+## :speech_balloon: Global questions {#global-questions}
 
 ### The linstor command does not work!?
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -78,6 +78,13 @@ const config = {
           // before it and handles the names its dataset gets wrong. See
           // src/plugins/emoji/.
           beforeDefaultRemarkPlugins: [require('./src/plugins/emoji/inline')],
+          // Must stay in remarkPlugins: it rewrites the toc export, so it has to
+          // run after the default plugin that builds it.
+          remarkPlugins: [require('./src/plugins/emoji/toc')],
+          // Takes heading emoji out of the heading text and gives every other
+          // emoji an accessible name, so neither reaches a screen reader or a
+          // braille display as a bare character.
+          rehypePlugins: [require('./src/plugins/emoji/headings')],
         },
         blog: false,
         theme: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -72,6 +72,12 @@ const config = {
           // Remove this to remove the "edit this page" links.
           editUrl:
             'https://github.com/xcp-ng/xcp-ng-org/edit/master/',
+          // Emoji are written as `:name:` in the markdown, never as characters,
+          // so that the sources stay readable to anyone using a screen reader.
+          // Docusaurus's own remark-emoji does most of the work; this runs
+          // before it and handles the names its dataset gets wrong. See
+          // src/plugins/emoji/.
+          beforeDefaultRemarkPlugins: [require('./src/plugins/emoji/inline')],
         },
         blog: false,
         theme: {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.10.2",
-    "@docusaurus/types": "3.10.2"
+    "@docusaurus/types": "3.10.2",
+    "node-emoji": "^2.1.0"
   },
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
-    "write-heading-ids": "docusaurus write-heading-ids"
+    "write-heading-ids": "docusaurus write-heading-ids",
+    "lint:emoji": "node scripts/check-emoji.js"
   },
   "dependencies": {
     "@docusaurus/core": "3.10.2",

--- a/scripts/check-emoji.js
+++ b/scripts/check-emoji.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Check that no documentation file contains an emoji character: they are written
+ * as `:name:` shortcodes instead, so that the sources stay readable to anyone
+ * using a screen reader or a braille display. See the Emoji section of README.md.
+ *
+ * Run with `npm run lint:emoji`. Fenced code blocks and code spans are exempt:
+ * an emoji there is part of quoted output, and remark does not convert
+ * shortcodes inside them anyway. For a case outside those, put
+ * `<!-- allow-emoji -->` on the line before.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const {EMOJI_SOURCE} = require('../src/plugins/emoji/vocabulary');
+
+const ROOT = path.join(__dirname, '..');
+const TARGETS = ['docs', 'README.md'];
+const ALLOW = '<!-- allow-emoji -->';
+
+function markdownFiles(target) {
+  const abs = path.join(ROOT, target);
+  if (!fs.statSync(abs).isDirectory()) {
+    return abs.endsWith('.md') ? [abs] : [];
+  }
+  return fs
+    .readdirSync(abs, {withFileTypes: true})
+    .flatMap((entry) =>
+      entry.isDirectory()
+        ? markdownFiles(path.join(target, entry.name))
+        : entry.name.endsWith('.md')
+          ? [path.join(abs, entry.name)]
+          : [],
+    );
+}
+
+/** Blank out code spans, so an emoji quoted inline is not reported. */
+function withoutCodeSpans(line) {
+  return line.replace(/`+[^`]*`+/g, (span) => ' '.repeat(span.length));
+}
+
+const problems = [];
+
+for (const file of TARGETS.flatMap(markdownFiles)) {
+  const lines = fs.readFileSync(file, 'utf8').split('\n');
+  let fence = false;
+
+  lines.forEach((line, index) => {
+    if (/^\s*(```+|~~~+)/.test(line)) {
+      fence = !fence;
+      return;
+    }
+    if (fence || lines[index - 1]?.includes(ALLOW)) {
+      return;
+    }
+    for (const match of withoutCodeSpans(line).matchAll(new RegExp(EMOJI_SOURCE, 'gu'))) {
+      problems.push(
+        `${path.relative(ROOT, file)}:${index + 1}:${match.index + 1}: ${match[0]}  in: ${line.trim()}`,
+      );
+    }
+  });
+}
+
+if (problems.length > 0) {
+  console.error(
+    `Emoji characters in documentation sources (${problems.length}). Write the ` +
+      '`:name:` shortcode instead — see the Emoji section of README.md.\n',
+  );
+  problems.forEach((problem) => console.error(`  ${problem}`));
+  process.exit(1);
+}
+
+console.log('No emoji characters in the documentation sources.');

--- a/scripts/check-emoji.js
+++ b/scripts/check-emoji.js
@@ -1,22 +1,62 @@
 #!/usr/bin/env node
 /**
- * Check that no documentation file contains an emoji character: they are written
- * as `:name:` shortcodes instead, so that the sources stay readable to anyone
- * using a screen reader or a braille display. See the Emoji section of README.md.
+ * Check how the documentation writes emoji. See the Emoji section of README.md
+ * for the rule; run with `npm run lint:emoji`.
  *
- * Run with `npm run lint:emoji`. Fenced code blocks and code spans are exempt:
- * an emoji there is part of quoted output, and remark does not convert
- * shortcodes inside them anyway. For a case outside those, put
- * `<!-- allow-emoji -->` on the line before.
+ * Two directions go wrong, and both are silent, which is why they are checked:
+ *
+ *   - an emoji *character* in the markdown, which is what the rule forbids: it
+ *     reaches anyone reading the source as noise or a question mark;
+ *   - a `:name:` shortcode that will not become an emoji — a name nothing knows,
+ *     a name that resolves to a flat monochrome glyph, or a shortcode written
+ *     somewhere shortcodes are never converted. Each of those renders as the
+ *     literal text `:name:`, or as the wrong glyph, and nobody notices until
+ *     someone looks at the page.
+ *
+ * Names are resolved with node-emoji, the dataset Docusaurus's own remark-emoji
+ * uses, so this agrees with the build about which names exist. Keep the version
+ * range in package.json in step with remark-emoji's (^2.1.0) so npm can dedupe
+ * them to a single copy.
+ *
+ * Exempt: fenced code blocks, code spans, and the JSX template literals that
+ * `<Terminal>` blocks are written with. Those hold quoted output, where the
+ * character is part of what is quoted and no shortcode would be converted
+ * anyway. For a quoted case outside them, put `<!-- allow-emoji -->` on the line
+ * before.
  */
 
 const fs = require('fs');
 const path = require('path');
-const {EMOJI_SOURCE} = require('../src/plugins/emoji/vocabulary');
+const nodeEmoji = require('node-emoji');
+const {NAMES, EMOJI_SOURCE} = require('../src/plugins/emoji/vocabulary');
 
 const ROOT = path.join(__dirname, '..');
 const TARGETS = ['docs', 'README.md'];
 const ALLOW = '<!-- allow-emoji -->';
+
+// remark-emoji's own shortcode pattern, which is what contributors write against.
+const SHORTCODE = /:\+1:|:-1:|:[\w-]+:/g;
+// Attribute values, in HTML and in JSX: title="...", label={`...`}.
+const ATTRIBUTE = /=\s*("[^"]*"|'[^']*'|\{`[^`]*`\})/g;
+
+/** The character a shortcode will produce, or undefined if nothing knows the name. */
+const resolve = (name) => NAMES[name] ?? nodeEmoji.get(name);
+
+/**
+ * Is this shortcode-shaped text actually meant as an emoji? A MAC address, a
+ * timestamp, a table alignment row and a log line like `INFO:root:done` all
+ * contain `:...:`, so require a letter in the name and nothing word-like or
+ * colon-like touching either end.
+ *
+ * The cost is that a typo written flush against a word — `Gear:gaer:` — is not
+ * reported. A correct name there works and is left alone, so this only loses the
+ * warning, and only in a spot nobody writes.
+ */
+function looksIntentional(line, match) {
+  const before = line[match.index - 1] ?? '';
+  const after = line[match.index + match[0].length] ?? '';
+  return /[a-zA-Z]/.test(match[0]) && !/[\w:]/.test(before) && !/[\w:]/.test(after);
+}
 
 function markdownFiles(target) {
   const abs = path.join(ROOT, target);
@@ -34,40 +74,122 @@ function markdownFiles(target) {
     );
 }
 
-/** Blank out code spans, so an emoji quoted inline is not reported. */
-function withoutCodeSpans(line) {
-  return line.replace(/`+[^`]*`+/g, (span) => ' '.repeat(span.length));
+/** Blank out code spans, so what they quote is not checked. */
+const withoutCodeSpans = (line) => line.replace(/`+[^`]*`+/g, (span) => ' '.repeat(span.length));
+
+/**
+ * Walk a file's lines, yielding the ones that carry prose, with a flag for the
+ * front matter — code blocks, code spans and JSX template literals are gone.
+ */
+function* proseLines(text) {
+  const lines = text.split('\n');
+  const frontMatterEnd = lines[0]?.trim() === '---' ? lines.indexOf('---', 1) : -1;
+  let fence = false;
+  let template = false;
+
+  for (const [index, line] of lines.entries()) {
+    if (/^\s*(```+|~~~+)/.test(line)) {
+      fence = !fence;
+      continue;
+    }
+    // A JSX expression template literal, as <Terminal>{`...`}</Terminal> uses.
+    const opens = line.includes('{`');
+    const closes = line.includes('`}');
+    if (template) {
+      template = !closes;
+      continue;
+    }
+    if (opens && !closes) {
+      template = true;
+      continue;
+    }
+    if (fence || lines[index - 1]?.includes(ALLOW)) {
+      continue;
+    }
+    yield {
+      number: index + 1,
+      raw: line,
+      prose: withoutCodeSpans(line),
+      inFrontMatter: index > 0 && index < frontMatterEnd,
+    };
+  }
 }
 
 const problems = [];
+const report = (file, line, kind, detail) =>
+  problems.push({kind, where: `${path.relative(ROOT, file)}:${line.number}`, detail, line});
 
 for (const file of TARGETS.flatMap(markdownFiles)) {
-  const lines = fs.readFileSync(file, 'utf8').split('\n');
-  let fence = false;
+  for (const line of proseLines(fs.readFileSync(file, 'utf8'))) {
+    for (const match of line.prose.matchAll(new RegExp(EMOJI_SOURCE, 'gu'))) {
+      report(file, line, 'character', `${match[0]} at column ${match.index + 1}`);
+    }
 
-  lines.forEach((line, index) => {
-    if (/^\s*(```+|~~~+)/.test(line)) {
-      fence = !fence;
-      return;
+    const attributes = line.prose.match(ATTRIBUTE) ?? [];
+
+    for (const match of line.prose.matchAll(SHORTCODE)) {
+      const name = match[0].slice(1, -1);
+      const emoji = resolve(name);
+
+      if (!emoji) {
+        if (looksIntentional(line.prose, match)) {
+          report(file, line, 'unknown', `${match[0]} — no emoji has this name`);
+        }
+        continue;
+      }
+      if (line.inFrontMatter) {
+        report(file, line, 'dead', `${match[0]} in front matter`);
+      } else if (attributes.some((attribute) => attribute.includes(match[0]))) {
+        report(file, line, 'dead', `${match[0]} in an attribute value`);
+      }
+      // No variation selector and a base that fonts render as text: a flat,
+      // monochrome glyph instead of the emoji.
+      if (!emoji.includes('️') && !/^\p{Emoji_Presentation}/u.test(emoji)) {
+        report(file, line, 'flat', `${match[0]} resolves to ${emoji}, without U+FE0F`);
+      }
+      if (/^#{1,6}\s/.test(line.raw.trim()) && !/\{#[^}]+\}/.test(line.raw)) {
+        report(file, line, 'heading', `${match[0]} in a heading with no {#id}`);
+      }
     }
-    if (fence || lines[index - 1]?.includes(ALLOW)) {
-      return;
-    }
-    for (const match of withoutCodeSpans(line).matchAll(new RegExp(EMOJI_SOURCE, 'gu'))) {
-      problems.push(
-        `${path.relative(ROOT, file)}:${index + 1}:${match.index + 1}: ${match[0]}  in: ${line.trim()}`,
-      );
-    }
-  });
+  }
 }
 
+const EXPLANATIONS = {
+  character:
+    'Emoji characters in the sources. Write the `:name:` shortcode instead, so\n' +
+    '  the markdown stays readable to anyone using a screen reader.',
+  unknown:
+    'Names nothing resolves, which render as the literal text `:name:`. Fix the\n' +
+    '  typo, or add the emoji to ALIASES in src/plugins/emoji/vocabulary.js if\n' +
+    '  gemoji has a name for it.',
+  flat:
+    'Names that resolve without the U+FE0F variation selector, so some fonts draw\n' +
+    '  a flat monochrome glyph. Add the colourful form to PRESENTATION in\n' +
+    '  src/plugins/emoji/vocabulary.js.',
+  dead: 'Shortcodes where nothing converts them: front matter and attribute values\n' +
+    '  are not markdown text. Rewrite so the emoji sits in the page text.',
+  heading:
+    'Headings with an emoji and no explicit {#id}: the id is built before the\n' +
+    '  shortcode is converted, so it would be made out of the emoji name. Add the\n' +
+    '  id, or run `npm run write-heading-ids`.',
+};
+
 if (problems.length > 0) {
-  console.error(
-    `Emoji characters in documentation sources (${problems.length}). Write the ` +
-      '`:name:` shortcode instead — see the Emoji section of README.md.\n',
-  );
-  problems.forEach((problem) => console.error(`  ${problem}`));
+  console.error(`Emoji problems in the documentation sources (${problems.length}).\n`);
+  for (const [kind, explanation] of Object.entries(EXPLANATIONS)) {
+    const found = problems.filter((problem) => problem.kind === kind);
+    if (found.length === 0) {
+      continue;
+    }
+    console.error(`${explanation}\n`);
+    for (const problem of found) {
+      console.error(`  ${problem.where}: ${problem.detail}`);
+      console.error(`    ${problem.line.raw.trim().slice(0, 100)}`);
+    }
+    console.error('');
+  }
+  console.error('See the Emoji section of README.md.');
   process.exit(1);
 }
 
-console.log('No emoji characters in the documentation sources.');
+console.log('Emoji: no characters in the sources, every shortcode resolves.');

--- a/src/plugins/emoji/headings.js
+++ b/src/plugins/emoji/headings.js
@@ -1,0 +1,185 @@
+/**
+ * Rehype plugin: make the emoji in the built page readable to assistive tech.
+ *
+ * The markdown sources hold no emoji characters — contributors write `:name:`
+ * and the build inserts the character (see inline.js) — but that only ever fixed
+ * the *sources*. The rendered page still put the character in the heading text,
+ * where a screen reader announces the decoration before the label on every
+ * heading, and a braille display, having no cell for the code point, shows a
+ * placeholder the reader has to route the cursor to in order to identify.
+ *
+ * Neither is fixable at the character: what a braille display receives is text,
+ * so the only lever is changing the text. This plugin does that, two ways.
+ *
+ * A heading's leading emoji is decoration — the heading reads correctly without
+ * it — so it is hidden from assistive tech where it stands:
+ *
+ *     <h2 id="serial-console-access"><span aria-hidden="true">🧵</span> Serial…</h2>
+ *
+ * toc.js does the same to the table of contents, which Docusaurus builds from
+ * the markdown, too early for a rehype plugin to reach.
+ *
+ * Why aria-hidden rather than drawing the emoji from a data attribute as CSS
+ * generated content — which would additionally keep it out of the text copied
+ * with the heading and out of the search index? Because support. `aria-hidden`
+ * is ARIA 1.0 and needs no CSS at all, where `content: … / ''` is recent
+ * (roughly Chrome 77, Safari 17.4, Firefox 137) and absent from text-mode
+ * browsers entirely, so in w3m and in anything older the heading emoji would
+ * simply disappear. Keeping the character in the DOM is the price of having it
+ * render everywhere.
+ *
+ * That trade is forced, not an oversight: in a text browser the visible text
+ * *is* the accessibility tree, so nothing can show w3m the emoji while hiding it
+ * from a screen reader. CSS works in graphical browsers only because it offers a
+ * visual-only channel that a terminal does not have.
+ *
+ * Every other emoji is content rather than decoration — the ⚠️ opening a caveat
+ * means something — so it stays, and gets a real accessible name instead:
+ *
+ *     <span role="img" aria-label="rocket">🚀</span>
+ *
+ * `role="img"` is the part that matters. `aria-label` on a bare <span> is a
+ * generic role and is not reliably exposed; with the role, the accessible name
+ * replaces the content, so a braille display receives the word in ordinary cells
+ * rather than an unmapped character. Speech is unchanged: the name is the one a
+ * screen reader would have announced for the character anyway.
+ *
+ * A heading whose emoji is not leading, or which has a second one, keeps it in
+ * the text and it falls through to the span treatment. That is a correct result
+ * rather than a failure, so it is deliberately not an error — no contributor has
+ * to remember a rule about it.
+ */
+
+const {EMOJI_SOURCE, label} = require('./vocabulary');
+
+const HEADINGS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
+
+// Quoted material keeps its characters and must not be touched: fenced blocks
+// and code spans hold sample output such as the saxophone in the xo-api payload,
+// and the ★ that labels a footnote lives in an inline SVG.
+const SKIP = new Set(['pre', 'code', 'svg']);
+
+/**
+ * Whether assistive tech has already been told what to do with this subtree.
+ *
+ * Two cases. The heading emoji this plugin has just hidden, which must not then
+ * be labelled as well. And the footnote back-references remark-gfm generates —
+ * `<a aria-label="Back to reference 1">↩</a>` is already named, so labelling the
+ * ↩ inside it would nest a role for no gain.
+ */
+function carriesOwnAria(node) {
+  const properties = node.properties ?? {};
+  return Boolean(
+    properties['aria-label'] ??
+      properties.ariaLabel ??
+      properties['aria-hidden'] ??
+      properties.ariaHidden,
+  );
+}
+
+const LEADING_EMOJI = new RegExp(`^${EMOJI_SOURCE}`, 'u');
+const HAS_EMOJI = new RegExp(EMOJI_SOURCE, 'u');
+const EMOJI = new RegExp(EMOJI_SOURCE, 'gu');
+
+/**
+ * Hide a heading's leading emoji from assistive tech, in place.
+ *
+ * The space after the emoji stays in the text, so the heading still reads as
+ * `🧵 Serial console access` on screen with no styling involved.
+ */
+function hideLeadingEmoji(heading) {
+  const first = heading.children?.[0];
+  if (first?.type !== 'text') {
+    return;
+  }
+
+  const [emoji] = first.value.match(LEADING_EMOJI) ?? [];
+  if (!emoji) {
+    return;
+  }
+
+  // The emoji and the text after it may be one node or two, depending on what
+  // produced them. Drop the node if the emoji was all of it.
+  first.value = first.value.slice(emoji.length);
+  if (first.value === '') {
+    heading.children.shift();
+  }
+
+  heading.children.unshift({
+    type: 'element',
+    tagName: 'span',
+    properties: {'aria-hidden': 'true'},
+    children: [{type: 'text', value: emoji}],
+  });
+}
+
+/** The children that replace a text node, with each emoji in it wrapped. */
+async function wrapEmoji(value) {
+  const children = [];
+  let done = 0;
+
+  for (const match of value.matchAll(EMOJI)) {
+    const emoji = match[0];
+    const name = await label(emoji);
+    // Nothing knows this one. Leaving the character alone is what remark-emoji
+    // does with a name it cannot resolve, and a label we made up would be worse
+    // than the one the screen reader already has. `done` deliberately does not
+    // move, so the character stays in the text that follows.
+    if (!name) {
+      continue;
+    }
+
+    if (match.index > done) {
+      children.push({type: 'text', value: value.slice(done, match.index)});
+    }
+    children.push({
+      type: 'element',
+      tagName: 'span',
+      properties: {role: 'img', 'aria-label': name},
+      children: [{type: 'text', value: emoji}],
+    });
+    done = match.index + emoji.length;
+  }
+
+  if (children.length === 0) {
+    return undefined;
+  }
+  if (done < value.length) {
+    children.push({type: 'text', value: value.slice(done)});
+  }
+  return children;
+}
+
+module.exports = function emojiAccessibility() {
+  return async (tree) => {
+    const texts = [];
+
+    (function walk(node, parent) {
+      if (node.type === 'element') {
+        if (SKIP.has(node.tagName) || carriesOwnAria(node)) {
+          return;
+        }
+        // Before the children are walked, so the emoji it hides ends up inside
+        // an aria-hidden span that the walk then skips rather than labels.
+        if (HEADINGS.has(node.tagName)) {
+          hideLeadingEmoji(node);
+        }
+      }
+
+      // Collected rather than replaced here, because wrapping is async and this
+      // walk would otherwise have to rebuild children mid-traversal.
+      if (node.type === 'text' && parent && HAS_EMOJI.test(node.value)) {
+        texts.push({parent, node});
+      }
+
+      node.children?.forEach((child) => walk(child, node));
+    })(tree, undefined);
+
+    for (const {parent, node} of texts) {
+      const children = await wrapEmoji(node.value);
+      if (children) {
+        parent.children.splice(parent.children.indexOf(node), 1, ...children);
+      }
+    }
+  };
+};

--- a/src/plugins/emoji/inline.js
+++ b/src/plugins/emoji/inline.js
@@ -1,0 +1,40 @@
+/**
+ * Remark plugin: convert the `:name:` shortcodes that Docusaurus's built-in
+ * remark-emoji cannot, so every emoji in the docs can be written as ASCII.
+ *
+ * Docusaurus already converts shortcodes (markdown.emoji, on by default). This
+ * only fills the gaps in its dataset, listed in vocabulary.js: names it does not
+ * know at all, such as `:green_circle:`, and names where it returns a
+ * text-presentation codepoint, such as `:gear:`. Everything else keeps going
+ * through the mechanism Docusaurus documents.
+ *
+ * Registered as a beforeDefaultRemarkPlugin so it runs first and remark-emoji
+ * finds nothing left to do for these names. Headings go through it like any
+ * other text: their ids are computed by the default headings plugin, which runs
+ * earlier still, which is why an emoji heading needs an explicit `{#id}`.
+ *
+ * Unknown shortcodes are left alone, exactly as remark-emoji and GitHub leave
+ * them: `:foo:` renders as `:foo:`, visible enough that review catches it.
+ */
+
+const {NAMES} = require('./vocabulary');
+
+// Same shape as remark-emoji's own pattern, which is what contributors already
+// write against. `:+1:` and `:-1:` need the special case.
+const SHORTCODE = /:\+1:|:-1:|:[\w-]+:/g;
+
+module.exports = function inlineEmoji() {
+  return (tree) => {
+    (function walk(node) {
+      // Only text nodes: code spans and fenced blocks have their own node types,
+      // so a shortcode written inside them is left alone for free.
+      if (node.type === 'text') {
+        node.value = node.value.replace(
+          SHORTCODE,
+          (shortcode) => NAMES[shortcode.slice(1, -1)] ?? shortcode,
+        );
+      }
+      node.children?.forEach(walk);
+    })(tree);
+  };
+};

--- a/src/plugins/emoji/toc.js
+++ b/src/plugins/emoji/toc.js
@@ -1,0 +1,94 @@
+/**
+ * Remark plugin: hide the leading emoji in the table of contents entries too,
+ * the same way headings.js hides it in the headings themselves.
+ *
+ * Docusaurus builds the `toc` export from the markdown, well before headings.js
+ * gets a rehype tree to work on, so hiding it in the heading would leave the
+ * table of contents still announcing the character — and still showing a
+ * placeholder cell on a braille display.
+ *
+ * Each entry carries a `value` of ready-made HTML, rendered with
+ * dangerouslySetInnerHTML, so wrapping the emoji is all it takes:
+ *
+ *     value: '<span aria-hidden="true">🧵</span> Serial console access'
+ *
+ * Why not put the span in the heading and let the toc plugin serialise it?
+ * Because that serialiser keeps only `className` and drops every other
+ * attribute (toc/utils.js, mdxJsxTextElementToHtml), so `aria-hidden` would not
+ * survive the trip.
+ *
+ * This has to run after the default toc plugin, so register it in
+ * `remarkPlugins` rather than `beforeDefaultRemarkPlugins`.
+ */
+
+const {EMOJI_SOURCE} = require('./vocabulary');
+
+// Just the emoji: the space after it stays in the text, so the entry still reads
+// as `🧵 Serial console access` on screen.
+const LEADING_EMOJI = new RegExp(`^${EMOJI_SOURCE}`, 'u');
+
+/** Read a string out of an estree Identifier or Literal key. */
+function keyName(key) {
+  return key?.type === 'Identifier' ? key.name : key?.type === 'Literal' ? key.value : undefined;
+}
+
+/** Collect every ObjectExpression in an estree, however deeply nested. */
+function findObjectExpressions(node, found = []) {
+  if (!node || typeof node !== 'object') {
+    return found;
+  }
+  if (Array.isArray(node)) {
+    node.forEach((child) => findObjectExpressions(child, found));
+    return found;
+  }
+  if (node.type === 'ObjectExpression') {
+    found.push(node);
+  }
+  Object.values(node).forEach((value) => findObjectExpressions(value, found));
+  return found;
+}
+
+/** The exported `toc` declaration, or undefined if this page has none. */
+function findTocExport(tree) {
+  for (const node of tree.children) {
+    if (node.type !== 'mdxjsEsm' || !node.data?.estree) {
+      continue;
+    }
+    for (const statement of node.data.estree.body) {
+      const declared =
+        statement.type === 'ExportNamedDeclaration' && statement.declaration?.declarations?.[0];
+      if (declared && keyName(declared.id) === 'toc') {
+        return declared;
+      }
+    }
+  }
+  return undefined;
+}
+
+module.exports = function tocEmoji() {
+  return (tree) => {
+    const tocExport = findTocExport(tree);
+    if (!tocExport) {
+      // Nothing to do: a page can legitimately have no table of contents, and an
+      // .md file may export its own toc.
+      return;
+    }
+
+    for (const entry of findObjectExpressions(tocExport.init)) {
+      const value = entry.properties?.find((property) => keyName(property.key) === 'value')?.value;
+      if (value?.type !== 'Literal' || typeof value.value !== 'string') {
+        continue;
+      }
+
+      const [emoji] = value.value.match(LEADING_EMOJI) ?? [];
+      if (!emoji) {
+        continue;
+      }
+
+      value.value = `<span aria-hidden="true">${emoji}</span>${value.value.slice(emoji.length)}`;
+      // valueToEstree may have left a `raw` behind, which would win over `value`
+      // when this is printed back out.
+      delete value.raw;
+    }
+  };
+};

--- a/src/plugins/emoji/vocabulary.js
+++ b/src/plugins/emoji/vocabulary.js
@@ -1,6 +1,7 @@
 /**
- * Emoji vocabulary, shared by the emoji remark plugin (inline.js) and by the
- * check script that enforces the rule (scripts/check-emoji.js).
+ * Emoji vocabulary, shared by the three emoji build plugins (inline.js,
+ * headings.js, toc.js) and by the check script that enforces the rule
+ * (scripts/check-emoji.js).
  *
  * Documentation sources contain no emoji characters: contributors write the
  * `:name:` shortcode and the build inserts the character. Docusaurus does that
@@ -112,4 +113,43 @@ const EMOJI_SOURCE = [
   '(?:\\u200D.(?:\\uFE0F|[\\u{1F3FB}-\\u{1F3FF}])?)*',
 ].join('');
 
-module.exports = {NAMES, EMOJI_SOURCE};
+// The other direction, character to name, for the plugins that have to label an
+// emoji they find in the built page. node-emoji's own `which` covers everything
+// remark-emoji converted; this covers the names it had never heard of, which are
+// exactly the ones ALIASES exists for.
+//
+// The two gemoji names that are not words go in as well: `+1` would reach a
+// screen reader as "plus one", which is not what 👍 means to a reader.
+const OWN_LABELS = {
+  ...Object.fromEntries(Object.entries(NAMES).map(([name, character]) => [character, name])),
+  '👍': 'thumbs_up',
+  '👎': 'thumbs_down',
+};
+
+// node-emoji is ESM-only and this file is required from a CommonJS config, so it
+// has to be imported dynamically. Cache the promise: label() is called once per
+// emoji, on every page.
+let nodeEmojiPromise;
+
+function nodeEmoji() {
+  nodeEmojiPromise ??= import('node-emoji');
+  return nodeEmojiPromise;
+}
+
+/**
+ * The accessible name for an emoji character: its emoji name, spelled out.
+ *
+ * This is what a braille display receives in place of the character, so it has
+ * to be words rather than a shortcode — `desktop computer`, not
+ * `desktop_computer`. It matches what a screen reader announces for the bare
+ * character anyway, so speech is unchanged.
+ *
+ * @param {string} character a single emoji, variation selector and all
+ * @returns {Promise<string | undefined>} undefined if nothing knows this emoji
+ */
+async function label(character) {
+  const name = OWN_LABELS[character] ?? (await nodeEmoji()).which(character);
+  return name?.replace(/_/g, ' ');
+}
+
+module.exports = {NAMES, EMOJI_SOURCE, label};

--- a/src/plugins/emoji/vocabulary.js
+++ b/src/plugins/emoji/vocabulary.js
@@ -1,0 +1,109 @@
+/**
+ * Emoji vocabulary, shared by the emoji remark plugin (inline.js) and by the
+ * check script that enforces the rule (scripts/check-emoji.js).
+ *
+ * Documentation sources contain no emoji characters: contributors write the
+ * `:name:` shortcode and the build inserts the character. Docusaurus does that
+ * conversion itself (markdown.emoji, on by default, via remark-emoji), so the
+ * only thing needed here is the handful of names remark-emoji gets wrong.
+ */
+
+// Names remark-emoji does not know. Its dataset is node-emoji, built on
+// emojilib, whose vocabulary predates Unicode 12 and the ZWJ profession
+// sequences, so it is missing everything below. The names follow gemoji (what
+// GitHub uses) so contributors' habits keep working.
+//
+// The regional_indicator_* entries are the Slack/Discord convention. We use
+// four of them as vendor initials in "From VMware" and friends.
+const ALIASES = {
+  adhesive_bandage: '🩹',
+  cartwheeling: '🤸',
+  coin: '🪙',
+  green_circle: '🟢',
+  guide_dog: '🦮',
+  health_worker: '🧑‍⚕️',
+  ice_cube: '🧊',
+  identification_card: '🪪',
+  ladder: '🪜',
+  magic_wand: '🪄',
+  placard: '🪧',
+  regional_indicator_h: '🇭',
+  regional_indicator_k: '🇰',
+  regional_indicator_v: '🇻',
+  regional_indicator_x: '🇽',
+  scientist: '🧑‍🔬',
+  shaking_face: '🫨',
+  stethoscope: '🩺',
+  technologist: '🧑‍💻',
+  wheel: '🛞',
+  window: '🪟',
+  yellow_circle: '🟡',
+};
+
+// Names where remark-emoji returns the text-presentation codepoint, without the
+// U+FE0F variation selector. Some browser and font combinations render those as
+// a flat monochrome glyph. These are the emoji-presentation forms the docs
+// displayed back when the characters lived in the markdown, so keep them.
+const PRESENTATION = {
+  artificial_satellite: '🛰️',
+  balance_scale: '⚖️',
+  building_construction: '🏗️',
+  card_file_box: '🗃️',
+  card_index_dividers: '🗂️',
+  computer_mouse: '🖱️',
+  control_knobs: '🎛️',
+  desktop_computer: '🖥️',
+  file_cabinet: '🗄️',
+  framed_picture: '🖼️',
+  gear: '⚙️',
+  hammer_and_wrench: '🛠️',
+  houses: '🏘️',
+  keyboard: '⌨️',
+  label: '🏷️',
+  motorway: '🛣️',
+  pen: '🖊️',
+  radioactive: '☢️',
+  rescue_worker_helmet: '⛑️',
+  shield: '🛡️',
+  spider_web: '🕸️',
+  wastebasket: '🗑️',
+  world_map: '🗺️',
+  writing_hand: '✍️',
+};
+
+/** The names this plugin handles itself, i.e. everything remark-emoji gets wrong. */
+const NAMES = {...ALIASES, ...PRESENTATION};
+
+// What counts as "an emoji character" for the check script, as a regexp source
+// string to be compiled with the 'u' flag. Deliberately a list
+// of the emoji ranges rather than the whole Miscellaneous Symbols and Dingbats
+// blocks: those blocks also hold characters the docs legitimately use as text —
+// ★ labels a footnote in an inline SVG, → appears in prose, and the build system
+// pages draw trees out of box-drawing characters. None of those have an emoji
+// name, and none of them read as an emoji to a screen reader.
+const EMOJI_SOURCE = [
+  '[',
+  '\\u00A9\\u00AE\\u203C\\u2049\\u2122\\u2139',
+  '\\u2194-\\u2199\\u21A9\\u21AA',
+  '\\u231A\\u231B\\u2328\\u23CF\\u23E9-\\u23F3\\u23F8-\\u23FA',
+  '\\u24C2\\u25AA\\u25AB\\u25B6\\u25C0\\u25FB-\\u25FE',
+  '\\u2600-\\u2604\\u260E\\u2611\\u2614\\u2615\\u2618\\u261D\\u2620\\u2622\\u2623',
+  '\\u2626\\u262A\\u262E\\u262F\\u2638-\\u263A\\u2640\\u2642\\u2648-\\u2653',
+  '\\u265F\\u2660\\u2663\\u2665\\u2666\\u2668\\u267B\\u267E\\u267F',
+  '\\u2692-\\u2697\\u2699\\u269B\\u269C\\u26A0\\u26A1\\u26A7\\u26AA\\u26AB',
+  '\\u26B0\\u26B1\\u26BD\\u26BE\\u26C4\\u26C5\\u26C8\\u26CE\\u26CF\\u26D1',
+  '\\u26D3\\u26D4\\u26E9\\u26EA\\u26F0-\\u26F5\\u26F7-\\u26FA\\u26FD',
+  '\\u2702\\u2705\\u2708-\\u270D\\u270F\\u2712\\u2714\\u2716\\u271D\\u2721\\u2728',
+  '\\u2733\\u2734\\u2744\\u2747\\u274C\\u274E\\u2753-\\u2755\\u2757\\u2763\\u2764',
+  '\\u2795-\\u2797\\u27A1\\u27B0\\u27BF',
+  '\\u2934\\u2935\\u2B05-\\u2B07\\u2B1B\\u2B1C\\u2B50\\u2B55',
+  '\\u3030\\u303D\\u3297\\u3299',
+  '\\u{1F000}-\\u{1FAFF}',
+  ']',
+  // Keep a variation selector, skin tone or ZWJ sequence together with its base,
+  // so a single emoji is reported once instead of two or three times.
+  '(?:\\uFE0F|[\\u{1F3FB}-\\u{1F3FF}])?',
+  '(?:\\u200D.(?:\\uFE0F|[\\u{1F3FB}-\\u{1F3FF}])?)*',
+].join('');
+
+module.exports = {NAMES, EMOJI_SOURCE};

--- a/src/plugins/emoji/vocabulary.js
+++ b/src/plugins/emoji/vocabulary.js
@@ -6,6 +6,10 @@
  * `:name:` shortcode and the build inserts the character. Docusaurus does that
  * conversion itself (markdown.emoji, on by default, via remark-emoji), so the
  * only thing needed here is the handful of names remark-emoji gets wrong.
+ *
+ * The two tables below are the ones to extend when a name does not work. Which
+ * one depends on the symptom, and the Emoji section of README.md walks a
+ * contributor through it — keep the two in step if you change how this works.
  */
 
 // Names remark-emoji does not know. Its dataset is node-emoji, built on

--- a/src/plugins/emoji/vocabulary.js
+++ b/src/plugins/emoji/vocabulary.js
@@ -51,6 +51,7 @@ const ALIASES = {
 const PRESENTATION = {
   artificial_satellite: '🛰️',
   balance_scale: '⚖️',
+  biohazard: '☣️',
   building_construction: '🏗️',
   card_file_box: '🗃️',
   card_index_dividers: '🗂️',
@@ -70,6 +71,7 @@ const PRESENTATION = {
   rescue_worker_helmet: '⛑️',
   shield: '🛡️',
   spider_web: '🕸️',
+  thermometer: '🌡️',
   wastebasket: '🗑️',
   world_map: '🗺️',
   writing_hand: '✍️',


### PR DESCRIPTION
This is a RFC/prototype, which could turn into a plain PR if deemed good enough despite I can't vouch for the technical aspects, that were managed by an AI agent. Else, we can also throw this draft away and have someone else implement it better.

There are two use cases to care for: HTML and markdown. A blind reader may prefer reading the markdown directly rather than the HTML website. But unicode emojis don't always render well with braille screen readers (they may render as ? and then you have to do manual steps to know what character that is actually) and text to speech.

The proposed approach is to replace the unicode emojis with :emoji-name:. Some are not supported out of the box by docusaurus, so in this draft implementation, the LLM has done some magic to include a JS plugin that makes it work, but it comes at the cost of added JS dependencies and of maintaining a list of extra emoji names. To mitigate the risk of getting it wrong as a doc contributor, a github action would attempt to detect broken emojis (that I have entirely NOT tested).

I also suggest implementing such a change in Xen Orchestra docs and Vates docs.

Whatever the chosen approach, we should then implement it in all Vates docs too for consistency.

I'm handing over this accessibility topic to the doc team, that can use this draft if useful, or do something else.

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
