### PR TITLE
docs: remove the emoji left in headings

### DIFF
--- a/docs/guides/create-use-custom-xcpng-ubuntu-templates.md
+++ b/docs/guides/create-use-custom-xcpng-ubuntu-templates.md
@@ -17,7 +17,7 @@ This post explains in detail the steps to create templates based on Ubuntu. The 
 
 All experiments will be conducted using the graphical virtual machine manager [Xen Orchestra](https://xen-orchestra.com), except for the last part where we will use XO-CLI (Xen Orchestra CLI) to bypass the graphical interface.
 
-## ℹ️ Prerequisites {#prerequisites}
+## Prerequisites {#prerequisites}
 
 * [XCP-NG](https://xcp-ng.org/)
 * [Xen Orchestra](https://xen-orchestra.com) from the sources or Xen Orchestra virtual Appliance (XOA)

--- a/docs/guides/guest-UEFI-Secure-Boot.md
+++ b/docs/guides/guest-UEFI-Secure-Boot.md
@@ -4,7 +4,7 @@ How to configure UEFI Secure boot?
 
 Enabling UEFI Secure Boot for guests ensures that XCP-ng VMs will only execute trusted binaries at boot. In practice, these are the binaries released by the operating system (OS) vendor for the OS running in the VM (Microsoft Windows, Debian, RHEL, Alpine, etc.).
 
-## 🆕 Recent changes in guest Secure Boot configuration {#recent-changes-in-guest-secure-boot-configuration}
+## Recent changes in guest Secure Boot configuration {#recent-changes-in-guest-secure-boot-configuration}
 
 The default guest Secure Boot keys in XCP-ng are changing.
 
@@ -44,7 +44,7 @@ This step is also required for Secure Boot support on previously V2V-migrated VM
 **Risk of data loss:** Propagating certificates to an existing VM will change its Secure Boot vTPM measurements. If you depend on these measurements (e.g. BitLocker with TPM protector), you must carefully read the [Preparing for Secure Boot Variable Changes](#preparing-for-secure-boot-variable-changes) procedure.
 :::
 
-## ℹ️ Requirements {#requirements}
+## Requirements {#requirements}
 
 * XCP-ng >= 8.2.1.
 * UEFI Secure Boot Certificates installed on the pool (this is detailed below).
@@ -52,7 +52,7 @@ This step is also required for Secure Boot support on previously V2V-migrated VM
 
 Note: it's not necessary that the XCP-ng host boots in UEFI mode for Secure Boot to be enabled on VMs.
 
-## 🆙 8.3 with varstored >= 1.2.0-3.4 {#83-with-varstored--120-34}
+## 8.3 with varstored >= 1.2.0-3.4 {#83-with-varstored--120-34}
 
 Secure Boot is ready to use on new VMs without extra configuration. Simply activate Secure Boot on your VMs, and they will be provided with an appropriate set of default Secure Boot variables.
 

--- a/docs/management/ha.md
+++ b/docs/management/ha.md
@@ -186,7 +186,7 @@ If you have enough memory to put one host in maintenance (migrating all its VMs 
 - **Do NOT restart host toolstacks while high availability is enabled!** Attempting to restart the toolstack on an active host will cause the host to be immediately fenced and removed from the active liveset and pool. Always make sure that HA is disabled before restarting toolstacks.
 :::
 
-## ↔️ Behavior {#behavior}
+## Behavior {#behavior}
 
 ### Halting the VM
 

--- a/docs/management/hosts-pools.md
+++ b/docs/management/hosts-pools.md
@@ -188,7 +188,7 @@ You can also use `xsconsole` (the text console you get on the host's physical/se
 
 Lost the root password? See the [reset procedure](../troubleshooting/common-problems.md#reset-xcp-ng-root-password) in the troubleshooting section.
 
-## ⏰ Time synchronization (NTP) {#time-synchronization-ntp}
+## Time synchronization (NTP) {#time-synchronization-ntp}
 
 Correct and consistent clocks across the pool matter more than on ordinary servers: XAPI coordination, live migration, HA heartbeats, logs correlation and Windows guests (which get their initial time from the host) all rely on it. NTP servers are normally configured at [installation time](../installation/install-xcp-ng.md).
 

--- a/docs/management/manage-locally/cli.md
+++ b/docs/management/manage-locally/cli.md
@@ -6,7 +6,7 @@ The xe CLI can be used locally on any XCP-ng host, it's installed along with it.
 The complete set of all `xe` commands is available in the [Appendix section](../../../appendix/cli_reference).
 :::
 
-## ℹ️ Getting help with xe commands {#getting-help-with-xe-commands}
+## Getting help with xe commands {#getting-help-with-xe-commands}
 
 Basic help is available for CLI commands on-host by typing the following:
 
@@ -96,7 +96,7 @@ After running this command, you no longer have to specify the remote XCP-ng serv
 
 Using the `XE_EXTRA_ARGS` environment variable also enables tab completion of xe commands when issued against a remote XCP-ng server, which is disabled by default.
 
-## 🀄 Special characters and syntax {#special-characters-and-syntax}
+## Special characters and syntax {#special-characters-and-syntax}
 
 To specify argument/value pairs on the xe command line, write: `argument=value`
 

--- a/docs/management/updates.md
+++ b/docs/management/updates.md
@@ -22,7 +22,7 @@ We maintain one or several releases in parallel:
 
 If your version is lower than `8.3`, it will not receive updates anymore. To keep benefiting from bugfixes and security fixes you need to [upgrade](../../installation/upgrade).
 
-## ℹ️ Prerequisites {#prerequisites}
+## Prerequisites {#prerequisites}
 
 ### Access to the repository
 

--- a/docs/management/vm-load-balancing.md
+++ b/docs/management/vm-load-balancing.md
@@ -98,7 +98,7 @@ The global situation (resource usage) is examined **every minute**.
 TODO: more details to come here
 :::
 
-## ↔️ VM anti-affinity {#vm-anti-affinity}
+## VM anti-affinity {#vm-anti-affinity}
 
 VM anti-affinity is a feature that prevents VMs with the same user tags from running on the same host. This functionality is available directly in the load-balancer plugin.
 This way, you can avoid having pairs of redundant VMs or similar running on the same host.

--- a/docs/project/architecture.md
+++ b/docs/project/architecture.md
@@ -87,7 +87,7 @@ For each read/write in the VM disk, requests pass through an emulated driver, th
 The process described above is used for HVMs and also for PV guests (at startup, PV drivers are not loaded).
 After starting a PV guest, the emulated driver in the VM is replaced by `blkfront` (a PV driver) which allows to communicate directly with `tapdisk` using a protocol: `blkif`; `blktap` and `qemu-dm` then become useless to handle devices requests. Note that system calls are used with two drivers: `eventchn dev` and `gntdev` to map VM memory pages in the user space of the host. Thus a shared ring can be used to receive requests directly from `tapdisk` in host user space instead of using the kernel space.
 
-## ↕️ Components for VDI I/O {#components-for-vdi-io}
+## Components for VDI I/O {#components-for-vdi-io}
 
 ### XenStore
 

--- a/docs/project/development-process/build-system.md
+++ b/docs/project/development-process/build-system.md
@@ -161,7 +161,7 @@ Then, if it is an **update candidate** for an existing package:
     * What to test.
     * Is a reboot required…
 
-## 🆕 Special case: new packages {#special-case-new-packages}
+## Special case: new packages {#special-case-new-packages}
 Importing new packages requires extra steps.
 
 **TODO**

--- a/docs/releases/release-8-1.md
+++ b/docs/releases/release-8-1.md
@@ -12,7 +12,7 @@ XCP-ng 8.1 is EOL (End Of Life) since 2021. Please check the [currently supporte
 
 SHA256 checksums, GPG signatures and net-install ISO are available [here](http://mirrors.xcp-ng.org/isos/8.1/).
 
-## ℹ️ Release information {#release-information}
+## Release information {#release-information}
 
 * Released on 2020-03-31.
 * Based on Citrix Hypervisor 8.1.

--- a/docs/releases/release-8-2.md
+++ b/docs/releases/release-8-2.md
@@ -18,7 +18,7 @@ SHA256 checksums, GPG signatures and net-install ISO are available [here](https:
 LTS means **Long Term Support**: more information in [this section](../#lts-releases).
 :::
 
-## ℹ️ Release information {#release-information}
+## Release information {#release-information}
 
 * Released on 2020-11-18
 * Based on Citrix Hypervisor 8.2
@@ -161,7 +161,7 @@ Plans are laid out for simpler installation and maintenance of Windows guest too
 
 Using the Windows guest tools is [documented here](/vms#windows-guest-tools).
 
-## 🆕 Update: what's new in XCP-ng 8.2.1 {#update-whats-new-in-xcp-ng-821}
+## Update: what's new in XCP-ng 8.2.1 {#update-whats-new-in-xcp-ng-821}
 
 XCP-ng 8.2.1 was released as a maintenance update for XCP-ng 8.2 LTS, which has its own version number because it also comes with updated installation images.
 

--- a/docs/releases/release-8-3.md
+++ b/docs/releases/release-8-3.md
@@ -22,7 +22,7 @@ LTS means **Long Term Support**: more information in [this section](../#lts-rele
 * [Attention points](#attention-points) - Highly recommended read before upgrading.
 * [Known issues](#known-issues)
 
-## ℹ️ Release information {#release-information}
+## Release information {#release-information}
 
 For this release, the product lifecycle has changed:
 * A longer preview phase, enabling broad user feedback, now ended.

--- a/docs/troubleshooting/advanced.md
+++ b/docs/troubleshooting/advanced.md
@@ -65,6 +65,6 @@ When reporting such a crash (forum or support), provide the crash dump contents 
 3. You can boot the [installation ISO](installation-upgrade.md) and use its shell for repairs: your root filesystem can be mounted from there (the installer's rescue capabilities are also usable over [remote access during installation](installation-upgrade.md#getting-remote-access-to-host-during-installation)).
 4. For RAID-related boot failures, see [software RAID issues](storage/disk-failure-software-RAID.md).
 
-## 🆘 Produce a status report {#produce-a-status-report}
+## Produce a status report {#produce-a-status-report}
 
 When asking for help, generate a status report archive containing logs and configuration: see [the procedure](log-files.md#produce-a-status-report). Mention exactly what you changed last: most "impossible" host issues follow a recent change.

--- a/docs/troubleshooting/common-problems.md
+++ b/docs/troubleshooting/common-problems.md
@@ -92,7 +92,7 @@ Try these steps:
 
 ---
 
-## ⏰ Server loses time on 14th gen Dell hardware {#server-loses-time-on-14th-gen-dell-hardware}
+## Server loses time on 14th gen Dell hardware {#server-loses-time-on-14th-gen-dell-hardware}
 
 ### Cause
 
@@ -309,7 +309,7 @@ To know more about certificates in XAPI, check out the [XAPI documentation](http
 
 ---
 
-## ⌨️ Installation hanging at "Select Keymap" {#installation-hanging-at-select-keymap}
+## Installation hanging at "Select Keymap" {#installation-hanging-at-select-keymap}
 
 ### Issue
 

--- a/docs/troubleshooting/storage/disk-failure-software-RAID.md
+++ b/docs/troubleshooting/storage/disk-failure-software-RAID.md
@@ -6,7 +6,7 @@ title: 'Software RAID issues'
 
 This page regroups the common issues you might deal with regarding software RAID.
 
-## ⏏️ Disk replacement with software RAID {#disk-replacement-with-software-raid}
+## Disk replacement with software RAID {#disk-replacement-with-software-raid}
 
 If XCP-ng has been installed with a *software RAID 1 full disk mirror* method, a disk failure can be fixed with a disk replacement. Here's how:
 

--- a/docs/vms/advanced.md
+++ b/docs/vms/advanced.md
@@ -48,7 +48,7 @@ Notes:
 * If the guest uses the TPM for disk encryption (e.g. BitLocker), **keep your recovery keys safe**: losing the vTPM state means the guest can't unseal its keys.
 * Suspending or checkpointing (RAM snapshot) a vTPM-equipped VM is not supported.
 
-## ⏰ Time in VMs {#time-in-vms}
+## Time in VMs {#time-in-vms}
 
 Guests get their initial clock from the host, then keep time themselves. Recommendations:
 

--- a/docs/vms/snapshots.md
+++ b/docs/vms/snapshots.md
@@ -68,7 +68,7 @@ xe vm-checkpoint vm="my-vm" new-name-label="before-upgrade-with-ram"
 In Xen Orchestra you can exclude specific disks from snapshots (and backups) by naming convention: putting `[NOSNAP]` (snapshots) or `[NOBAK]` (backups and their snapshots) in the disk's name. Very useful for large scratch/data disks. On XCP-ng 8.3, disk exclusion is supported natively by the snapshot API, which XO uses.
 :::
 
-## ⏪ Revert to a snapshot {#revert-to-a-snapshot}
+## Revert to a snapshot {#revert-to-a-snapshot}
 
 Reverting replaces the VM's current state with the snapshot's state. **Everything written since the snapshot is lost.**
 


### PR DESCRIPTION
Follow-up to #525. That sweep only matched part of the emoji code point ranges, so headings using BMP symbols (`ℹ️ ↔️ ↕️ ⏰ ⌨️ ⏏️`) or the enclosed-alphanumeric block (`🆕 🆙 🆘 🀄 ⏪`) kept theirs, e.g. `## ℹ️ Requirements` on the [guest UEFI Secure Boot](https://docs.xcp-ng.org/guides/guest-UEFI-Secure-Boot/) page.

Removes the 22 remaining occurrences across 17 files. A fresh scan of `docs/` and `blog/` now returns zero emoji in Markdown headings.

Headings only: body text, tables, diagrams and code samples are untouched. Explicit `{#anchor}` IDs are unchanged, so no incoming link or in-page anchor breaks.