### PR TITLE
Say that the snapshot fixer needs XCP-ng 8.3 or newer

### DIFF
--- a/docs/troubleshooting/xapi/snapshot-of.md
+++ b/docs/troubleshooting/xapi/snapshot-of.md
@@ -6,6 +6,10 @@ Corrupted VDIs or interrupted operations can inadvertently corrupt the `snapshot
 
 A fix for this long-standing issue is being developed for several storage backends, and a [helper script](https://github.com/xcp-ng/xcp/blob/master/scripts/snapshot-fixer.py) is provided to fix xapi databases with incongruent snapshot metadata.
 
+:::note
+The script requires XCP-ng 8.3 or newer and refuses to run on earlier releases, where it does not produce correct results. There is no equivalent for XCP-ng 8.2, which is EOL: upgrade to a supported release to use it.
+:::
+
 :::danger
 The script temporarily disables HA and stops xapi to apply the changes to the database. This means that the pool is not running operations like handling backups, migrating, starting or stopping VMs, and HA is disabled during the operation. To check for issues in the pool without stopping xapi and rewriting the database, the `dry-run` option can be used:
 

--- a/docs/troubleshooting/xapi/snapshot-of.md
+++ b/docs/troubleshooting/xapi/snapshot-of.md
@@ -7,7 +7,7 @@ Corrupted VDIs or interrupted operations can inadvertently corrupt the `snapshot
 A fix for this long-standing issue is being developed for several storage backends, and a [helper script](https://github.com/xcp-ng/xcp/blob/master/scripts/snapshot-fixer.py) is provided to fix xapi databases with incongruent snapshot metadata.
 
 :::note
-The script requires XCP-ng 8.3 or newer and refuses to run on earlier releases, where it does not produce correct results. There is no equivalent for XCP-ng 8.2, which is EOL: upgrade to a supported release to use it.
+The script requires XCP-ng 8.3 or later. It refuses to run on earlier versions because they do not produce correct results. There is no equivalent for XCP-ng 8.2, which has reached end of life. Upgrade to a supported release to use this script.
 :::
 
 :::danger


### PR DESCRIPTION
Reported through the docs feedback survey on 3 September: a reader on XCP-ng 8.2 found this page, went to run the script, and it refused to run.

`snapshot-fixer.py` exits with an error below 8.3 (`MIN_MAJOR`/`MIN_MINOR` in the script). The gate was added deliberately in xcp-ng/xcp#812, because the script does not work correctly on 8.2.1. The page said nothing about it, so the reader had no way to know before trying.

Adds a note stating the requirement next to the link.
