### PR TITLE
Add clarification to xe (XAPI CLI) reference documentation

### DIFF
--- a/docs/appendix/cli_reference.md
+++ b/docs/appendix/cli_reference.md
@@ -1,13 +1,17 @@
 # xe command reference
 
-The list of all `xe` commands.
 
-This section groups the commands by the objects that the command addresses. These objects are listed alphabetically.
+This section groups commands by the objects they apply to. The objects are listed in alphabetical order.
 
-:::tip
-This section is in construction
+:::note
+This list is not exhaustive.
 :::
 
+:::tip
+You can list all xe commands with `xe help --all`. To get help for a specific command, use xe help <command>.
+
+To return only specifics values in response of `<OBJECT>-list` commands, use the optional parameter `params=param1,param2,...` (or `params=all`).
+:::
 
 ## Appliance commands
 
@@ -2201,6 +2205,14 @@ snapshot-export-to-template filename=file_name snapshot-uuid=snapshot_uuid  [pre
 ```
 
 Export a snapshot to *file name*.
+
+### `snapshot-list`
+
+```
+snapshot-list [params=param1,param2,...] [uuid] [name-label] [name-description] [<ALL_OTHER_OBJECT_ATTRIBUTES>]
+```
+
+Lists all the snapshots, filtering on the optional arguments. To filter on map parameters, use the syntax `map-param:key=value`.
 
 ### `snapshot-reset-powerstate`
 

--- a/docs/management/manage-locally/cli.md
+++ b/docs/management/manage-locally/cli.md
@@ -3,7 +3,7 @@
 The xe CLI can be used locally on any XCP-ng host, it's installed along with it. However, it's poolwide only. If you want a CLI or an API to control multiple pools at once, we strongly advise to use [Xen Orchestra CLI](../../manage-at-scale/xo-cli).
 
 :::info
-The complete set of all `xe` commands is available in the [Appendix section](../../../appendix/cli_reference).
+You can find more detailed `xe` commands in the [Appendix](../../../appendix/cli_reference) section.
 :::
 
 ## Getting help with xe commands {#getting-help-with-xe-commands}


### PR DESCRIPTION
Thanks to the @xcp-ng/xapi-network team for helping to craft this PR.

As a newcomer, this documentation is a great help and I suggest to point explicitly the partial coverage of the `xe` commands.

Because there were so many missing commands, I didn't consider adding them all.
I just add the one that made me aware of this situation.

I removed the "exhaustive notes" and added tips that I think is worth mentioning.

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
