### PR TITLE
Fix link to extract install.img documentation

### DIFF
--- a/docs/installation/install-xcp-ng.md
+++ b/docs/installation/install-xcp-ng.md
@@ -486,7 +486,7 @@ If you can neither setup PXE nor serve the answerfile from a server that will be
         module2 /install.img
     }
     ```
-4. [Extract install.img](../../project/development-process/ISO-modification#extract-an-existing-iso-image)
+4. [Extract install.img](../../project/development-process/ISO-modification#extract-installimg)
 5. Add your answerfile
     ```
     cp answerfile.xml "$WORK_DIR/install/answerfile.xml"


### PR DESCRIPTION
Link was pointing to extraction of an ISO file instead of an install.img file.



> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
