### PR TITLE
Fix text formatting to prevent Docusaurus build failure

### DIFF
--- a/docs/appendix/cli_reference.md
+++ b/docs/appendix/cli_reference.md
@@ -8,7 +8,7 @@ This list is not exhaustive.
 :::
 
 :::tip
-You can list all xe commands with `xe help --all`. To get help for a specific command, use xe help <command>.
+You can list all xe commands with `xe help --all`. To get help for a specific command, use `xe help <command>`.
 
 To return only specifics values in response of `<OBJECT>-list` commands, use the optional parameter `params=param1,param2,...` (or `params=all`).
 :::


### PR DESCRIPTION
An instruction written under brackets was interpreted by Docusaurus as a tag instead of text, which prevented Docusaurus to build the site correctly:

```
> build
> docusaurus build

[INFO] [en] Creating an optimized production build...
[webpackbar] ℹ Compiling Client
[webpackbar] ℹ Compiling Server
[webpackbar] ✔ Server: Compiled with some errors in 7.51s
<w> [webpack.cache.PackFileCacheStrategy] Skipped not serializable cache item 'Compilation/modules|/data/xcp-ng-org/node_modules/@docusaurus/mdx-loader/lib/index.js??ruleSet[1].rules[8].use[0]!/data/xcp-ng-org/docs/appendix/cli_reference.md': No serializer registered for VFileMessage
<w> while serializing webpack/lib/cache/PackFileCacheStrategy.PackContentItems -> webpack/lib/NormalModule -> webpack/lib/ModuleBuildError -> Error -> VFileMessage
[webpackbar] ✔ Client: Compiled with some errors in 10.53s
[ERROR] Client bundle compiled with errors therefore further build is impossible.
Error: MDX compilation failed for file "/data/xcp-ng-org/docs/appendix/cli_reference.md"
Cause: Expected a closing tag for `<command>` (11:100-11:109) before the end of `paragraph`
Details:
{
  "column": 1,
  "file": "",
  "message": "Expected a closing tag for `<command>` (11:100-11:109) before the end of `paragraph`",
  "line": 11,
  "name": "11:1-11:110",
  "place": {
    "start": {
      "_bufferIndex": 0,
      "_index": 0,
      "line": 11,
      "column": 1,
      "offset": 180
    },
    "end": {
      "_bufferIndex": -1,
      "_index": 1,
      "line": 11,
      "column": 110,
      "offset": 289
    }
  },
  "reason": "Expected a closing tag for `<command>` (11:100-11:109) before the end of `paragraph`",
  "ruleId": "end-tag-mismatch",
  "source": "mdast-util-mdx-jsx"
}
Pull and build done at Mon Aug 31 10:03:01 AM CEST 2026
```

This PR escapes that instruction so it's correctly interpreted as text, and the site can be built as expected.

> Before submitting the pull request, you must agree with the following statements by checking both boxes with a 'x'.
> * [x] "I accept that my contribution is placed under the CC BY-SA 2.0 license [1]."
> * [x] "My contribution complies with the Developer Certificate of Origin [2]." 
>
> [1] https://creativecommons.org/licenses/by-sa/2.0/
> [2] https://docs.xcp-ng.org/project/contributing/#developer-certificate-of-origin-dco
