### PR TITLE
Point Secure Boot boot failures at the guide that covers them

### DIFF
--- a/docs/troubleshooting/common-problems.md
+++ b/docs/troubleshooting/common-problems.md
@@ -322,3 +322,15 @@ This issue is often caused by keyboard being on **Scroll Lock** mode.
 ### Solution
 
 Disable **Scroll Lock** on your keyboard (physical or virtual). Input should resume immediately.
+
+---
+
+## VM does not boot with Secure Boot enabled {#vm-does-not-boot-with-secure-boot-enabled}
+
+### Cause
+
+A VM with Secure Boot enabled can fail to boot for several reasons: the pool or the VM is missing UEFI certificates, or the guest's boot binaries were signed with a key that is not valid according to the certificates installed in the VM.
+
+### Solution
+
+From XCP-ng 8.3, `xe vm-get-secureboot-readiness uuid=<vm-uuid>` reports which of these applies. Each status, its symptoms and its fix are listed in [Troubleshoot Guest Secure Boot Issues](../guides/guest-UEFI-Secure-Boot.md#troubleshoot-guest-secure-boot-issues).


### PR DESCRIPTION
Reported through the docs feedback survey on 23 August, marked as Outdated: "What about Secure Boot Fails?"

The content already exists and is quite complete in the Guest UEFI Secure Boot guide. The reader was in Troubleshooting and did not find it. This adds a signpost entry only, with no new material (except for a small duplicate piece of information, as I'm introducing the subject).

`xe vm-get-secureboot-readiness` was verified on my lab host running 8.3.0.

