### PR TITLE
Add a Invariant TSC section

### DIFF
--- a/docs/compute.md
+++ b/docs/compute.md
@@ -176,6 +176,11 @@ xe vm-param-set other-config:pci=0/0000:04:01.0,0/0000:00:19.0 uuid=<vm uuid>
 
 :::
 
+:::Note
+Given that VMs with PCI Passthrough can't be live migrated, it may be advisable to
+[Enable Invariant TSC](#invariant-tsc) to improve performance.
+:::
+
 ### 6. Start your VM and be happy :-)
 
 <Terminal shell title="root@xcp-ng-host — 6. Start your VM and be happy :-)">{`
@@ -350,6 +355,18 @@ We understand the use cases that necessitate nested virtualization and are commi
 As coretemp is not supported in XCP-ng, you can't rely on `sensors` to get the CPU temperatures on Intel platforms.
 
 Starting with XCP-ng 8.3 (`xen-4.17.6-9.3.xcpng8.3`), the `xenpm get-core-temp` command was introduced as an alternative.
+
+## Invariant TSC {#invariant-tsc}
+
+By default, XCP-ng doesn't expose Invariant TSC to the guest due to complications related to live migrations.
+This causes the guest to rely on alternative clock sources e.g Xen PV Clock or HPET, which can significantly impact performance of some applications (especially timer-sensitive ones).
+
+If you don't intend to live migrate or suspend the guest, you can enable native TSC mode which would expose Invariant TSC in the guest.
+
+<Terminal shell title="root@xcp-ng-host — Enable Invariant TSC">{`
+xe vm-param-add uuid=[VM-UUID] param-name=platform tsc_mode=2
+xe vm-param-add uuid=[VM-UUID] param-name=platform nomigrate=true
+`}</Terminal>
 
 ## Advanced Xen {#advanced-xen}
 


### PR DESCRIPTION
In order to improve performance, it is possible to enable native TSC which would expose Invariant TSC to the guest. That allows the guest to rely on more efficient clocksource than PV Timer or HPET; which can yield significantly better performance in some workloads (in particular timer-sensitive ones).

However, it comes at the cost of live migration due to lack of proper support for TSC live-migration at this time.

Add a hint for PCI Passthrough to enable this optimization given that live migration is already impossible when PCI Passthrough is in use, and there's nothing to lose by enabling this.

---

That can be useful for people looking to improve performance when they can affort live migration support (in particular in single-host configurations and when using PCI Passthrough).

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
